### PR TITLE
feat(chrome-devtools-mcp): integrate upstream changes from v0.12.1

### DIFF
--- a/packages/chrome-devtools-mcp/src/PageCollector.ts
+++ b/packages/chrome-devtools-mcp/src/PageCollector.ts
@@ -93,19 +93,27 @@ export class PageCollector<T> {
   }
 
   #onTargetCreated = async (target: Target) => {
-    const page = await target.page();
-    if (!page) {
-      return;
+    try {
+      const page = await target.page();
+      if (!page) {
+        return;
+      }
+      this.addPage(page);
+    } catch (err) {
+      logger('Error getting a page for a target onTargetCreated', err);
     }
-    this.addPage(page);
   };
 
   #onTargetDestroyed = async (target: Target) => {
-    const page = await target.page();
-    if (!page) {
-      return;
+    try {
+      const page = await target.page();
+      if (!page) {
+        return;
+      }
+      this.cleanupPageDestroyed(page);
+    } catch (err) {
+      logger('Error getting a page for a target onTargetDestroyed', err);
     }
-    this.cleanupPageDestroyed(page);
   };
 
   public addPage(page: Page) {

--- a/packages/chrome-devtools-mcp/src/browser.ts
+++ b/packages/chrome-devtools-mcp/src/browser.ts
@@ -48,7 +48,10 @@ export async function ensureBrowserConnected(options: {
   wsEndpoint?: string;
   wsHeaders?: Record<string, string>;
   devtools: boolean;
+  channel?: Channel;
+  userDataDir?: string;
 }) {
+  const {channel} = options;
   if (browser?.connected) {
     return browser;
   }
@@ -66,12 +69,63 @@ export async function ensureBrowserConnected(options: {
     }
   } else if (options.browserURL) {
     connectOptions.browserURL = options.browserURL;
+  } else if (channel || options.userDataDir) {
+    const userDataDir = options.userDataDir;
+    if (userDataDir) {
+      // TODO: re-expose this logic via Puppeteer.
+      const portPath = path.join(userDataDir, 'DevToolsActivePort');
+      try {
+        const fileContent = await fs.promises.readFile(portPath, 'utf8');
+        const [rawPort, rawPath] = fileContent
+          .split('\n')
+          .map(line => {
+            return line.trim();
+          })
+          .filter(line => {
+            return !!line;
+          });
+        if (!rawPort || !rawPath) {
+          throw new Error(`Invalid DevToolsActivePort '${fileContent}' found`);
+        }
+        const port = parseInt(rawPort, 10);
+        if (isNaN(port) || port <= 0 || port > 65535) {
+          throw new Error(`Invalid port '${rawPort}' found`);
+        }
+        const browserWSEndpoint = `ws://127.0.0.1:${port}${rawPath}`;
+        connectOptions.browserWSEndpoint = browserWSEndpoint;
+      } catch (error) {
+        throw new Error(
+          `Could not connect to Chrome in ${userDataDir}. Check if Chrome is running and remote debugging is enabled.`,
+          {
+            cause: error,
+          },
+        );
+      }
+    } else {
+      if (!channel) {
+        throw new Error('Channel must be provided if userDataDir is missing');
+      }
+      connectOptions.channel = (
+        channel === 'stable' ? 'chrome' : `chrome-${channel}`
+      ) as ChromeReleaseChannel;
+    }
   } else {
-    throw new Error('Either browserURL or wsEndpoint must be provided');
+    throw new Error(
+      'Either browserURL, wsEndpoint, channel or userDataDir must be provided',
+    );
   }
 
   logger('Connecting Puppeteer to ', JSON.stringify(connectOptions));
-  browser = await puppeteer.connect(connectOptions);
+  try {
+    browser = await puppeteer.connect(connectOptions);
+  } catch (err) {
+    throw new Error(
+      'Could not connect to Chrome. Check if Chrome is running and remote debugging is enabled by going to chrome://inspect/#remote-debugging.',
+      {
+        cause: err,
+      },
+    );
+  }
   logger('Connected Puppeteer');
   return browser;
 }

--- a/packages/chrome-devtools-mcp/src/cli.ts
+++ b/packages/chrome-devtools-mcp/src/cli.ts
@@ -8,6 +8,19 @@ import type {YargsOptions} from './third_party/index.js';
 import {yargs, hideBin} from './third_party/index.js';
 
 export const cliOptions = {
+  autoConnect: {
+    type: 'boolean',
+    description:
+      'If specified, automatically connects to a browser (Chrome 145+) running in the user data directory identified by the channel param. Requires remote debugging being enabled in Chrome here: chrome://inspect/#remote-debugging.',
+    conflicts: ['isolated', 'executablePath'],
+    default: false,
+    coerce: (value: boolean | undefined) => {
+      if (!value) {
+        return;
+      }
+      return value;
+    },
+  },
   browserUrl: {
     type: 'string',
     description:
@@ -220,6 +233,14 @@ export function parseArguments(version: string, argv = process.argv) {
       [
         '$0 --user-data-dir=/tmp/user-data-dir',
         'Use a custom user data directory',
+      ],
+      [
+        '$0 --auto-connect',
+        'Connect to a stable Chrome instance (Chrome 145+) running instead of launching a new instance',
+      ],
+      [
+        '$0 --auto-connect --channel=canary',
+        'Connect to a canary Chrome instance (Chrome 145+) running instead of launching a new instance',
       ],
     ]);
 

--- a/packages/chrome-devtools-mcp/src/tools/pages.ts
+++ b/packages/chrome-devtools-mcp/src/tools/pages.ts
@@ -34,13 +34,19 @@ export const selectPage = defineTool({
     pageIdx: zod
       .number()
       .describe(
-        'The index of the page to select. Call list_pages to list pages.',
+        `The index of the page to select. Call ${listPages.name} to get available pages.`,
       ),
+    bringToFront: zod
+      .boolean()
+      .optional()
+      .describe('Whether to focus the page and bring it to the top.'),
   },
   handler: async (request, response, context) => {
     const page = context.getPageByIdx(request.params.pageIdx);
-    await page.bringToFront();
     context.selectPage(page);
+    if (request.params.bringToFront) {
+      await page.bringToFront();
+    }
     response.setIncludePages(true);
   },
 });


### PR DESCRIPTION
Integrate key upstream changes from ChromeDevTools/chrome-devtools-mcp v0.12.1:

- Add --auto-connect option to connect to running Chrome instance (Chrome 145+)
- Add channel/userDataDir support for browser connection via DevToolsActivePort
- Make bringToFront optional in select_page tool
- Add unhandled promise rejection logging
- Add error handling for target created/destroyed events in PageCollector
- Improve error messages with cause information

These changes bring our fork up to date with the latest upstream features
while preserving our WebMCP integration.