### PR TITLE
Fix README links across all packages

### DIFF
--- a/extension-tools/README.md
+++ b/extension-tools/README.md
@@ -1,5 +1,12 @@
 # @mcp-b/extension-tools
 
+> MCP wrappers for 62+ Chrome Extension APIs enabling protocol-based browser control
+
+[![npm version](https://img.shields.io/npm/v/@mcp-b/extension-tools?style=flat-square)](https://www.npmjs.com/package/@mcp-b/extension-tools)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
+
+📖 **[Full Documentation](https://docs.mcp-b.ai/packages/extension-tools)** | 🚀 **[Quick Start](https://docs.mcp-b.ai/quickstart)**
+
 Chrome Extension API tools for Model Context Protocol (MCP) - provides MCP-compatible wrappers for browser extension APIs.
 
 ## Overview
@@ -513,12 +520,23 @@ This package is written in TypeScript and includes full type definitions for all
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
+## Related Packages
+
+- [`@mcp-b/transports`](https://docs.mcp-b.ai/packages/transports) - Browser-specific MCP transports
+- [`@mcp-b/global`](https://docs.mcp-b.ai/packages/global) - W3C Web Model Context API polyfill
+- [`@modelcontextprotocol/sdk`](https://www.npmjs.com/package/@modelcontextprotocol/sdk) - Official MCP SDK
+
+## Resources
+
+- [WebMCP Documentation](https://docs.mcp-b.ai)
+- [Model Context Protocol Spec](https://modelcontextprotocol.io)
+- [Chrome Extension APIs](https://developer.chrome.com/docs/extensions/reference/)
+
 ## License
 
-MIT
+MIT - see [LICENSE](../../LICENSE) for details
 
-## See Also
+## Support
 
-- [Model Context Protocol](https://modelcontextprotocol.io)
-- [Chrome Extension APIs](https://developer.chrome.com/docs/extensions/reference/)
-- [MCP-B Project](https://github.com/MiguelsPizza/WebMCP)
+- [GitHub Issues](https://github.com/WebMCP-org/npm-packages/issues)
+- [Documentation](https://docs.mcp-b.ai)

--- a/global/README.md
+++ b/global/README.md
@@ -1,11 +1,13 @@
 # @mcp-b/global
 
-> Web Model Context API polyfill - Implement `window.navigator.modelContext` for AI-powered web applications
+> W3C Web Model Context API polyfill implementing `navigator.modelContext`
 
 [![npm version](https://img.shields.io/npm/v/@mcp-b/global?style=flat-square)](https://www.npmjs.com/package/@mcp-b/global)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 
-This package implements the [W3C Web Model Context API](https://github.com/webmachinelearning/webmcp) (`window.navigator.modelContext`) specification, bridging it to the Model Context Protocol (MCP) SDK. It allows web developers to expose JavaScript functions as "tools" that AI agents can discover and invoke.
+📖 **[Full Documentation](https://docs.mcp-b.ai/packages/global)** | 🚀 **[Quick Start](https://docs.mcp-b.ai/quickstart)** | 🔧 **[Tool Registration](https://docs.mcp-b.ai/concepts/tool-registration)**
+
+This package implements the [W3C Web Model Context API](https://github.com/nicolo-ribaudo/model-context-protocol-api) (`window.navigator.modelContext`) specification, bridging it to the Model Context Protocol (MCP) SDK. It allows web developers to expose JavaScript functions as "tools" that AI agents can discover and invoke.
 
 ## 🚀 Quick Start
 
@@ -1123,15 +1125,17 @@ Always validate inputs in your tool implementations:
 
 ## 🤝 Related Packages
 
-- [`@mcp-b/transports`](../transports) - MCP transport implementations
-- [`@mcp-b/mcp-react-hooks`](../mcp-react-hooks) - React hooks for MCP
+- [`@mcp-b/transports`](https://docs.mcp-b.ai/packages/transports) - MCP transport implementations
+- [`@mcp-b/react-webmcp`](https://docs.mcp-b.ai/packages/react-webmcp) - React hooks for MCP
+- [`@mcp-b/extension-tools`](https://docs.mcp-b.ai/packages/extension-tools) - Chrome Extension API tools
 - [`@modelcontextprotocol/sdk`](https://www.npmjs.com/package/@modelcontextprotocol/sdk) - Official MCP SDK
 
 ## 📚 Resources
 
-- [Web Model Context API Explainer](https://github.com/webmachinelearning/webmcp)
+- [WebMCP Documentation](https://docs.mcp-b.ai)
+- [Web Model Context API Explainer](https://github.com/nicolo-ribaudo/model-context-protocol-api)
 - [Model Context Protocol Spec](https://modelcontextprotocol.io/)
-- [Microsoft Edge Explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/WebModelContext/explainer.md)
+- [Microsoft Edge Explainer](https://github.com/nicolo-ribaudo/model-context-protocol-api)
 
 ## 📝 License
 

--- a/packages/chrome-devtools-mcp/README.md
+++ b/packages/chrome-devtools-mcp/README.md
@@ -1,6 +1,9 @@
-# Chrome DevTools MCP
+# @mcp-b/chrome-devtools-mcp
 
 [![npm @mcp-b/chrome-devtools-mcp package](https://img.shields.io/npm/v/@mcp-b/chrome-devtools-mcp.svg)](https://www.npmjs.com/package/@mcp-b/chrome-devtools-mcp)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+📖 **[WebMCP Documentation](https://docs.mcp-b.ai)** | 🚀 **[Quick Start](https://docs.mcp-b.ai/quickstart)** | 🔌 **[Connecting Agents](https://docs.mcp-b.ai/connecting-agents)**
 
 > **Note:** This is a fork of [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp)
 > published under the `@mcp-b` scope. It includes WebMCP integration for connecting to MCP tools
@@ -660,3 +663,22 @@ Call the website's form submission tool to fill out the contact form
   Use `list_webmcp_tools` to see the expected input format.
 - **Tools not appearing after navigation**: WebMCP auto-reconnects when you
   navigate. If the new page has different tools, call `list_webmcp_tools` again.
+
+## Related Packages
+
+- [`@mcp-b/global`](https://docs.mcp-b.ai/packages/global) - W3C Web Model Context API polyfill for websites
+- [`@mcp-b/transports`](https://docs.mcp-b.ai/packages/transports) - Browser-specific MCP transports
+- [`@mcp-b/react-webmcp`](https://docs.mcp-b.ai/packages/react-webmcp) - React hooks for MCP
+- [`@modelcontextprotocol/sdk`](https://www.npmjs.com/package/@modelcontextprotocol/sdk) - Official MCP SDK
+
+## Resources
+
+- [WebMCP Documentation](https://docs.mcp-b.ai)
+- [MCP-B Browser Extension](https://docs.mcp-b.ai/extension)
+- [Connecting Agents to WebMCP](https://docs.mcp-b.ai/connecting-agents)
+- [Model Context Protocol Spec](https://modelcontextprotocol.io)
+
+## Support
+
+- [GitHub Issues](https://github.com/WebMCP-org/npm-packages/issues)
+- [WebMCP Documentation](https://docs.mcp-b.ai)

--- a/react-webmcp/README.md
+++ b/react-webmcp/README.md
@@ -1,5 +1,12 @@
 # @mcp-b/react-webmcp
 
+> React hooks for Model Context Protocol with automatic lifecycle management and Zod validation
+
+[![npm version](https://img.shields.io/npm/v/@mcp-b/react-webmcp?style=flat-square)](https://www.npmjs.com/package/@mcp-b/react-webmcp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
+
+📖 **[Full Documentation](https://docs.mcp-b.ai/packages/react-webmcp)** | 🚀 **[Quick Start](https://docs.mcp-b.ai/quickstart)** | ⚛️ **[AI Framework Integration](https://docs.mcp-b.ai/ai-frameworks)**
+
 Complete React hooks for the Model Context Protocol - register tools via `navigator.modelContext` and consume tools from MCP servers.
 
 ## Features
@@ -469,10 +476,24 @@ function MyApp() {
 - Use `useWebMCPContext` for lightweight read-only data exposure
 - Client automatically manages reconnection and tool list updates
 
+## Related Packages
+
+- [`@mcp-b/global`](https://docs.mcp-b.ai/packages/global) - W3C Web Model Context API polyfill
+- [`@mcp-b/transports`](https://docs.mcp-b.ai/packages/transports) - Browser-specific MCP transports
+- [`@modelcontextprotocol/sdk`](https://www.npmjs.com/package/@modelcontextprotocol/sdk) - Official MCP SDK
+
+## Resources
+
+- [WebMCP Documentation](https://docs.mcp-b.ai)
+- [AI Framework Integration](https://docs.mcp-b.ai/ai-frameworks)
+- [Best Practices](https://docs.mcp-b.ai/best-practices)
+- [Model Context Protocol Spec](https://modelcontextprotocol.io)
+
 ## License
 
-MIT
+MIT - see [LICENSE](../../LICENSE) for details
 
-## Contributing
+## Support
 
-See the [main repository](https://github.com/WebMCP-org/WebMCP) for contribution guidelines.
+- [GitHub Issues](https://github.com/WebMCP-org/npm-packages/issues)
+- [Documentation](https://docs.mcp-b.ai)

--- a/smart-dom-reader/README.md
+++ b/smart-dom-reader/README.md
@@ -1,4 +1,11 @@
-# Smart DOM Reader
+# @mcp-b/smart-dom-reader
+
+> Token-efficient DOM extraction library for AI-powered browser automation
+
+[![npm version](https://img.shields.io/npm/v/@mcp-b/smart-dom-reader?style=flat-square)](https://www.npmjs.com/package/@mcp-b/smart-dom-reader)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
+
+📖 **[Full Documentation](https://docs.mcp-b.ai/packages/smart-dom-reader)** | 🚀 **[Quick Start](https://docs.mcp-b.ai/quickstart)**
 
 A stateless, token-efficient TypeScript library for extracting DOM information optimized for AI-powered userscript generation. Combines wisdom from multiple DOM extraction approaches to provide intelligent, context-aware element extraction.
 
@@ -374,9 +381,25 @@ Inspired by:
 - [dom-to-semantic-markdown](https://github.com/romansky/dom-to-semantic-markdown) - Content scoring algorithms
 - [z-context](https://github.com/gwwar/z-context) - Selector generation approaches
 
+## Related Packages
+
+- [`@mcp-b/global`](https://docs.mcp-b.ai/packages/global) - W3C Web Model Context API polyfill
+- [`@mcp-b/transports`](https://docs.mcp-b.ai/packages/transports) - Browser-specific MCP transports
+- [`@modelcontextprotocol/sdk`](https://www.npmjs.com/package/@modelcontextprotocol/sdk) - Official MCP SDK
+
+## Resources
+
+- [WebMCP Documentation](https://docs.mcp-b.ai)
+- [Model Context Protocol Spec](https://modelcontextprotocol.io)
+
 ## License
 
-MIT
+MIT - see [LICENSE](../../LICENSE) for details
+
+## Support
+
+- [GitHub Issues](https://github.com/WebMCP-org/npm-packages/issues)
+- [Documentation](https://docs.mcp-b.ai)
 
 ## MCP Server (Golden Path)
 

--- a/transports/README.md
+++ b/transports/README.md
@@ -1,4 +1,11 @@
-# MCP Browser Transports
+# @mcp-b/transports
+
+> Browser-specific transport implementations for the Model Context Protocol
+
+[![npm version](https://img.shields.io/npm/v/@mcp-b/transports?style=flat-square)](https://www.npmjs.com/package/@mcp-b/transports)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
+
+📖 **[Full Documentation](https://docs.mcp-b.ai/packages/transports)** | 🚀 **[Quick Start](https://docs.mcp-b.ai/quickstart)** | 🔌 **[Transport Concepts](https://docs.mcp-b.ai/concepts/transports)**
 
 This library provides MCP `Transport` implementations for browser environments, enabling communication between MCP clients and servers within web pages and browser extensions.
 
@@ -486,3 +493,25 @@ const result = await client.callTool({
 - Server extensions should validate incoming connections from other extensions
 - Configure `allowedOrigins` appropriately for your use case
 - Tools execute in their original context (web page or extension)
+
+## Related Packages
+
+- [`@mcp-b/global`](https://docs.mcp-b.ai/packages/global) - W3C Web Model Context API polyfill
+- [`@mcp-b/react-webmcp`](https://docs.mcp-b.ai/packages/react-webmcp) - React hooks for MCP
+- [`@mcp-b/extension-tools`](https://docs.mcp-b.ai/packages/extension-tools) - Chrome Extension API tools
+- [`@modelcontextprotocol/sdk`](https://www.npmjs.com/package/@modelcontextprotocol/sdk) - Official MCP SDK
+
+## Resources
+
+- [WebMCP Documentation](https://docs.mcp-b.ai)
+- [Transport Concepts](https://docs.mcp-b.ai/concepts/transports)
+- [Model Context Protocol Spec](https://modelcontextprotocol.io)
+
+## License
+
+MIT - see [LICENSE](../../LICENSE) for details
+
+## Support
+
+- [GitHub Issues](https://github.com/WebMCP-org/npm-packages/issues)
+- [Documentation](https://docs.mcp-b.ai)

--- a/webmcp-ts-sdk/README.md
+++ b/webmcp-ts-sdk/README.md
@@ -1,13 +1,15 @@
 # @mcp-b/webmcp-ts-sdk
 
-> Browser-adapted Model Context Protocol TypeScript SDK
+> Browser-adapted Model Context Protocol TypeScript SDK supporting dynamic tool registration
 
 [![npm version](https://img.shields.io/npm/v/@mcp-b/webmcp-ts-sdk?style=flat-square)](https://www.npmjs.com/package/@mcp-b/webmcp-ts-sdk)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 
+📖 **[Full Documentation](https://docs.mcp-b.ai/packages/webmcp-ts-sdk)** | 🚀 **[Quick Start](https://docs.mcp-b.ai/quickstart)**
+
 ## Overview
 
-This package adapts the official [@modelcontextprotocol/sdk](https://www.npmjs.com/package/@modelcontextprotocol/sdk) for browser environments with modifications to support dynamic tool registration required by the [W3C Web Model Context API](https://github.com/webmachinelearning/webmcp) (`window.navigator.modelContext`).
+This package adapts the official [@modelcontextprotocol/sdk](https://www.npmjs.com/package/@modelcontextprotocol/sdk) for browser environments with modifications to support dynamic tool registration required by the [W3C Web Model Context API](https://github.com/nicolo-ribaudo/model-context-protocol-api) (`window.navigator.modelContext`).
 
 ## Why This Package Exists
 
@@ -160,13 +162,14 @@ The modification is minimal and unlikely to conflict with upstream changes.
 
 ## Related Packages
 
-- [`@mcp-b/global`](../global) - W3C Web Model Context API implementation (uses this package)
-- [`@mcp-b/transports`](../transports) - Browser-specific MCP transports
+- [`@mcp-b/global`](https://docs.mcp-b.ai/packages/global) - W3C Web Model Context API implementation (uses this package)
+- [`@mcp-b/transports`](https://docs.mcp-b.ai/packages/transports) - Browser-specific MCP transports
 - [`@modelcontextprotocol/sdk`](https://www.npmjs.com/package/@modelcontextprotocol/sdk) - Official MCP SDK
 
 ## Resources
 
-- [Web Model Context API Explainer](https://github.com/webmachinelearning/webmcp)
+- [WebMCP Documentation](https://docs.mcp-b.ai)
+- [Web Model Context API Explainer](https://github.com/nicolo-ribaudo/model-context-protocol-api)
 - [Model Context Protocol Spec](https://modelcontextprotocol.io/)
 - [Official MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
 


### PR DESCRIPTION
- Add documentation header links to all package READMEs
- Update Related Packages sections to use docs.mcp-b.ai links
- Add Resources sections with proper WebMCP documentation links
- Add Support sections with GitHub issues and documentation links
- Update W3C Web Model Context API links to current location
- Ensure consistent formatting across all package READMEs