### PR TITLE
Enforce iframe prefix name validation regex

### DIFF
--- a/.changeset/enforce-prefix-validation.md
+++ b/.changeset/enforce-prefix-validation.md
@@ -1,0 +1,20 @@
+---
+"@mcp-b/mcp-iframe": minor
+---
+
+Enforce MCP name validation for tool and prompt prefixes
+
+**BREAKING CHANGE**: Default prefix separator changed from `:` to `_` to comply with MCP schema requirements.
+
+Tool and prompt names must match the pattern `^[a-zA-Z0-9_-]{1,128}$`. The previous default separator `:` was invalid according to this schema.
+
+Changes:
+- Changed default `prefix-separator` from `:` to `_`
+- Added runtime validation for prefix separator (warns and sanitizes invalid characters)
+- Added validation for element ID/name (warns and sanitizes invalid characters)
+- Added validation before tool/prompt registration (skips registration with error if final name is invalid)
+- Names exceeding 128 characters will not be registered
+
+If you were relying on the `:` separator, you can either:
+1. Accept the new `_` separator (recommended for MCP compatibility)
+2. Explicitly set `prefix-separator=":"` attribute (not recommended as it may cause MCP validation errors)

--- a/e2e/test-app/src/mcp-iframe-host.ts
+++ b/e2e/test-app/src/mcp-iframe-host.ts
@@ -83,7 +83,7 @@ mcpIframe.addEventListener('mcp-iframe-tools-changed', (event) => {
 
 // Test tool calls
 async function callTool(name: string, args: Record<string, unknown>) {
-  const prefixedName = `child-iframe:${name}`;
+  const prefixedName = `child-iframe_${name}`;
   log(`Calling tool: ${prefixedName}`);
   toolResultEl.textContent = 'Calling...';
 
@@ -107,7 +107,7 @@ async function callTool(name: string, args: Record<string, unknown>) {
 
 // Test resource reads
 async function readResource(uri: string) {
-  const prefixedUri = `child-iframe:${uri}`;
+  const prefixedUri = `child-iframe_${uri}`;
   log(`Reading resource: ${prefixedUri}`);
   resourceResultEl.textContent = 'Reading...';
 
@@ -144,7 +144,7 @@ async function readResource(uri: string) {
 
 // Test prompt gets
 async function getPrompt(name: string, args: Record<string, unknown>) {
-  const prefixedName = `child-iframe:${name}`;
+  const prefixedName = `child-iframe_${name}`;
   log(`Getting prompt: ${prefixedName}`);
   promptResultEl.textContent = 'Getting...';
 

--- a/e2e/tests/mcp-iframe-element.spec.ts
+++ b/e2e/tests/mcp-iframe-element.spec.ts
@@ -23,9 +23,9 @@ test.describe('MCPIframeElement E2E Tests', () => {
 
     // Verify tool names are prefixed
     const toolsText = await toolsEl.textContent();
-    expect(toolsText).toContain('child-iframe:add');
-    expect(toolsText).toContain('child-iframe:multiply');
-    expect(toolsText).toContain('child-iframe:greet');
+    expect(toolsText).toContain('child-iframe_add');
+    expect(toolsText).toContain('child-iframe_multiply');
+    expect(toolsText).toContain('child-iframe_greet');
   });
 
   test('should expose resources from iframe', async ({ page }) => {
@@ -35,8 +35,8 @@ test.describe('MCPIframeElement E2E Tests', () => {
 
     // Verify resource URIs are prefixed
     const resourcesText = await resourcesEl.textContent();
-    expect(resourcesText).toContain('child-iframe:iframe://config');
-    expect(resourcesText).toContain('child-iframe:iframe://timestamp');
+    expect(resourcesText).toContain('child-iframe_iframe://config');
+    expect(resourcesText).toContain('child-iframe_iframe://timestamp');
   });
 
   test('should expose prompts from iframe', async ({ page }) => {
@@ -46,8 +46,8 @@ test.describe('MCPIframeElement E2E Tests', () => {
 
     // Verify prompt names are prefixed
     const promptsText = await promptsEl.textContent();
-    expect(promptsText).toContain('child-iframe:summarize');
-    expect(promptsText).toContain('child-iframe:translate');
+    expect(promptsText).toContain('child-iframe_summarize');
+    expect(promptsText).toContain('child-iframe_translate');
   });
 
   test('should call add tool and get result', async ({ page }) => {
@@ -177,6 +177,6 @@ test.describe('MCPIframeElement E2E Tests', () => {
     expect(elementInfo.exposedToolsCount).toBe(3);
     expect(elementInfo.exposedResourcesCount).toBe(2);
     expect(elementInfo.exposedPromptsCount).toBe(2);
-    expect(elementInfo.itemPrefix).toBe('child-iframe:');
+    expect(elementInfo.itemPrefix).toBe('child-iframe_');
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: Default prefix separator changed from ':' to '_'

The MCP schema requires tool/prompt names to match ^[a-zA-Z0-9_-]{1,128}$. The previous default separator ':' was invalid according to this schema.

Changes:
- Changed default prefix-separator from ':' to '_'
- Added runtime validation for prefix separator (warns and sanitizes)
- Added validation for element ID/name (warns and sanitizes)
- Added validation before tool/prompt registration (skips if invalid)
- Names exceeding 128 characters will not be registered