### PR TITLE
Publish React hooks to useWebMCP package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -693,6 +693,31 @@ importers:
         specifier: 'catalog:'
         version: 5.9.2
 
+  usewebmcp:
+    dependencies:
+      '@mcp-b/react-webmcp':
+        specifier: workspace:*
+        version: link:../react-webmcp
+      react:
+        specifier: 'catalog:'
+        version: 19.1.1
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.17.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.1.10
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.15.10(typescript@5.9.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+
   webmcp-ts-sdk:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -4705,9 +4730,6 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
-  quansync@0.2.10:
-    resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
-
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -5921,7 +5943,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5979,7 +6001,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.3
 
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
@@ -5988,7 +6010,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.2
+      semver: 7.7.3
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -6044,7 +6066,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.2
+      semver: 7.7.3
 
   '@changesets/get-release-plan@4.0.13':
     dependencies:
@@ -9761,7 +9783,7 @@ snapshots:
 
   package-manager-detector@0.2.11:
     dependencies:
-      quansync: 0.2.10
+      quansync: 0.2.11
 
   parent-module@1.0.1:
     dependencies:
@@ -9897,8 +9919,6 @@ snapshots:
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
-
-  quansync@0.2.10: {}
 
   quansync@0.2.11: {}
 
@@ -10483,7 +10503,7 @@ snapshots:
     dependencies:
       '@quansync/fs': 0.1.5
       defu: 6.1.4
-      jiti: 2.5.1
+      jiti: 2.6.1
       quansync: 0.2.11
 
   undici-types@6.21.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - extension-tools
   - global
   - react-webmcp
+  - usewebmcp
   - smart-dom-reader
   - smart-dom-reader/mcp-server
   - transports

--- a/usewebmcp/package.json
+++ b/usewebmcp/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "usewebmcp",
+  "version": "0.1.5",
+  "description": "React hooks for Model Context Protocol - alias for @mcp-b/react-webmcp",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "react",
+    "hooks",
+    "react-hooks",
+    "browser",
+    "ai",
+    "assistant",
+    "tools",
+    "zod",
+    "usewebmcp"
+  ],
+  "homepage": "https://github.com/WebMCP-org/WebMCP#readme",
+  "bugs": {
+    "url": "https://github.com/WebMCP-org/WebMCP/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/WebMCP-org/WebMCP.git",
+    "directory": "packages/usewebmcp"
+  },
+  "license": "MIT",
+  "author": "WebMCP Team",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:prod": "NODE_ENV=prod tsdown",
+    "check": "biome check --write .",
+    "clean": "rm -rf dist .turbo",
+    "format": "biome format --write .",
+    "lint": "biome lint --write .",
+    "prepublishOnly": "pnpm run build:prod",
+    "publish:dry": "pnpm publish --access public --dry-run",
+    "publish:npm": "pnpm publish --access public",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mcp-b/react-webmcp": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "react": "catalog:",
+    "zod": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/usewebmcp/src/index.ts
+++ b/usewebmcp/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * usewebmcp
+ *
+ * This package is an alias for @mcp-b/react-webmcp, providing the same
+ * React hooks for Model Context Protocol under a simpler package name.
+ *
+ * @packageDocumentation
+ */
+
+// Re-export everything from the main package
+export * from '@mcp-b/react-webmcp';

--- a/usewebmcp/tsconfig.json
+++ b/usewebmcp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "tsdown.config.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.*", "**/*.spec.*"]
+}

--- a/usewebmcp/tsdown.config.ts
+++ b/usewebmcp/tsdown.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  platform: 'browser',
+  dts: true,
+  minify: process.env.NODE_ENV === 'prod',
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  // Don't bundle peer dependencies or the main package
+  external: ['react', 'react/jsx-runtime', 'react-dom', 'zod', '@mcp-b/react-webmcp'],
+  tsconfig: './tsconfig.json',
+});


### PR DESCRIPTION
Adds a new npm package `usewebmcp` that re-exports everything from @mcp-b/react-webmcp, providing users with a simpler package name option. Both packages will be published and maintained in sync.