### PR TITLE
refactor(webmcp-ts-sdk): strip out auth and Node.js transports

### DIFF
--- a/webmcp-ts-sdk/README.md
+++ b/webmcp-ts-sdk/README.md
@@ -1,6 +1,6 @@
 # @mcp-b/webmcp-ts-sdk
 
-> Browser-adapted MCP TypeScript SDK - Dynamic tool registration for AI agents like Claude, ChatGPT, and Gemini
+> Browser-optimized MCP TypeScript SDK - Stripped-down re-exports excluding auth and Node.js transports, with dynamic tool registration for AI agents
 
 [![npm version](https://img.shields.io/npm/v/@mcp-b/webmcp-ts-sdk?style=flat-square)](https://www.npmjs.com/package/@mcp-b/webmcp-ts-sdk)
 [![npm downloads](https://img.shields.io/npm/dm/@mcp-b/webmcp-ts-sdk?style=flat-square)](https://www.npmjs.com/package/@mcp-b/webmcp-ts-sdk)
@@ -17,8 +17,9 @@
 | Feature | Benefit |
 |---------|---------|
 | **Dynamic Tool Registration** | Register tools after transport connection - required for browser apps |
+| **Browser-Optimized** | Excludes Node.js-only code (auth, stdio, Express transports) |
 | **Minimal Overhead** | Only ~50 lines of custom code on top of official SDK |
-| **Full SDK Compatibility** | Re-exports all types, classes, and utilities from official SDK |
+| **Selective Re-exports** | Only browser-relevant types and classes exposed |
 | **Type-Safe** | No prototype hacks - clean TypeScript extension |
 | **Auto-Updates** | Types and protocol follow official SDK automatically |
 
@@ -76,24 +77,40 @@ export class BrowserMcpServer extends BaseMcpServer {
 
 **Key Difference**: Capabilities are registered **before** connecting, allowing tools to be added dynamically afterward.
 
-## What's Re-Exported
+## What's Included
 
-This package re-exports almost everything from the official SDK:
+This package provides a **stripped-down** version of the MCP SDK optimized for browser environments:
 
-### Types
-- All MCP protocol types (`Tool`, `Resource`, `Prompt`, etc.)
-- Request/response schemas
-- Client and server capabilities
-- Error codes and constants
+### ✅ Included
 
-### Classes
-- `Server` - Base server class (unchanged)
-- `McpServer` - Aliased to `BrowserMcpServer` with our modifications
+| Category | Exports |
+|----------|---------|
+| **Core Classes** | `Client`, `Server`, `McpServer` (BrowserMcpServer), `Protocol` |
+| **Transports** | `InMemoryTransport` only (for testing and in-process communication) |
+| **Types** | All MCP protocol types (`Tool`, `Resource`, `Prompt`, etc.) |
+| **Schemas** | All Zod validation schemas for requests/responses |
+| **Utilities** | `Transport` interface, `mergeCapabilities`, error codes, protocol constants |
 
-### Utilities
-- `Transport` interface
-- `mergeCapabilities` helper
-- Protocol version constants
+### ❌ Excluded (for browser optimization)
+
+| Category | Why Excluded |
+|----------|--------------|
+| **OAuth/Auth Modules** | Not needed for browser-to-browser MCP communication |
+| **stdio Transport** | Node.js only - requires `child_process` |
+| **SSE Transports** | Server-side Express integration |
+| **Streamable HTTP Transports** | Server-side Express integration |
+| **WebSocket Transport** | Use `@mcp-b/transports` for browser transports instead |
+| **Server Auth Router** | Express middleware - not applicable to browsers |
+| **CLI** | Command-line interface - not for browsers |
+
+### Browser Transports
+
+For browser-specific transports (postMessage, Chrome extension messaging, iframe communication), use **[@mcp-b/transports](https://docs.mcp-b.ai/packages/transports)** alongside this package:
+
+```typescript
+import { McpServer } from '@mcp-b/webmcp-ts-sdk';
+import { TabServerTransport, ExtensionClientTransport } from '@mcp-b/transports';
+```
 
 ## Installation
 

--- a/webmcp-ts-sdk/package.json
+++ b/webmcp-ts-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-b/webmcp-ts-sdk",
   "version": "1.0.2-beta.2",
-  "description": "Browser-adapted MCP TypeScript SDK - Dynamic tool registration for W3C Web Model Context API and AI agent integration",
+  "description": "Browser-optimized MCP TypeScript SDK - Stripped-down re-exports excluding auth and Node.js transports, with dynamic tool registration for AI agents",
   "keywords": [
     "mcp",
     "model-context-protocol",

--- a/webmcp-ts-sdk/src/index.ts
+++ b/webmcp-ts-sdk/src/index.ts
@@ -1,81 +1,286 @@
-// Export our browser-optimized MCP Server as the primary export
-// This replaces the standard McpServer with one that supports dynamic tool registration
+/**
+ * @mcp-b/webmcp-ts-sdk
+ *
+ * Browser-optimized MCP TypeScript SDK for WebMCP.
+ *
+ * This package provides a stripped-down version of the MCP SDK optimized for browser environments.
+ * It excludes:
+ * - OAuth/authentication modules (not needed for browser-to-browser communication)
+ * - Node.js-specific transports (stdio, SSE server, streamable HTTP server)
+ * - Server-side middleware and routers
+ *
+ * For browser-specific transports (postMessage, Chrome extension messaging, etc.),
+ * use @mcp-b/transports alongside this package.
+ */
 
-// Re-export Server class from official SDK (for advanced usage)
+// ============================================================================
+// BROWSER-OPTIMIZED MCP SERVER
+// ============================================================================
+
+export { BrowserMcpServer, BrowserMcpServer as McpServer } from './browser-server.js';
+
+// ============================================================================
+// CORE CLIENT & SERVER CLASSES
+// ============================================================================
+
+export type { ClientOptions } from '@modelcontextprotocol/sdk/client/index.js';
+// Client class for connecting to MCP servers
+export { Client } from '@modelcontextprotocol/sdk/client/index.js';
+export type { ServerOptions } from '@modelcontextprotocol/sdk/server/index.js';
+// Server classes for creating MCP servers
 export { Server } from '@modelcontextprotocol/sdk/server/index.js';
-// Re-export protocol utilities
-export { mergeCapabilities } from '@modelcontextprotocol/sdk/shared/protocol.js';
-// Re-export transport interfaces
-export type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 
-// Re-export all commonly used types from official SDK
+// McpServer (high-level server API) - also re-export base for advanced usage
+export { McpServer as BaseMcpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// ============================================================================
+// PROTOCOL & TRANSPORT
+// ============================================================================
+
+// In-memory transport (useful for testing and in-process communication)
+export { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 export type {
+  ProtocolOptions,
+  RequestOptions,
+} from '@modelcontextprotocol/sdk/shared/protocol.js';
+// Protocol base class and utilities
+export {
+  mergeCapabilities,
+  Protocol,
+} from '@modelcontextprotocol/sdk/shared/protocol.js';
+// Transport interface (for custom transports)
+export type {
+  Transport,
+  TransportSendOptions,
+} from '@modelcontextprotocol/sdk/shared/transport.js';
+
+// ============================================================================
+// PROTOCOL CONSTANTS & ERROR CODES
+// ============================================================================
+
+export {
+  ErrorCode,
+  JSONRPC_VERSION,
+  LATEST_PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+} from '@modelcontextprotocol/sdk/types.js';
+
+// ============================================================================
+// TYPE EXPORTS - Core MCP Types
+// ============================================================================
+
+export type {
+  AudioContent,
+  BlobResourceContents,
   CallToolRequest,
   CallToolResult,
+  // Cancelled notification
+  CancelledNotification,
+  // Capabilities
   ClientCapabilities,
+  // Client request/notification/result types
   ClientNotification,
   ClientRequest,
   ClientResult,
+  // Completion types (for autocompletion)
+  CompleteRequest,
+  CompleteResult,
+  // Sampling types (for LLM sampling requests)
   CreateMessageRequest,
   CreateMessageResult,
+  // Pagination types
+  Cursor,
+  // Elicitation types (for user input requests)
   ElicitRequest,
   ElicitResult,
+  EmbeddedResource,
   GetPromptRequest,
   GetPromptResult,
+  ImageContent,
+  // Base protocol types
   Implementation,
+  InitializedNotification,
+  // Initialization
   InitializeRequest,
   InitializeResult,
+  // JSON-RPC types
+  JSONRPCError,
   JSONRPCMessage,
+  JSONRPCNotification,
+  JSONRPCRequest,
+  JSONRPCResponse,
   ListPromptsRequest,
   ListPromptsResult,
   ListResourcesRequest,
   ListResourcesResult,
+  ListResourceTemplatesRequest,
+  ListResourceTemplatesResult,
+  ListRootsRequest,
+  ListRootsResult,
   ListToolsRequest,
   ListToolsResult,
+  // Logging types
   LoggingLevel,
   LoggingMessageNotification,
+  // Error class
   McpError,
+  // Extra info passed with messages
+  MessageExtraInfo,
   Notification,
+  PaginatedRequest,
+  PaginatedResult,
+  // Progress types
+  Progress,
+  ProgressNotification,
+  ProgressToken,
+  // Prompt types
   Prompt,
+  PromptArgument,
+  PromptListChangedNotification,
   PromptMessage,
   ReadResourceRequest,
   ReadResourceResult,
   Request,
+  RequestId,
+  RequestInfo,
+  // Resource types
   Resource,
   ResourceContents,
+  ResourceLink,
+  ResourceListChangedNotification,
   ResourceTemplate,
+  ResourceUpdatedNotification,
   Result,
+  // Root types
+  Root,
+  RootsListChangedNotification,
+  SamplingMessage,
   ServerCapabilities,
+  // Server request/notification/result types
   ServerNotification,
   ServerRequest,
   ServerResult,
+  SubscribeRequest,
+  // Content types
+  TextContent,
+  TextResourceContents,
+  // Tool types
   Tool,
   ToolAnnotations,
+  UnsubscribeRequest,
 } from '@modelcontextprotocol/sdk/types.js';
 
-// Re-export schemas for request/response validation
+// ============================================================================
+// SCHEMA EXPORTS - Zod Schemas for Validation
+// ============================================================================
+
 export {
+  AudioContentSchema,
+  BlobResourceContentsSchema,
   CallToolRequestSchema,
   CallToolResultSchema,
+  // Cancelled notification schema
+  CancelledNotificationSchema,
+  // Capability schemas
+  ClientCapabilitiesSchema,
+  // Client/Server message schemas
+  ClientNotificationSchema,
+  ClientRequestSchema,
+  ClientResultSchema,
+  CompatibilityCallToolResultSchema,
+  // Completion schemas
+  CompleteRequestSchema,
+  CompleteResultSchema,
+  ContentBlockSchema,
+  // Sampling schemas
   CreateMessageRequestSchema,
   CreateMessageResultSchema,
+  // Pagination schemas
+  CursorSchema,
+  // Elicitation schemas
   ElicitRequestSchema,
   ElicitResultSchema,
-  ErrorCode,
+  EmbeddedResourceSchema,
+  EmptyResultSchema,
   GetPromptRequestSchema,
   GetPromptResultSchema,
+  ImageContentSchema,
+  ImplementationSchema,
+  InitializedNotificationSchema,
+  // Initialization schemas
   InitializeRequestSchema,
   InitializeResultSchema,
-  LATEST_PROTOCOL_VERSION,
+  isInitializedNotification,
+  isInitializeRequest,
+  // Type guards
+  isJSONRPCError,
+  isJSONRPCNotification,
+  isJSONRPCRequest,
+  isJSONRPCResponse,
+  // JSON-RPC schemas
+  JSONRPCErrorSchema,
+  JSONRPCMessageSchema,
+  JSONRPCNotificationSchema,
+  JSONRPCRequestSchema,
+  JSONRPCResponseSchema,
   ListPromptsRequestSchema,
   ListPromptsResultSchema,
   ListResourcesRequestSchema,
   ListResourcesResultSchema,
+  ListResourceTemplatesRequestSchema,
+  ListResourceTemplatesResultSchema,
+  ListRootsRequestSchema,
+  ListRootsResultSchema,
   ListToolsRequestSchema,
   ListToolsResultSchema,
+  // Logging schemas
   LoggingLevelSchema,
+  LoggingMessageNotificationSchema,
+  ModelHintSchema,
+  ModelPreferencesSchema,
+  NotificationSchema,
+  PaginatedRequestSchema,
+  PaginatedResultSchema,
+  // Ping schema
+  PingRequestSchema,
+  ProgressNotificationSchema,
+  // Progress schemas
+  ProgressSchema,
+  ProgressTokenSchema,
+  PromptArgumentSchema,
+  PromptListChangedNotificationSchema,
+  PromptMessageSchema,
+  // Prompt schemas
+  PromptSchema,
   ReadResourceRequestSchema,
   ReadResourceResultSchema,
-  SUPPORTED_PROTOCOL_VERSIONS,
+  RequestIdSchema,
+  // Base schemas
+  RequestSchema,
+  ResourceContentsSchema,
+  ResourceLinkSchema,
+  ResourceListChangedNotificationSchema,
+  // Resource schemas
+  ResourceSchema,
+  ResourceTemplateSchema,
+  ResourceUpdatedNotificationSchema,
+  ResultSchema,
+  // Root schemas
+  RootSchema,
+  RootsListChangedNotificationSchema,
+  SamplingMessageSchema,
+  ServerCapabilitiesSchema,
+  ServerNotificationSchema,
+  ServerRequestSchema,
+  ServerResultSchema,
+  SetLevelRequestSchema,
+  SubscribeRequestSchema,
+  // Content schemas
+  TextContentSchema,
+  TextResourceContentsSchema,
+  ToolAnnotationsSchema,
+  ToolListChangedNotificationSchema,
+  // Tool schemas
+  ToolSchema,
+  UnsubscribeRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-export { BrowserMcpServer as McpServer, BrowserMcpServer } from './browser-server.js';


### PR DESCRIPTION
- Remove OAuth/auth module exports (not needed for browser MCP)
- Remove Node.js-specific transport exports (stdio, SSE, streamable HTTP)
- Keep only InMemoryTransport (useful for testing)
- Add comprehensive type and schema exports for browser use
- Update README with "What's Included/Excluded" documentation
- Update package description to reflect stripped-down nature

This makes the package more focused on browser-only use cases,
while @mcp-b/transports provides browser-specific transports.