### PR TITLE
fix(docs): correct broken documentation links and badge service URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ This monorepo uses pnpm workspaces with Turbo for build orchestration and Change
 
 ```bash
 # Clone the repository
-git clone https://github.com/WebMCP-org/WebMCP.git
-cd WebMCP/npm-packages
+git clone https://github.com/WebMCP-org/npm-packages.git
+cd npm-packages
 
 # Install dependencies
 pnpm install
@@ -257,6 +257,6 @@ We welcome contributions! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for gu
 
 ## Links
 
-- [GitHub Repository](https://github.com/WebMCP-org/WebMCP)
+- [GitHub Repository](https://github.com/WebMCP-org/npm-packages)
 - [npm Organization](https://www.npmjs.com/org/mcp-b)
-- [Issue Tracker](https://github.com/WebMCP-org/WebMCP/issues)
+- [Issue Tracker](https://github.com/WebMCP-org/npm-packages/issues)

--- a/packages/chrome-devtools-mcp/CONTRIBUTING.md
+++ b/packages/chrome-devtools-mcp/CONTRIBUTING.md
@@ -42,10 +42,10 @@ for PR and commit titles.
 Check that you are using node version specified in .nvmrc, then run following commands:
 
 ```sh
-git clone https://github.com/ChromeDevTools/chrome-devtools-mcp.git
-cd chrome-devtools-mcp
-npm ci
-npm run build
+git clone https://github.com/WebMCP-org/npm-packages.git
+cd npm-packages
+pnpm install
+pnpm build
 ```
 
 ### Testing with @modelcontextprotocol/inspector

--- a/packages/chrome-devtools-mcp/README.md
+++ b/packages/chrome-devtools-mcp/README.md
@@ -290,9 +290,9 @@ Configure the following fields and press `CTRL+S` to save the configuration:
 
 **Click the button to install:**
 
-[<img src="https://mcpbadge.dev/badge-install-in-vs-code-stable-dark" alt="Install in VS Code">](https://vscode.dev/redirect/mcp/install?name=%40mcp-b%2Fchrome-devtools-mcp&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40mcp-b%2Fchrome-devtools-mcp%40latest%22%5D%2C%22env%22%3A%7B%7D%7D)
+[<img src="https://img.shields.io/badge/Install-VS%20Code-007ACC?style=for-the-badge&logo=visualstudiocode" alt="Install in VS Code">](https://vscode.dev/redirect/mcp/install?name=%40mcp-b%2Fchrome-devtools-mcp&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40mcp-b%2Fchrome-devtools-mcp%40latest%22%5D%2C%22env%22%3A%7B%7D%7D)
 
-[<img src="https://mcpbadge.dev/badge-install-in-vs-code-insiders-dark" alt="Install in VS Code Insiders">](https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522%2540mcp-b%252Fchrome-devtools-mcp%2522%252C%2522config%2522%253A%257B%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522-y%2522%252C%2522%2540mcp-b%252Fchrome-devtools-mcp%2540latest%2522%255D%252C%2522env%2522%253A%257B%257D%257D%257D)
+[<img src="https://img.shields.io/badge/Install-VS%20Code%20Insiders-3578CF?style=for-the-badge&logo=visualstudiocode" alt="Install in VS Code Insiders">](https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522%2540mcp-b%252Fchrome-devtools-mcp%2522%252C%2522config%2522%253A%257B%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522-y%2522%252C%2522%2540mcp-b%252Fchrome-devtools-mcp%2540latest%2522%255D%252C%2522env%2522%253A%257B%257D%257D%257D)
 
 **Or install manually:**
 


### PR DESCRIPTION
- Update GitHub repository URLs to point to WebMCP-org/npm-packages
- Replace broken mcpbadge.dev badges with shields.io alternatives
- Fix clone instructions in CONTRIBUTING.md for chrome-devtools-mcp
- Ensure all documentation links resolve correctly