### PR TITLE
fix(chrome-devtools-mcp): update import paths in tests dir for vendor rename

### DIFF
--- a/packages/chrome-devtools-mcp/scripts/post-build.ts
+++ b/packages/chrome-devtools-mcp/scripts/post-build.ts
@@ -36,7 +36,9 @@ function renameNodeModulesToVendor(): void {
   // Update all import paths in the built JS files
   console.log('Updating import paths from node_modules to vendor...');
   const srcDir = path.join(BUILD_DIR, 'src');
+  const testsDir = path.join(BUILD_DIR, 'tests');
   updateImportPathsInDir(srcDir);
+  updateImportPathsInDir(testsDir);
 
   console.log('Successfully renamed node_modules to vendor');
 }


### PR DESCRIPTION
## Summary
The post-build script was only updating import paths from `node_modules` to `vendor` in the `src` directory, but not in the `tests` directory. This caused test failures when the tests tried to import from the renamed vendor directory.

## Test plan
- [x] All 223 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)