### PR TITLE
feat(fetch-wrapper): add server-side http_request helpers, types, docs, and tests

### DIFF
--- a/docs/FETCH_PROXY_IMPLEMENTATION_PLAN.md
+++ b/docs/FETCH_PROXY_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,51 @@
+# Fetch Proxy Implementation Plan
+
+## Goal
+
+Deliver a fetch wrapper that proxies requests through an MCP tool (`http_request`) so sandboxed iframe apps can call backend logic via the host without direct network access.
+
+## Constraints
+
+- **Single path:** iframe → postMessage → host → MCP tool → server logic.
+- **Fetch-aligned schema:** request/response payloads map to standard Fetch semantics.
+- **No WebMCP changes in this phase.**
+- **Host observability:** requests are visible and enforceable at the MCP boundary.
+
+## Milestones
+
+### 1) Transport Contract (Done)
+- Define `http_request` payload/response types aligned with Fetch.
+- Support `method`, `url`, `headers`, `redirect`, `cache`, `credentials`, `timeoutMs`.
+- Support body encodings: `json`, `text`, `urlEncoded`, `formData`, `base64`, `none`.
+
+### 2) Client Wrapper (Done)
+- Implement `createMcpFetch(client, options)` to serialize Fetch calls into `http_request`.
+- Implement `initMcpFetch(client, options)` to patch/restore `globalThis.fetch`.
+- Handle AbortSignal by wiring to MCP `callTool`.
+
+### 3) Server Tool Helper (Done)
+- Provide a utility to build `http_request` tool handlers:
+  - Response builder helper
+  - Handler wrapper that emits structured responses
+
+### 4) Demo Integration (Next)
+- Add a minimal iframe demo that uses the wrapper to fetch `/api/time`.
+- Route the request to shared application logic in the MCP server.
+- Verify host-visible logging.
+
+### 5) Tests (Done + Expand)
+- Unit tests for request serialization and response reconstruction.
+- Add integration test to ensure fetch → `http_request` → response round-trips.
+
+## Risks & Mitigations
+
+- **Binary streaming:** Deferred in MVP. Use `base64` encoding for binary payloads.
+- **FormData file handling:** Supported via base64 encoding for file entries.
+- **Error propagation:** MCP errors should be surfaced as `Response` with error JSON.
+
+## Success Criteria
+
+- Apps can call `fetch('/api/...')` in a sandboxed iframe and receive responses.
+- Host observes every request at the MCP boundary.
+- No dependency on direct network access from the iframe.
+- Wrapper can be adopted without modifying WebMCP tool registration.

--- a/packages/fetch-wrapper/README.md
+++ b/packages/fetch-wrapper/README.md
@@ -1,0 +1,49 @@
+# @mcp-b/fetch-wrapper
+
+Fetch wrapper that proxies requests through an MCP tool so iframe apps can call backend logic via the host.
+
+## Installation
+
+```bash
+pnpm add @mcp-b/fetch-wrapper
+```
+
+## Usage
+
+```ts
+import { Client } from '@mcp-b/webmcp-ts-sdk';
+import { createHttpRequestTool, createMcpFetch, initMcpFetch } from '@mcp-b/fetch-wrapper';
+
+const client = new Client({ name: 'app', version: '1.0.0' });
+// Connect client to your MCP transport before using.
+
+// Option 1: wrap a fetch function
+const mcpFetch = createMcpFetch(client);
+const response = await mcpFetch('/api/time');
+
+// Option 2: patch global fetch
+const restore = initMcpFetch(client);
+await fetch('/api/time');
+restore();
+```
+
+## Server Tool Helper
+
+```ts
+import { createHttpRequestTool } from '@mcp-b/fetch-wrapper';
+
+const httpRequestTool = createHttpRequestTool(async (request) => {
+  if (request.url.endsWith('/api/time')) {
+    return { status: 200, headers: { 'content-type': 'application/json' }, body: { time: Date.now() }, bodyType: 'json' };
+  }
+  return { status: 404, headers: { 'content-type': 'application/json' }, body: { error: 'Not found' }, bodyType: 'json' };
+});
+
+// register httpRequestTool as your MCP tool handler for `http_request`
+```
+
+## Tool Contract
+
+The wrapper expects a tool named `http_request` (configurable via `toolName`) that accepts a Fetch-aligned payload and returns a structured response.
+
+See `src/types.ts` for the exact schema and body serialization rules.

