### PR TITLE
feat(deps): bump @modelcontextprotocol/sdk to 1.24.3 and add output schema docs

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,10 +1,10 @@
-# Load nvm if available
+# Load nvm if available (optional - may not be installed in all environments)
 export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" || true
 
 # Use Node version from .nvmrc if nvm is available
-if command -v nvm &> /dev/null && [ -f .nvmrc ]; then
-  nvm use
+if type nvm >/dev/null 2>&1 && [ -f .nvmrc ]; then
+  nvm use || true
 fi
 
 pnpm lint-staged

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: ^5.2.2
       version: 5.2.2
     '@modelcontextprotocol/sdk':
-      specifier: 1.15.0
-      version: 1.15.0
+      specifier: 1.24.3
+      version: 1.24.3
     '@radix-ui/react-collapsible':
       specifier: ^1.1.12
       version: 1.1.12
@@ -146,7 +146,7 @@ importers:
         version: link:../../../../webmcp-ts-sdk
       '@mcp-ui/client':
         specifier: ^5.14.1
-        version: 5.14.1(@preact/signals-core@1.12.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 5.14.1(@preact/signals-core@1.12.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.20.2
         version: 1.20.2
@@ -312,7 +312,7 @@ importers:
         version: link:../../../../react-webmcp
       '@mcp-ui/server':
         specifier: ^5.2.0
-        version: 5.13.1
+        version: 5.13.1(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.20.2
         version: 1.20.2
@@ -400,7 +400,7 @@ importers:
         version: link:../../transports
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.15.0
+        version: 1.24.3(zod@3.25.76)
       react:
         specifier: 'catalog:'
         version: 19.1.1
@@ -440,7 +440,7 @@ importers:
         version: link:../../transports
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.15.0
+        version: 1.24.3(zod@3.25.76)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -541,7 +541,7 @@ importers:
         version: link:../smart-dom-reader
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.15.0
+        version: 1.24.3(zod@3.25.76)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -730,7 +730,7 @@ importers:
         version: link:../webmcp-ts-sdk
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.15.0
+        version: 1.24.3(zod@3.25.76)
       react:
         specifier: 'catalog:'
         version: 19.1.1
@@ -846,7 +846,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.15.0
+        version: 1.24.3(zod@4.1.12)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1833,10 +1833,6 @@ packages:
   '@mcp-ui/server@5.13.1':
     resolution: {integrity: sha512-jTHy8MTa+Cppw80mFID5ranw+CrmePpncIub726PGg38WETGR8tg7CW0mD9YS6pBdRL+A+EDNCiGbVlPjDfQHA==}
 
-  '@modelcontextprotocol/sdk@1.15.0':
-    resolution: {integrity: sha512-67hnl/ROKdb03Vuu0YOr+baKTvf1/5YBHBm9KnZdjdAh8hjt4FRCPD5ucwxGB237sBpzlqQsLy1PFu7z/ekZ9Q==}
-    engines: {node: '>=18'}
-
   '@modelcontextprotocol/sdk@1.17.3':
     resolution: {integrity: sha512-JPwUKWSsbzx+DLFznf/QZ32Qa+ptfbUlHhRLrBQBAFu9iI1iYvizM4p+zhhRDceSsPutXp4z+R/HPVphlIiclg==}
     engines: {node: '>=18'}
@@ -1847,6 +1843,16 @@ packages:
 
   '@modelcontextprotocol/sdk@1.24.1':
     resolution: {integrity: sha512-YTg4v6bKSst8EJM8NXHC3nGm8kgHD08IbIBbognUeLAgGLVgLpYrgQswzLQd4OyTL4l614ejhqsDrV1//t02Qw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.24.3':
+    resolution: {integrity: sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -7866,9 +7872,9 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mcp-ui/client@5.14.1(@preact/signals-core@1.12.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@mcp-ui/client@5.14.1(@preact/signals-core@1.12.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.20.2
+      '@modelcontextprotocol/sdk': 1.24.1(zod@3.25.76)
       '@quilted/threads': 3.3.1(@preact/signals-core@1.12.1)
       '@r2wc/react-to-web-component': 2.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@remote-dom/core': 1.10.1(@preact/signals-core@1.12.1)
@@ -7876,32 +7882,19 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
     transitivePeerDependencies:
+      - '@cfworker/json-schema'
       - '@preact/signals-core'
       - preact
       - supports-color
+      - zod
 
-  '@mcp-ui/server@5.13.1':
+  '@mcp-ui/server@5.13.1(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.20.2
+      '@modelcontextprotocol/sdk': 1.24.1(zod@3.25.76)
     transitivePeerDependencies:
+      - '@cfworker/json-schema'
       - supports-color
-
-  '@modelcontextprotocol/sdk@1.15.0':
-    dependencies:
-      ajv: 6.12.6
-      content-type: 1.0.5
-      cors: 2.8.5
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.3
-      express: 5.1.0
-      express-rate-limit: 7.5.1(express@5.1.0)
-      pkce-challenge: 5.0.0
-      raw-body: 3.0.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
+      - zod
 
   '@modelcontextprotocol/sdk@1.17.3':
     dependencies:
@@ -7953,6 +7946,44 @@ snapshots:
       raw-body: 3.0.0
       zod: 3.25.76
       zod-to-json-schema: 3.25.0(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.24.3(zod@3.25.76)':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.1.0
+      express-rate-limit: 7.5.1(express@5.1.0)
+      jose: 6.1.3
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.0(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.24.3(zod@4.1.12)':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.1.0
+      express-rate-limit: 7.5.1(express@5.1.0)
+      jose: 6.1.3
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.0
+      zod: 4.1.12
+      zod-to-json-schema: 3.25.0(zod@4.1.12)
     transitivePeerDependencies:
       - supports-color
 
@@ -9443,7 +9474,7 @@ snapshots:
   agents@0.2.20(@cloudflare/workers-types@4.20251014.0)(react@19.1.1)(typescript@5.8.3):
     dependencies:
       '@ai-sdk/openai': 2.0.53(zod@3.25.76)
-      '@modelcontextprotocol/sdk': 1.20.2
+      '@modelcontextprotocol/sdk': 1.24.1(zod@3.25.76)
       ai: 5.0.78(zod@3.25.76)
       cron-schedule: 5.0.4
       json-schema: 0.4.0
@@ -9456,6 +9487,7 @@ snapshots:
       zod: 3.25.76
       zod-to-ts: 1.2.0(typescript@5.8.3)(zod@3.25.76)
     transitivePeerDependencies:
+      - '@cfworker/json-schema'
       - '@cloudflare/workers-types'
       - supports-color
       - typescript
@@ -13462,6 +13494,10 @@ snapshots:
   zod-to-json-schema@3.25.0(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.0(zod@4.1.12):
+    dependencies:
+      zod: 4.1.12
 
   zod-to-ts@1.2.0(typescript@5.8.3)(zod@3.25.76):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ catalog:
   '@cloudflare/vite-plugin': ^1.13.18
   '@composio/json-schema-to-zod': ^0.1.17
   '@hookform/resolvers': ^5.2.2
-  '@modelcontextprotocol/sdk': 1.15.0
+  '@modelcontextprotocol/sdk': 1.24.3
   '@radix-ui/react-collapsible': ^1.1.12
   '@sentry/cloudflare': ^10.22.0
   '@sentry/react': ^10.22.0

--- a/webmcp-ts-sdk/README.md
+++ b/webmcp-ts-sdk/README.md
@@ -124,11 +124,37 @@ await server.connect(transport);
 server.registerTool('my-tool', {
   description: 'A dynamically registered tool',
   inputSchema: { message: z.string() },
+  // Output schemas enable structured, type-safe AI responses
   outputSchema: { result: z.string() }
 }, async ({ message }) => {
   return {
     content: [{ type: 'text', text: `Echo: ${message}` }],
+    // structuredContent must match the outputSchema
     structuredContent: { result: `Echo: ${message}` }
+  };
+});
+
+// Example with complex output schema
+server.registerTool('analyze-data', {
+  description: 'Analyze data and return structured results',
+  inputSchema: {
+    data: z.array(z.number()),
+    operation: z.enum(['sum', 'average', 'stats'])
+  },
+  outputSchema: {
+    result: z.number(),
+    operation: z.string(),
+    metadata: z.object({
+      count: z.number(),
+      min: z.number().optional(),
+      max: z.number().optional()
+    })
+  }
+}, async ({ data, operation }) => {
+  const stats = calculateStats(data, operation);
+  return {
+    content: [{ type: 'text', text: `Result: ${stats.result}` }],
+    structuredContent: stats
   };
 });
 ```


### PR DESCRIPTION
- Update MCP SDK from 1.15.0 to 1.24.3 (latest)
  - Adds SEP-1613: JSON Schema 2020-12 support for inputSchema/outputSchema
  - Adds SEP-1577: Sampling With Tools improvements
  - Adds Zod v4 support

- Add comprehensive output schema documentation to READMEs:
  - @mcp-b/global: Full output schemas section with JSON Schema and Zod examples
  - @mcp-b/react-webmcp: useWebMCP example with outputSchema
  - @mcp-b/webmcp-ts-sdk: Complex output schema examples

- Fix pre-commit hook to gracefully handle missing nvm

Output schemas are essential for modern AI integrations as providers
compile tool definitions into TypeScript, enabling type-safe responses.