### PR TITLE
fix(types): tighten JSON schema inference and add negative type checks

### DIFF
--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -81,6 +81,8 @@ import type {
   ElicitationResult,
   InferArgsFromInputSchema,
   JsonSchemaForInference,
+  LooseContentBlock,
+  MaybePromise,
   ModelContext,
   ToolExecutionContext,
   ToolDescriptor,
@@ -89,6 +91,44 @@ import type {
   TypedModelContext,
   CallToolResult,
 } from '@mcp-b/types';
+```
+
+### Sync or async execute handlers
+
+`execute` can return a plain result or a `Promise`.
+
+```typescript
+import type { CallToolResult, ToolDescriptor } from '@mcp-b/types';
+
+const syncTool: ToolDescriptor<{ message: string }, CallToolResult, 'sync_echo'> = {
+  name: 'sync_echo',
+  description: 'Synchronous echo',
+  inputSchema: {
+    type: 'object',
+    properties: { message: { type: 'string' } },
+    required: ['message'],
+  },
+  execute(args) {
+    return {
+      content: [{ type: 'text', text: args.message }],
+    };
+  },
+};
+```
+
+### Strict and loose content blocks
+
+`CallToolResult.content` accepts strict MCP content blocks and pragmatic loose objects.
+
+```typescript
+import type { CallToolResult } from '@mcp-b/types';
+
+const result: CallToolResult = {
+  content: [
+    { type: 'text', text: 'strict block' },
+    { text: 'loose block', data: 'opaque payload' },
+  ],
+};
 ```
 
 ### Typed tool descriptors
@@ -139,6 +179,8 @@ const searchTool: ToolDescriptor<SearchArgs> = {
 ```
 
 ### Pure JSON Schema inference (input + output)
+
+Inference focuses on core keywords (`type`, `properties`, `required`, `items`, `enum`, `const`) and tolerates additional schema metadata.
 
 ```typescript
 import type { JsonSchemaForInference } from '@mcp-b/types';

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-b/types",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "TypeScript type definitions for the W3C Web Model Context API (navigator.modelContext)",
   "keywords": [
     "mcp",

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -60,7 +60,7 @@ export interface InputSchema {
   /**
    * List of required property names.
    */
-  required?: string[];
+  required?: readonly string[];
 
   /**
    * Additional JSON Schema keywords.
@@ -227,6 +227,16 @@ export type ContentBlock =
   | ResourceLink
   | EmbeddedResource;
 
+/**
+ * Looser content block shape accepted by many MCP tool implementations.
+ *
+ * This keeps tool return typing practical while preserving strict content
+ * unions via {@link ContentBlock} for consumers that want discriminated checks.
+ */
+export type LooseContentBlock = Record<string, unknown> & {
+  type?: string;
+};
+
 // ============================================================================
 // Result Types
 // ============================================================================
@@ -240,7 +250,7 @@ export interface CallToolResult {
   /**
    * Ordered content blocks to return to the model.
    */
-  content: ContentBlock[];
+  content: Array<ContentBlock | LooseContentBlock>;
 
   /**
    * Optional machine-readable payload.
@@ -293,7 +303,7 @@ export interface ElicitationFormParams {
     /**
      * Required field names.
      */
-    required?: string[];
+    required?: readonly string[];
 
     /**
      * Additional schema keywords.

--- a/packages/types/src/global-register-tools.test-d.ts
+++ b/packages/types/src/global-register-tools.test-d.ts
@@ -1,0 +1,287 @@
+import { expectTypeOf, test } from 'vitest';
+import type {
+  CallToolResult,
+  InputSchema,
+  JsonSchemaForInference,
+  RegistrationHandle,
+  ToolDescriptor,
+} from './index.js';
+
+const shouldInvokeRegisterTool = Date.now() < 0;
+
+function splitCsv(input: string | undefined): string[] {
+  if (!input) {
+    return [];
+  }
+  return input
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function normalizeFeatureKey(input: string): string {
+  return input.toLowerCase().replace(/\s+/g, '_');
+}
+
+test('global registerTool kitchen sink examples compile', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  const handles: RegistrationHandle[] = [];
+
+  handles.push(
+    navigator.modelContext.registerTool({
+      name: 'ping_sync',
+      description: 'Simple synchronous tool',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+      execute() {
+        return {
+          content: [{ type: 'text', text: 'pong' }],
+        };
+      },
+    })
+  );
+
+  handles.push(
+    navigator.modelContext.registerTool({
+      name: 'search_async',
+      description: 'Async tool with inferred args',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
+          maxResults: { type: 'integer', minimum: 1, maximum: 50 },
+        },
+        required: ['query'],
+        additionalProperties: false,
+      } as const satisfies JsonSchemaForInference,
+      async execute(args) {
+        const query: string = args.query;
+        const maxResults: number | undefined = args.maxResults;
+        void maxResults;
+        return {
+          content: [{ type: 'text', text: `searching for ${query}` }],
+        };
+      },
+    })
+  );
+
+  handles.push(
+    navigator.modelContext.registerTool({
+      name: 'search_summary',
+      description: 'Async tool with inferred structured output',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
+          maxResults: { type: 'integer', minimum: 1, maximum: 50 },
+        },
+        required: ['query'],
+        additionalProperties: false,
+      } as const satisfies JsonSchemaForInference,
+      outputSchema: {
+        type: 'object',
+        properties: {
+          total: { type: 'integer' },
+          tags: { type: 'array', items: { type: 'string' } },
+          mode: { type: 'string', enum: ['compact', 'full'] },
+        },
+        required: ['total'],
+        additionalProperties: false,
+      } as const satisfies JsonSchemaForInference,
+      async execute(args) {
+        return {
+          // Loose content block shape is accepted.
+          content: [{ text: `summary for ${args.query}`, data: 'opaque' }],
+          structuredContent: {
+            total: 1,
+            tags: [args.query],
+            mode: 'compact' as const,
+          },
+        };
+      },
+    })
+  );
+
+  handles.push(
+    navigator.modelContext.registerTool({
+      name: 'runtime_schema',
+      description: 'Widened schema fallback',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          payload: { type: 'string' },
+        },
+      } as InputSchema,
+      execute(args) {
+        const fallbackArgs: Record<string, unknown> = args;
+        void fallbackArgs;
+        return {
+          content: [{ type: 'text', text: 'runtime schema accepted' }],
+        };
+      },
+    })
+  );
+
+  const explicitTypedTool: ToolDescriptor<
+    { id: string },
+    CallToolResult & { structuredContent: { id: string; found: boolean } },
+    'lookup_explicit'
+  > = {
+    name: 'lookup_explicit',
+    description: 'Explicit generic descriptor',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+      },
+      required: ['id'],
+    },
+    execute(args) {
+      return {
+        content: [{ type: 'text', text: `lookup ${args.id}` }],
+        structuredContent: {
+          id: args.id,
+          found: true,
+        },
+      };
+    },
+  };
+
+  handles.push(navigator.modelContext.registerTool(explicitTypedTool));
+
+  handles.push(
+    navigator.modelContext.registerTool({
+      name: 'deploy_with_elicitation',
+      description: 'Uses execution context elicitation',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          environment: { type: 'string' },
+        },
+        required: ['environment'],
+      },
+      async execute(args, context) {
+        const response = await context.elicitInput({
+          mode: 'form',
+          message: `Deploy to ${args.environment}?`,
+          requestedSchema: {
+            type: 'object',
+            properties: {
+              confirmed: { type: 'boolean' },
+            },
+            required: ['confirmed'],
+          },
+        });
+
+        if (response.action !== 'accept' || !response.content?.confirmed) {
+          return {
+            content: [{ type: 'text', text: 'deployment cancelled' }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [{ type: 'text', text: `deploying ${args.environment}` }],
+        };
+      },
+    })
+  );
+
+  // Exercise handle typing in the same file.
+  for (const handle of handles) {
+    expectTypeOf(handle.unregister).toBeFunction();
+  }
+});
+
+test('global registerTool implementation-first examples compile', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  const featureToggleHandle = navigator.modelContext.registerTool({
+    name: 'feature_toggle_summary',
+    description: 'Compute normalized feature toggle summary',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        features: { type: 'string', description: 'Comma separated feature keys' },
+        defaultOn: { type: 'string', description: 'Comma separated enabled keys' },
+      },
+      required: ['features'],
+    } as const satisfies JsonSchemaForInference,
+    outputSchema: {
+      type: 'object',
+      properties: {
+        featureCount: { type: 'integer' },
+        enabledCount: { type: 'integer' },
+        normalizedFeatures: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+      required: ['featureCount', 'enabledCount'],
+      additionalProperties: false,
+    } as const satisfies JsonSchemaForInference,
+    execute(args) {
+      const normalizedFeatures = splitCsv(args.features).map(normalizeFeatureKey);
+      const enabledSet = new Set(splitCsv(args.defaultOn).map(normalizeFeatureKey));
+      const deduped = [...new Set(normalizedFeatures)];
+      const enabledCount = deduped.filter((feature) => enabledSet.has(feature)).length;
+
+      const summary =
+        deduped.length === 0
+          ? 'No features configured'
+          : `${enabledCount}/${deduped.length} features enabled by default`;
+
+      return {
+        content: [
+          { type: 'text', text: summary },
+          { text: summary, data: deduped.join(',') },
+        ],
+        structuredContent: {
+          featureCount: deduped.length,
+          enabledCount,
+          normalizedFeatures: deduped,
+        },
+      };
+    },
+  });
+
+  const callResult = navigator.modelContext.callTool({
+    name: 'feature_toggle_summary',
+    arguments: {
+      features: 'Search, Billing, Multi Region',
+      defaultOn: 'billing',
+    },
+  });
+
+  void callResult.then((result) => {
+    const firstBlock = result.content[0];
+    if (
+      firstBlock &&
+      'type' in firstBlock &&
+      firstBlock.type === 'text' &&
+      'text' in firstBlock &&
+      typeof firstBlock.text === 'string'
+    ) {
+      const rendered = firstBlock.text.toUpperCase();
+      void rendered;
+    }
+  });
+
+  const listedTools = navigator.modelContext.listTools();
+  for (const tool of listedTools) {
+    if (tool.name === 'feature_toggle_summary') {
+      const schemaType = tool.inputSchema.type;
+      void schemaType;
+    }
+  }
+
+  featureToggleHandle.unregister();
+});

--- a/packages/types/src/index.test-d.ts
+++ b/packages/types/src/index.test-d.ts
@@ -1,6 +1,12 @@
 import { expectTypeOf, test } from 'vitest';
 import type { CallToolResult, RegistrationHandle } from './common.js';
-import type { ModelContext, ModelContextInput, ToolCallEvent } from './index.js';
+import type {
+  LooseContentBlock,
+  MaybePromise,
+  ModelContext,
+  ModelContextInput,
+  ToolCallEvent,
+} from './index.js';
 import type { ToolDescriptor, ToolListItem } from './tool.js';
 
 // === Producer API ===
@@ -57,4 +63,11 @@ test('ToolCallEvent extends Event with name, arguments, respondWith', () => {
 // === Global augmentation ===
 test('navigator.modelContext is typed as ModelContext', () => {
   expectTypeOf<Navigator['modelContext']>().toEqualTypeOf<ModelContext>();
+});
+
+test('index re-exports helper types for permissive results', () => {
+  expectTypeOf<MaybePromise<CallToolResult>>().toEqualTypeOf<
+    CallToolResult | Promise<CallToolResult>
+  >();
+  expectTypeOf<LooseContentBlock>().toMatchTypeOf<Record<string, unknown>>();
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,6 +17,7 @@ export type {
   JsonObject,
   JsonPrimitive,
   JsonValue,
+  LooseContentBlock,
   RegistrationHandle,
   ResourceContents,
   ResourceLink,
@@ -31,12 +32,14 @@ export type {
   JsonSchemaBoolean,
   JsonSchemaEnumValue,
   JsonSchemaForInference,
+  JsonSchemaMultiType,
   JsonSchemaNull,
   JsonSchemaNumber,
   JsonSchemaObject,
   JsonSchemaPrimitiveType,
   JsonSchemaString,
   JsonSchemaType,
+  JsonSchemaTypeArray,
 } from './json-schema.js';
 export type {
   AnyToolDescriptor,
@@ -53,6 +56,7 @@ export type {
   TypedModelContext,
 } from './model-context.js';
 export type {
+  MaybePromise,
   ToolAnnotations,
   ToolDescriptor,
   ToolDescriptorFromSchema,

--- a/packages/types/src/json-schema.test-d.ts
+++ b/packages/types/src/json-schema.test-d.ts
@@ -39,6 +39,58 @@ const outputSchema = {
   additionalProperties: false,
 } as const satisfies JsonSchemaForInference;
 
+const requiredKeysFromRuntime: string[] = ['query'];
+
+const schemaWithWidenedRequired = {
+  type: 'object',
+  properties: {
+    query: { type: 'string' },
+    limit: { type: 'integer' },
+  },
+  required: requiredKeysFromRuntime,
+} as const satisfies JsonSchemaForInference;
+
+const schemaWithSupplementalKeywords = {
+  type: 'object',
+  properties: {
+    email: { type: 'string', format: 'email' },
+  },
+  required: ['email'],
+  allOf: [{ type: 'object' }],
+} as const satisfies JsonSchemaForInference;
+
+const schemaWithTypeUnion = {
+  type: ['string', 'null'],
+} as const satisfies JsonSchemaForInference;
+
+const schemaWithNullable = {
+  type: 'string',
+  nullable: true,
+} as const satisfies JsonSchemaForInference;
+
+const schemaWithDynamicMapValues = {
+  type: 'object',
+  additionalProperties: { type: 'integer' },
+} as const satisfies JsonSchemaForInference;
+
+const schemaWithNamedAndDynamicProperties = {
+  type: 'object',
+  properties: {
+    query: { type: 'string' },
+  },
+  required: ['query'],
+  additionalProperties: { type: 'integer' },
+} as const satisfies JsonSchemaForInference;
+
+const schemaWithObjectTypeUnion = {
+  type: ['object', 'null'],
+  properties: {
+    query: { type: 'string' },
+  },
+  required: ['query'],
+  additionalProperties: false,
+} as const satisfies JsonSchemaForInference;
+
 declare const runtimeSchema: InputSchema;
 declare const registerTool: ModelContext['registerTool'];
 const shouldInvokeRegisterTool = Date.now() < 0;
@@ -53,6 +105,8 @@ test('InferJsonSchema maps primitive, enum, const, and array schemas', () => {
   expectTypeOf<InferJsonSchema<{ type: 'array'; items: { type: 'number' } }>>().toEqualTypeOf<
     number[]
   >();
+  expectTypeOf<InferJsonSchema<typeof schemaWithTypeUnion>>().toEqualTypeOf<string | null>();
+  expectTypeOf<InferJsonSchema<typeof schemaWithNullable>>().toEqualTypeOf<string | null>();
 });
 
 test('InferArgsFromInputSchema handles closed and open object schemas', () => {
@@ -74,12 +128,50 @@ test('InferArgsFromInputSchema falls back for widened runtime schemas', () => {
   >();
 });
 
+test('InferArgsFromInputSchema treats widened required arrays as optional fields', () => {
+  const args: InferArgsFromInputSchema<typeof schemaWithWidenedRequired> = {};
+  expectTypeOf(args.query).toEqualTypeOf<string | undefined>();
+  expectTypeOf(args.limit).toEqualTypeOf<number | undefined>();
+});
+
+test('InferArgsFromInputSchema ignores supplemental schema keywords', () => {
+  type Args = InferArgsFromInputSchema<typeof schemaWithSupplementalKeywords>;
+  const args: Args = { email: 'test@example.com' };
+  expectTypeOf(args.email).toEqualTypeOf<string>();
+});
+
+test('InferArgsFromInputSchema infers map-like objects from additionalProperties', () => {
+  expectTypeOf<InferArgsFromInputSchema<typeof schemaWithDynamicMapValues>>().toEqualTypeOf<
+    Record<string, number>
+  >();
+});
+
+test('InferArgsFromInputSchema keeps extras unknown when named properties are present', () => {
+  type Args = InferArgsFromInputSchema<typeof schemaWithNamedAndDynamicProperties>;
+  const args: Args = { query: 'hello', limit: 10 };
+  expectTypeOf(args.query).toEqualTypeOf<string>();
+  expectTypeOf(args.limit).toEqualTypeOf<unknown>();
+});
+
+test('InferArgsFromInputSchema supports object type unions for argument inference', () => {
+  type Args = InferArgsFromInputSchema<typeof schemaWithObjectTypeUnion>;
+  const args: Args = { query: 'webmcp' };
+  expectTypeOf(args.query).toEqualTypeOf<string>();
+});
+
 test('ToolDescriptorFromSchema infers execute args from inputSchema', () => {
   type ExecuteArgs = Parameters<ToolDescriptorFromSchema<typeof closedSchema>['execute']>[0];
   const args: ExecuteArgs = { query: 'webmcp' };
 
   expectTypeOf(args.query).toEqualTypeOf<string>();
   expectTypeOf(args.limit).toEqualTypeOf<number | undefined>();
+});
+
+test('ToolDescriptorFromSchema execute args reject missing required keys', () => {
+  type ExecuteArgs = Parameters<ToolDescriptorFromSchema<typeof closedSchema>['execute']>[0];
+  // @ts-expect-error - query is required by closedSchema
+  const args: ExecuteArgs = { limit: 1 };
+  void args;
 });
 
 test('ToolDescriptorFromSchema infers structuredContent from outputSchema', () => {
@@ -121,6 +213,56 @@ test('ModelContext.registerTool infers execute args from literal schema', () => 
   }
 });
 
+test('ModelContext.registerTool rejects unknown execute args for closed schemas', () => {
+  if (shouldInvokeRegisterTool) {
+    registerTool({
+      name: 'search_closed_args',
+      description: 'Search docs with closed schema args',
+      inputSchema: closedSchema,
+      execute(args) {
+        // @ts-expect-error - closed schema does not infer unknown keys
+        const extra = args.extra;
+        void extra;
+        return {
+          content: [{ type: 'text', text: args.query }],
+        };
+      },
+    });
+  }
+});
+
+test('ModelContext.registerTool infers execute args from object type unions', () => {
+  if (shouldInvokeRegisterTool) {
+    registerTool({
+      name: 'search_union',
+      description: 'Search docs with object union schema',
+      inputSchema: schemaWithObjectTypeUnion,
+      async execute(args) {
+        const inferredArgs: { query: string } = args;
+        void inferredArgs;
+        return {
+          content: [{ type: 'text', text: args.query }],
+        };
+      },
+    });
+  }
+});
+
+test('ModelContext.registerTool accepts sync execute handlers', () => {
+  if (shouldInvokeRegisterTool) {
+    registerTool({
+      name: 'sync_search',
+      description: 'Sync search docs',
+      inputSchema: closedSchema,
+      execute(args) {
+        return {
+          content: [{ type: 'text', text: args.query }],
+        };
+      },
+    });
+  }
+});
+
 test('ModelContext.registerTool infers execute output from outputSchema', () => {
   if (shouldInvokeRegisterTool) {
     registerTool({
@@ -136,6 +278,148 @@ test('ModelContext.registerTool infers execute output from outputSchema', () => 
             total: 1,
             items: [query],
           },
+        };
+      },
+    });
+  }
+});
+
+test('ModelContext.registerTool accepts async output schema handlers with loose content blocks', () => {
+  if (shouldInvokeRegisterTool) {
+    registerTool({
+      name: 'feature_flags',
+      description: 'Summarize feature flags',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          features: { type: 'string', description: 'Comma separated features' },
+          defaultOn: { type: 'string', description: 'Comma separated defaults' },
+        },
+        required: ['features'],
+      } as const satisfies JsonSchemaForInference,
+      outputSchema: {
+        type: 'object',
+        properties: {
+          featureCount: { type: 'integer' },
+          enabledCount: { type: 'integer' },
+        },
+        required: ['featureCount', 'enabledCount'],
+      } as const satisfies JsonSchemaForInference,
+      async execute(args) {
+        const features = args.features?.split(',').filter(Boolean) ?? [];
+        const defaults = args.defaultOn?.split(',').filter(Boolean) ?? [];
+        return {
+          content: [{ text: 'feature summary', data: features.join(',') }],
+          structuredContent: {
+            featureCount: features.length,
+            enabledCount: defaults.length,
+          },
+        };
+      },
+    });
+  }
+});
+
+test('ModelContext.registerTool rejects invalid structuredContent for inferred outputSchema', () => {
+  if (shouldInvokeRegisterTool) {
+    // @ts-expect-error - structuredContent must satisfy outputSchema (missing total, extra test)
+    registerTool({
+      name: 'search_summary',
+      description: 'Async tool with inferred structured output',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
+          maxResults: { type: 'integer', minimum: 1, maximum: 50 },
+        },
+        required: ['query'],
+        additionalProperties: false,
+      } as const satisfies JsonSchemaForInference,
+      outputSchema: {
+        type: 'object',
+        properties: {
+          total: { type: 'integer' },
+          tags: { type: 'array', items: { type: 'string' } },
+          mode: { type: 'string', enum: ['compact', 'full'] },
+        },
+        required: ['total'],
+        additionalProperties: false,
+      } as const satisfies JsonSchemaForInference,
+      async execute(args) {
+        return {
+          content: [{ text: `summary for ${args.query}`, data: 'opaque' }],
+          structuredContent: {
+            test: 'test',
+            tags: [args.query],
+            mode: 'compact',
+          },
+        };
+      },
+    });
+  }
+});
+
+test('ModelContext.registerTool rejects structuredContent enum/type mismatches', () => {
+  if (shouldInvokeRegisterTool) {
+    // @ts-expect-error - total must be number and mode must match enum literals
+    registerTool({
+      name: 'search_summary_mismatch',
+      description: 'Invalid structured output',
+      inputSchema: closedSchema,
+      outputSchema: {
+        type: 'object',
+        properties: {
+          total: { type: 'integer' },
+          mode: { type: 'string', enum: ['compact', 'full'] },
+        },
+        required: ['total'],
+        additionalProperties: false,
+      } as const satisfies JsonSchemaForInference,
+      execute(args) {
+        return {
+          content: [{ type: 'text', text: args.query }],
+          structuredContent: {
+            total: '1',
+            mode: 'verbose',
+          },
+        };
+      },
+    });
+  }
+});
+
+test('ToolDescriptorFromSchema requires outputSchema when output generic is provided', () => {
+  // @ts-expect-error - outputSchema is required when output generic parameter is set
+  const tool: ToolDescriptorFromSchema<typeof closedSchema, typeof outputSchema> = {
+    name: 'missing_output_schema',
+    description: 'Missing output schema should fail',
+    inputSchema: closedSchema,
+    execute(args) {
+      return {
+        content: [{ type: 'text', text: args.query }],
+      };
+    },
+  };
+  void tool;
+});
+
+test('ToolDescriptorFromSchema falls back when input schema is widened to InputSchema', () => {
+  type ExecuteArgs = Parameters<ToolDescriptorFromSchema<InputSchema>['execute']>[0];
+  expectTypeOf<ExecuteArgs>().toEqualTypeOf<Record<string, unknown>>();
+});
+
+test('ModelContext.registerTool keeps execute args unknown for runtime schemas', () => {
+  if (shouldInvokeRegisterTool) {
+    registerTool({
+      name: 'runtime_schema_unknown_args',
+      description: 'Runtime schemas should keep args unknown',
+      inputSchema: runtimeSchema,
+      execute(args) {
+        // @ts-expect-error - runtime schema args are unknown and must be narrowed first
+        const query: string = args.query;
+        void query;
+        return {
+          content: [{ type: 'text', text: 'ok' }],
         };
       },
     });

--- a/packages/types/src/model-context.ts
+++ b/packages/types/src/model-context.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult, RegistrationHandle, ToolResponse } from './common.js';
+import type { CallToolResult, InputSchema, RegistrationHandle, ToolResponse } from './common.js';
 import type { JsonSchemaForInference, JsonSchemaObject } from './json-schema.js';
 import type { ToolDescriptor, ToolDescriptorFromSchema, ToolListItem } from './tool.js';
 
@@ -147,10 +147,15 @@ export interface ModelContext {
    * Registers a dynamic tool with explicitly typed args/result.
    */
   registerTool<
+    TInputSchema extends InputSchema,
     TArgs extends Record<string, unknown> = Record<string, unknown>,
     TResult extends CallToolResult = CallToolResult,
     TName extends string = string,
-  >(tool: ToolDescriptor<TArgs, TResult, TName>): RegistrationHandle;
+  >(
+    tool: ToolDescriptor<TArgs, TResult, TName> & {
+      inputSchema: TInputSchema;
+    } & (string extends TInputSchema['type'] ? unknown : never)
+  ): RegistrationHandle;
 
   /**
    * Unregisters a dynamic tool by name.


### PR DESCRIPTION
## Summary
- tighten JSON-schema-driven type inference paths for tool registration
- prevent fallback overloads from silently accepting inferable literal schemas
- add negative @ts-expect-error cases for structuredContent/outputSchema and arg inference edge cases

## Verification
- pnpm --filter @mcp-b/types test
- pnpm run check-all

## Notes
- branch was rebased onto latest origin/main before opening this PR