--- a/packages/fetch-wrapper/package.json
+++ b/packages/fetch-wrapper/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@mcp-b/fetch-wrapper",
+  "version": "0.1.0",
+  "description": "Fetch wrapper that proxies requests through MCP tools for cross-context apps",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "fetch",
+    "postmessage",
+    "iframe",
+    "proxy",
+    "http_request",
+    "webmcp"
+  ],
+  "homepage": "https://docs.mcp-b.ai/packages/fetch-wrapper",
+  "bugs": {
+    "url": "https://github.com/WebMCP-org/npm-packages/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/WebMCP-org/npm-packages.git",
+    "directory": "packages/fetch-wrapper"
+  },
+  "license": "MIT",
+  "author": "WebMCP Team",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "check": "biome check --write .",
+    "clean": "rm -rf dist .turbo",
+    "format": "biome format --write .",
+    "lint": "biome lint --write .",
+    "prepublishOnly": "node ../../scripts/validate-publish.js && pnpm run build",
+    "publish:dry": "pnpm publish --access public --dry-run",
+    "publish:npm": "pnpm publish --access public",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "version:major": "pnpm version major --no-git-tag-version",
+    "version:minor": "pnpm version minor --no-git-tag-version",
+    "version:patch": "pnpm version patch --no-git-tag-version"
+  },
+  "dependencies": {
+    "@mcp-b/webmcp-ts-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/fetch-wrapper/src/index.test.ts
+++ b/packages/fetch-wrapper/src/index.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createHttpRequestTool, createMcpFetch, initMcpFetch } from './index.js';
+
+const createMockClient = () => {
+  return {
+    callTool: vi.fn(),
+  };
+};
+
+describe('createMcpFetch', () => {
+  it('serializes JSON requests and builds JSON responses', async () => {
+    const client = createMockClient();
+    client.callTool.mockResolvedValue({
+      structuredContent: {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        body: { ok: true },
+        bodyType: 'json',
+      },
+    });
+
+    const mcpFetch = createMcpFetch(client);
+    const response = await mcpFetch('https://example.com/api/time', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ now: true }),
+    });
+
+    const payload = await response.json();
+    expect(payload).toEqual({ ok: true });
+
+    const callArgs = client.callTool.mock.calls[0]?.[0]?.arguments as Record<string, unknown>;
+    expect(callArgs.method).toBe('POST');
+    expect(callArgs.url).toBe('https://example.com/api/time');
+    expect(callArgs.bodyType).toBe('json');
+    expect(callArgs.body).toEqual({ now: true });
+  });
+
+  it('handles base64 responses', async () => {
+    const client = createMockClient();
+    const base64 = Buffer.from('hello').toString('base64');
+
+    client.callTool.mockResolvedValue({
+      structuredContent: {
+        status: 200,
+        headers: { 'content-type': 'application/octet-stream' },
+        body: base64,
+        bodyType: 'base64',
+      },
+    });
+
+    const mcpFetch = createMcpFetch(client);
+    const response = await mcpFetch('https://example.com/binary');
+    const buffer = Buffer.from(await response.arrayBuffer());
+
+    expect(buffer.toString('utf8')).toBe('hello');
+  });
+
+  it('falls back to base fetch when shouldHandle returns false', async () => {
+    const client = createMockClient();
+    const baseFetch = vi.fn(async () => new Response('fallback', { status: 200 }));
+
+    const mcpFetch = createMcpFetch(client, {
+      baseFetch,
+      shouldHandle: () => false,
+    });
+
+    const response = await mcpFetch('https://example.com/fallback');
+    expect(await response.text()).toBe('fallback');
+    expect(client.callTool).not.toHaveBeenCalled();
+  });
+});
+
+describe('initMcpFetch', () => {
+  it('patches and restores global fetch', async () => {
+    const originalFetch = globalThis.fetch;
+    const client = createMockClient();
+
+    client.callTool.mockResolvedValue({
+      structuredContent: {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+        body: 'ok',
+        bodyType: 'text',
+      },
+    });
+
+    const restore = initMcpFetch(client);
+
+    const response = await fetch('https://example.com/ok');
+    expect(await response.text()).toBe('ok');
+
+    restore();
+    expect(globalThis.fetch).toBe(originalFetch);
+  });
+});
+
+describe('createHttpRequestTool', () => {
+  it('wraps handler responses into MCP tool results', async () => {
+    const handler = createHttpRequestTool(async () => ({
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body: { ok: true },
+      bodyType: 'json',
+    }));
+
+    const result = await handler({
+      method: 'GET',
+      url: 'https://example.com/ok',
+    });
+
+    expect(result.structuredContent?.status).toBe(200);
+    expect(result.content?.[0]?.text).toContain('"ok":true');
+    expect(result.isError).toBe(false);
+  });
+});

--- a/packages/fetch-wrapper/src/index.ts
+++ b/packages/fetch-wrapper/src/index.ts
@@ -1,0 +1,349 @@
+import type {
+  HttpBodyType,
+  HttpRequestHandler,
+  HttpRequestPayload,
+  HttpResponsePayload,
+  HttpToolResult,
+  McpFetchClient,
+  McpFetchOptions,
+  SerializedFormDataEntry,
+} from './types.js';
+
+export type {
+  HttpBodyType,
+  HttpRequestHandler,
+  HttpRequestPayload,
+  HttpResponsePayload,
+  HttpToolResult,
+  McpFetchClient,
+  McpFetchOptions,
+  SerializedFormDataEntry,
+} from './types.js';
+
+const DEFAULT_TOOL_NAME = 'http_request';
+
+const BODYLESS_METHODS = new Set(['GET', 'HEAD']);
+const DEFAULT_RESPONSE_HEADERS: Record<string, string> = {
+  'content-type': 'application/json',
+};
+
+function encodeBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64');
+  }
+
+  let binary = '';
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index] ?? 0);
+  }
+  if (typeof globalThis.btoa !== 'function') {
+    throw new Error('Base64 encoding is not available in this environment.');
+  }
+  return globalThis.btoa(binary);
+}
+
+function decodeBase64(base64: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') {
+    return Uint8Array.from(Buffer.from(base64, 'base64'));
+  }
+  if (typeof globalThis.atob !== 'function') {
+    throw new Error('Base64 decoding is not available in this environment.');
+  }
+  const binary = globalThis.atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  const normalized: Record<string, string> = {};
+
+  if (headers instanceof Headers) {
+    headers.forEach((value, key) => {
+      normalized[key.toLowerCase()] = value;
+    });
+    return normalized;
+  }
+
+  if (Array.isArray(headers)) {
+    for (const [key, value] of headers) {
+      normalized[key.toLowerCase()] = value;
+    }
+    return normalized;
+  }
+
+  for (const [key, value] of Object.entries(headers)) {
+    normalized[key.toLowerCase()] = value;
+  }
+
+  return normalized;
+}
+
+async function serializeFormData(formData: FormData): Promise<SerializedFormDataEntry[]> {
+  const entries: SerializedFormDataEntry[] = [];
+
+  for (const [name, value] of formData.entries()) {
+    if (typeof value === 'string') {
+      entries.push({ name, value, encoding: 'text' });
+      continue;
+    }
+
+    const bytes = new Uint8Array(await value.arrayBuffer());
+    entries.push({
+      name,
+      value: encodeBase64(bytes),
+      encoding: 'base64',
+      filename: value.name,
+      contentType: value.type || undefined,
+    });
+  }
+
+  return entries;
+}
+
+async function serializeBody(request: Request): Promise<{
+  body?: unknown;
+  bodyType?: HttpBodyType;
+}> {
+  if (BODYLESS_METHODS.has(request.method.toUpperCase())) {
+    return { bodyType: 'none' };
+  }
+
+  if (!request.body) {
+    return { bodyType: 'none' };
+  }
+
+  const contentType = request.headers.get('content-type')?.toLowerCase() ?? '';
+  const clone = request.clone();
+
+  if (contentType.includes('application/json')) {
+    try {
+      const json = await clone.json();
+      return { body: json, bodyType: 'json' };
+    } catch {
+      const text = await clone.text();
+      return { body: text, bodyType: 'text' };
+    }
+  }
+
+  if (contentType.includes('application/x-www-form-urlencoded')) {
+    return { body: await clone.text(), bodyType: 'urlEncoded' };
+  }
+
+  if (contentType.includes('multipart/form-data')) {
+    const formData = await clone.formData();
+    return { body: await serializeFormData(formData), bodyType: 'formData' };
+  }
+
+  if (contentType.startsWith('text/')) {
+    return { body: await clone.text(), bodyType: 'text' };
+  }
+
+  const arrayBuffer = await clone.arrayBuffer();
+  const bytes = new Uint8Array(arrayBuffer);
+  if (bytes.length === 0) {
+    return { bodyType: 'none' };
+  }
+  return { body: encodeBase64(bytes), bodyType: 'base64' };
+}
+
+async function buildRequestPayload(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs?: number
+): Promise<HttpRequestPayload> {
+  const request = input instanceof Request ? new Request(input, init) : new Request(input, init);
+
+  const headers = normalizeHeaders(request.headers) ?? normalizeHeaders(init?.headers);
+  const body = await serializeBody(request);
+
+  return {
+    method: request.method,
+    url: request.url,
+    headers,
+    redirect: request.redirect,
+    cache: request.cache,
+    credentials: request.credentials,
+    timeoutMs,
+    ...body,
+  };
+}
+
+function extractResponsePayload(result: {
+  structuredContent?: unknown;
+  content?: Array<{ type: string; text?: string }>;
+}): HttpResponsePayload {
+  if (result.structuredContent && typeof result.structuredContent === 'object') {
+    return result.structuredContent as HttpResponsePayload;
+  }
+
+  const text = result.content?.find((item) => item.type === 'text')?.text;
+  if (!text) {
+    throw new Error('http_request response missing structuredContent and text payload');
+  }
+
+  try {
+    return JSON.parse(text) as HttpResponsePayload;
+  } catch {
+    throw new Error('http_request response text payload is not valid JSON');
+  }
+}
+
+function deserializeFormData(entries: SerializedFormDataEntry[]): FormData {
+  const formData = new FormData();
+  for (const entry of entries) {
+    if (entry.encoding === 'text') {
+      formData.append(entry.name, entry.value);
+    } else {
+      const bytes = decodeBase64(entry.value);
+      const blob = new Blob([bytes], { type: entry.contentType || undefined });
+      if (entry.filename) {
+        formData.append(entry.name, blob, entry.filename);
+      } else {
+        formData.append(entry.name, blob);
+      }
+    }
+  }
+  return formData;
+}
+
+function buildResponseBody(payload: HttpResponsePayload): BodyInit | null {
+  const bodyType = payload.bodyType ?? 'none';
+  const body = payload.body;
+
+  if (bodyType === 'none') {
+    return null;
+  }
+
+  if (bodyType === 'json') {
+    return JSON.stringify(body ?? null);
+  }
+
+  if (bodyType === 'urlEncoded') {
+    return typeof body === 'string' ? body : String(body ?? '');
+  }
+
+  if (bodyType === 'text') {
+    return typeof body === 'string' ? body : String(body ?? '');
+  }
+
+  if (bodyType === 'base64') {
+    if (typeof body !== 'string') {
+      throw new Error('Expected base64 string response body');
+    }
+    return decodeBase64(body);
+  }
+
+  if (bodyType === 'formData') {
+    if (!Array.isArray(body)) {
+      throw new Error('Expected formData array response body');
+    }
+    return deserializeFormData(body as SerializedFormDataEntry[]);
+  }
+
+  return null;
+}
+
+function buildFetchResponse(payload: HttpResponsePayload): Response {
+  const headers = new Headers(payload.headers ?? {});
+  const body = buildResponseBody(payload);
+
+  return new Response(body, {
+    status: payload.status,
+    statusText: payload.statusText,
+    headers,
+  });
+}
+
+function resolveSignal(input: RequestInfo | URL, init?: RequestInit): AbortSignal | undefined {
+  if (init?.signal) return init.signal;
+  if (input instanceof Request) return input.signal;
+  return undefined;
+}
+
+export function createHttpResponse(
+  body: unknown,
+  init: {
+    status?: number;
+    statusText?: string;
+    headers?: Record<string, string>;
+    bodyType?: HttpBodyType;
+    url?: string;
+    redirected?: boolean;
+  } = {}
+): HttpResponsePayload {
+  const status = init.status ?? 200;
+  const bodyType = init.bodyType ?? (body === undefined ? 'none' : 'json');
+  return {
+    status,
+    statusText: init.statusText,
+    headers: { ...DEFAULT_RESPONSE_HEADERS, ...(init.headers ?? {}) },
+    body,
+    bodyType,
+    url: init.url,
+    redirected: init.redirected,
+    ok: status >= 200 && status < 300,
+  };
+}
+
+export function createHttpRequestTool(
+  handler: HttpRequestHandler
+): (args: HttpRequestPayload) => Promise<HttpToolResult> {
+  return async (args: HttpRequestPayload): Promise<HttpToolResult> => {
+    const response = await handler(args);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(response) }],
+      structuredContent: response,
+      isError: response.status >= 400,
+    };
+  };
+}
+
+export function createMcpFetch(
+  client: McpFetchClient,
+  options: McpFetchOptions = {}
+): typeof fetch {
+  const toolName = options.toolName ?? DEFAULT_TOOL_NAME;
+  const baseFetch = options.baseFetch ?? globalThis.fetch;
+
+  if (!baseFetch) {
+    throw new Error('Global fetch is not available. Provide a baseFetch option.');
+  }
+
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const shouldHandle = options.shouldHandle?.(input, init) ?? true;
+    if (!shouldHandle) {
+      return baseFetch(input, init);
+    }
+
+    const payload = await buildRequestPayload(input, init, options.timeoutMs);
+    const signal = resolveSignal(input, init);
+
+    const result = await client.callTool(
+      { name: toolName, arguments: payload as Record<string, unknown> },
+      undefined,
+      signal ? { signal } : undefined
+    );
+
+    const responsePayload = extractResponsePayload(result);
+    return buildFetchResponse(responsePayload);
+  };
+}
+
+export function initMcpFetch(client: McpFetchClient, options: McpFetchOptions = {}): () => void {
+  const baseFetch = options.baseFetch ?? globalThis.fetch;
+
+  if (!baseFetch) {
+    throw new Error('Global fetch is not available. Provide a baseFetch option.');
+  }
+
+  const mcpFetch = createMcpFetch(client, { ...options, baseFetch });
+  globalThis.fetch = mcpFetch;
+
+  return () => {
+    globalThis.fetch = baseFetch;
+  };
+}

--- a/packages/fetch-wrapper/src/types.ts
+++ b/packages/fetch-wrapper/src/types.ts
@@ -1,0 +1,60 @@
+export type HttpBodyType = 'none' | 'json' | 'text' | 'formData' | 'urlEncoded' | 'base64';
+
+export type SerializedFormDataEntry = {
+  name: string;
+  value: string;
+  encoding: 'text' | 'base64';
+  filename?: string;
+  contentType?: string;
+};
+
+export interface HttpRequestPayload {
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  bodyType?: HttpBodyType;
+  redirect?: RequestRedirect;
+  cache?: RequestCache;
+  credentials?: RequestCredentials;
+  timeoutMs?: number;
+}
+
+export interface HttpResponsePayload {
+  status: number;
+  statusText?: string;
+  headers: Record<string, string>;
+  body?: unknown;
+  bodyType?: HttpBodyType;
+  url?: string;
+  redirected?: boolean;
+  ok?: boolean;
+}
+
+export interface HttpToolResult {
+  content?: Array<{ type: string; text?: string }>;
+  structuredContent?: HttpResponsePayload;
+  isError?: boolean;
+}
+
+export type HttpRequestHandler = (
+  request: HttpRequestPayload
+) => Promise<HttpResponsePayload> | HttpResponsePayload;
+
+export interface McpFetchOptions {
+  toolName?: string;
+  baseFetch?: typeof fetch;
+  shouldHandle?: (input: RequestInfo | URL, init?: RequestInit) => boolean;
+  timeoutMs?: number;
+}
+
+export interface McpFetchClient {
+  callTool: (
+    request: { name: string; arguments?: Record<string, unknown> },
+    options?: unknown,
+    requestOptions?: { signal?: AbortSignal }
+  ) => Promise<{
+    content?: Array<{ type: string; text?: string }>;
+    structuredContent?: unknown;
+  }>;
+}

--- a/packages/fetch-wrapper/tsconfig.json
+++ b/packages/fetch-wrapper/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.*", "**/*.spec.*"]
+}

--- a/packages/fetch-wrapper/tsdown.config.ts
+++ b/packages/fetch-wrapper/tsdown.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  dts: true,
+  format: ['esm'],
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  minify: true,
+  target: 'esnext',
+  platform: 'browser',
+  external: [],
+  tsconfig: './tsconfig.json',
+});


### PR DESCRIPTION
### Motivation
- Provide server-side utilities to simplify registering an `http_request` MCP tool that speaks the same Fetch-aligned schema the client wrapper expects.
- Add a clear response builder and handler wrapper so MCP servers can return structured responses (including JSON, text, base64, and formData) consistently.
- Improve developer experience by documenting the server helper and adding unit tests that verify the helper and client wrapper behaviors.

### Description
- Add `createHttpResponse` and `createHttpRequestTool` helpers to `packages/fetch-wrapper/src/index.ts` to build structured `http_request` responses and to wrap handlers into MCP tool results.
- Extend types in `packages/fetch-wrapper/src/types.ts` with `HttpRequestHandler`, `HttpToolResult`, and related types to statically describe server helper contracts.
- Add unit tests in `packages/fetch-wrapper/src/index.test.ts` to cover the new helper wrapper and existing fetch wrapper behaviors, and update the README with a server-side example demonstrating `createHttpRequestTool` usage.
- Add package metadata and build config for the new package and mark the server helper milestone as done in `docs/FETCH_PROXY_IMPLEMENTATION_PLAN.md`.

### Testing
- Unit tests were added under `packages/fetch-wrapper/src/index.test.ts` to validate request serialization, response reconstruction, and the `createHttpRequestTool` wrapper.
- Running `pnpm --filter @mcp-b/fetch-wrapper test` in this environment failed to execute because `vitest` and other dev tooling are not installed and the Node engine in the environment does not match the workspace constraints, so automated tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981170d36b8832bb747ddf2cc609451)