### PR TITLE
docs: make framework examples standalone repos and exclude from workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,26 +79,26 @@ pnpm add @mcp-b/smart-dom-reader
 
 ## Available Packages
 
-| Package | Version | Description |
-|---------|---------|-------------|
-| [@mcp-b/webmcp-polyfill](./packages/webmcp-polyfill) | [![npm](https://img.shields.io/npm/v/@mcp-b/webmcp-polyfill)](https://www.npmjs.com/package/@mcp-b/webmcp-polyfill) | Strict `navigator.modelContext` WebMCP core polyfill |
-| [@mcp-b/webmcp-types](./packages/webmcp-types) | [![npm](https://img.shields.io/npm/v/@mcp-b/webmcp-types)](https://www.npmjs.com/package/@mcp-b/webmcp-types) | Strict WebMCP core TypeScript definitions |
-| [@mcp-b/global](./packages/global) | [![npm](https://img.shields.io/npm/v/@mcp-b/global)](https://www.npmjs.com/package/@mcp-b/global) | Full MCPB runtime (WebMCP core + MCP bridge extensions) |
-| [@mcp-b/webmcp-ts-sdk](./packages/webmcp-ts-sdk) | [![npm](https://img.shields.io/npm/v/@mcp-b/webmcp-ts-sdk)](https://www.npmjs.com/package/@mcp-b/webmcp-ts-sdk) | TypeScript SDK adapter for MCP with browser-specific features |
-| [@mcp-b/transports](./packages/transports) | [![npm](https://img.shields.io/npm/v/@mcp-b/transports)](https://www.npmjs.com/package/@mcp-b/transports) | Browser transport implementations (Tab, Chrome Extension) |
-| [@mcp-b/react-webmcp](./packages/react-webmcp) | [![npm](https://img.shields.io/npm/v/@mcp-b/react-webmcp)](https://www.npmjs.com/package/@mcp-b/react-webmcp) | React hooks for full MCP-B runtime (core + extensions) |
-| [usewebmcp](./packages/usewebmcp) | [![npm](https://img.shields.io/npm/v/usewebmcp)](https://www.npmjs.com/package/usewebmcp) | React hooks for strict WebMCP core API only |
-| [@mcp-b/extension-tools](./packages/extension-tools) | [![npm](https://img.shields.io/npm/v/@mcp-b/extension-tools)](https://www.npmjs.com/package/@mcp-b/extension-tools) | Auto-generated MCP tools for Chrome Extension APIs |
-| [@mcp-b/smart-dom-reader](./packages/smart-dom-reader) | [![npm](https://img.shields.io/npm/v/@mcp-b/smart-dom-reader)](https://www.npmjs.com/package/@mcp-b/smart-dom-reader) | Token-efficient DOM extraction for AI agents |
-| [@mcp-b/chrome-devtools-mcp](./packages/chrome-devtools-mcp) | [![npm](https://img.shields.io/npm/v/@mcp-b/chrome-devtools-mcp)](https://www.npmjs.com/package/@mcp-b/chrome-devtools-mcp) | MCP server for Chrome DevTools with WebMCP integration |
-| [@mcp-b/mcp-iframe](./packages/mcp-iframe) | [![npm](https://img.shields.io/npm/v/@mcp-b/mcp-iframe)](https://www.npmjs.com/package/@mcp-b/mcp-iframe) | Custom element for exposing iframe MCP tools to parent page |
+| Package                                                      | Version                                                                                                                     | Description                                                   |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| [@mcp-b/webmcp-polyfill](./packages/webmcp-polyfill)         | [![npm](https://img.shields.io/npm/v/@mcp-b/webmcp-polyfill)](https://www.npmjs.com/package/@mcp-b/webmcp-polyfill)         | Strict `navigator.modelContext` WebMCP core polyfill          |
+| [@mcp-b/webmcp-types](./packages/webmcp-types)               | [![npm](https://img.shields.io/npm/v/@mcp-b/webmcp-types)](https://www.npmjs.com/package/@mcp-b/webmcp-types)               | Strict WebMCP core TypeScript definitions                     |
+| [@mcp-b/global](./packages/global)                           | [![npm](https://img.shields.io/npm/v/@mcp-b/global)](https://www.npmjs.com/package/@mcp-b/global)                           | Full MCPB runtime (WebMCP core + MCP bridge extensions)       |
+| [@mcp-b/webmcp-ts-sdk](./packages/webmcp-ts-sdk)             | [![npm](https://img.shields.io/npm/v/@mcp-b/webmcp-ts-sdk)](https://www.npmjs.com/package/@mcp-b/webmcp-ts-sdk)             | TypeScript SDK adapter for MCP with browser-specific features |
+| [@mcp-b/transports](./packages/transports)                   | [![npm](https://img.shields.io/npm/v/@mcp-b/transports)](https://www.npmjs.com/package/@mcp-b/transports)                   | Browser transport implementations (Tab, Chrome Extension)     |
+| [@mcp-b/react-webmcp](./packages/react-webmcp)               | [![npm](https://img.shields.io/npm/v/@mcp-b/react-webmcp)](https://www.npmjs.com/package/@mcp-b/react-webmcp)               | React hooks for full MCP-B runtime (core + extensions)        |
+| [usewebmcp](./packages/usewebmcp)                            | [![npm](https://img.shields.io/npm/v/usewebmcp)](https://www.npmjs.com/package/usewebmcp)                                   | React hooks for strict WebMCP core API only                   |
+| [@mcp-b/extension-tools](./packages/extension-tools)         | [![npm](https://img.shields.io/npm/v/@mcp-b/extension-tools)](https://www.npmjs.com/package/@mcp-b/extension-tools)         | Auto-generated MCP tools for Chrome Extension APIs            |
+| [@mcp-b/smart-dom-reader](./packages/smart-dom-reader)       | [![npm](https://img.shields.io/npm/v/@mcp-b/smart-dom-reader)](https://www.npmjs.com/package/@mcp-b/smart-dom-reader)       | Token-efficient DOM extraction for AI agents                  |
+| [@mcp-b/chrome-devtools-mcp](./packages/chrome-devtools-mcp) | [![npm](https://img.shields.io/npm/v/@mcp-b/chrome-devtools-mcp)](https://www.npmjs.com/package/@mcp-b/chrome-devtools-mcp) | MCP server for Chrome DevTools with WebMCP integration        |
+| [@mcp-b/mcp-iframe](./packages/mcp-iframe)                   | [![npm](https://img.shields.io/npm/v/@mcp-b/mcp-iframe)](https://www.npmjs.com/package/@mcp-b/mcp-iframe)                   | Custom element for exposing iframe MCP tools to parent page   |
 
 ### Deprecated Packages
 
-| Package | Status | Migration |
-|---------|--------|-----------|
-| ~~@mcp-b/mcp-react-hooks~~ | Deprecated | Use [@mcp-b/react-webmcp](./packages/react-webmcp) instead |
-| ~~@mcp-b/mcp-react-hook-form~~ | Removed | Use custom `useWebMCP` wrappers |
+| Package                        | Status     | Migration                                                  |
+| ------------------------------ | ---------- | ---------------------------------------------------------- |
+| ~~@mcp-b/mcp-react-hooks~~     | Deprecated | Use [@mcp-b/react-webmcp](./packages/react-webmcp) instead |
+| ~~@mcp-b/mcp-react-hook-form~~ | Removed    | Use custom `useWebMCP` wrappers                            |
 
 ## Quick Start
 
@@ -107,7 +107,7 @@ pnpm add @mcp-b/smart-dom-reader
 Register tools on `navigator.modelContext` so AI agents can discover and call them:
 
 ```ts
-import { initializeWebMCPPolyfill } from '@mcp-b/webmcp-polyfill';
+import { initializeWebMCPPolyfill } from "@mcp-b/webmcp-polyfill";
 
 // Initialize the polyfill (skipped automatically when native browser support is available)
 initializeWebMCPPolyfill();
@@ -116,10 +116,10 @@ const todos: Array<{ id: number; title: string; description?: string }> = [];
 
 // Register a read-only tool
 navigator.modelContext.registerTool({
-  name: 'get_todos',
-  description: 'Get all todo items',
+  name: "get_todos",
+  description: "Get all todo items",
   inputSchema: {
-    type: 'object',
+    type: "object",
     properties: {},
   },
   annotations: {
@@ -127,27 +127,32 @@ navigator.modelContext.registerTool({
     idempotentHint: true,
   },
   execute: async () => ({
-    content: [{ type: 'text', text: JSON.stringify(todos) }],
+    content: [{ type: "text", text: JSON.stringify(todos) }],
   }),
 });
 
 // Register a tool with input parameters
 navigator.modelContext.registerTool({
-  name: 'add_todo',
-  description: 'Add a new todo item',
+  name: "add_todo",
+  description: "Add a new todo item",
   inputSchema: {
-    type: 'object',
+    type: "object",
     properties: {
-      title: { type: 'string', description: 'Todo title' },
-      description: { type: 'string', description: 'Optional description' },
+      title: { type: "string", description: "Todo title" },
+      description: { type: "string", description: "Optional description" },
     },
-    required: ['title'],
+    required: ["title"],
   },
   execute: async (args) => {
     const newTodo = { id: Date.now(), ...args };
     todos.push(newTodo);
     return {
-      content: [{ type: 'text', text: JSON.stringify({ success: true, todo: newTodo }) }],
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ success: true, todo: newTodo }),
+        },
+      ],
     };
   },
 });
@@ -156,12 +161,12 @@ navigator.modelContext.registerTool({
 ### Consuming Tools as a Client
 
 ```tsx
-import { McpClientProvider, useMcpClient } from '@mcp-b/react-webmcp';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { TabClientTransport } from '@mcp-b/transports';
+import { McpClientProvider, useMcpClient } from "@mcp-b/react-webmcp";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { TabClientTransport } from "@mcp-b/transports";
 
-const client = new Client({ name: 'MyApp', version: '1.0.0' });
-const transport = new TabClientTransport('mcp', { clientInstanceId: 'my-app' });
+const client = new Client({ name: "MyApp", version: "1.0.0" });
+const transport = new TabClientTransport("mcp", { clientInstanceId: "my-app" });
 
 function App() {
   return (
@@ -176,15 +181,15 @@ function ToolConsumer() {
 
   const callTool = async () => {
     const result = await client.callTool({
-      name: 'get_todos',
-      arguments: {}
+      name: "get_todos",
+      arguments: {},
     });
     console.log(result);
   };
 
   return (
     <div>
-      <p>Connected: {isConnected ? 'Yes' : 'No'}</p>
+      <p>Connected: {isConnected ? "Yes" : "No"}</p>
       <p>Available tools: {tools.length}</p>
       <button onClick={callTool}>Call get_todos</button>
     </div>
@@ -197,21 +202,25 @@ function ToolConsumer() {
 The MCP-B packages are organized into functional layers:
 
 ### Core Layer
+
 - **@mcp-b/webmcp-polyfill** - Strict WebMCP core polyfill for `navigator.modelContext`
 - **@mcp-b/webmcp-types** - Strict WebMCP core TypeScript definitions
 - **@mcp-b/global** - Full MCPB runtime with bridge-oriented extension APIs
 - **@mcp-b/webmcp-ts-sdk** - TypeScript SDK adapter with browser-specific features
 
 ### Transport Layer
+
 - **@mcp-b/transports** - Communication between MCP servers and clients
   - `TabClientTransport` / `TabServerTransport` - Same-page communication
   - `ExtensionClientTransport` / `ExtensionServerTransport` - Chrome extension messaging
 
 ### Integration Layer
+
 - **@mcp-b/react-webmcp** - React hooks for MCP-B runtime (core + extensions)
 - **usewebmcp** - React hooks for strict WebMCP core only
 
 ### Tools & Utilities
+
 - **@mcp-b/extension-tools** - Pre-built tools for Chrome Extension APIs
 - **@mcp-b/smart-dom-reader** - AI-friendly DOM extraction
 
@@ -277,18 +286,19 @@ pnpm --filter @mcp-b/react-webmcp add zod
 
 ## Documentation
 
-| Document | Purpose |
-|----------|---------|
-| [CONTRIBUTING.md](./CONTRIBUTING.md) | How to contribute: setup, PR process, commit format |
-| [CLAUDE.md](./CLAUDE.md) | Quick reference for AI agents working in this repo |
-| [AI Contribution Manifesto](./docs/AI_CONTRIBUTION_MANIFESTO.md) | Safety rules and code quality bar |
-| [Package Philosophy](./docs/MCPB_PACKAGE_PHILOSOPHY.md) | Package boundaries and layering model |
-| [Testing Philosophy](./docs/TESTING_PHILOSOPHY.md) | Test layers, mocking policy, coverage expectations |
-| [E2E Testing](./docs/TESTING.md) | Playwright setup, test apps, debugging |
-| [Relevant Links](./docs/RELEVANT_LINKS.md) | Curated external best practices for contributors |
-| [Global Package Guide](./docs/global-guide.md) | Advanced usage for @mcp-b/global |
-| [React WebMCP Guide](./docs/react-webmcp-guide.md) | Advanced usage for @mcp-b/react-webmcp |
-| [WebMCP Alignment Matrix](./docs/plans/WEBMCP_ALIGNMENT_MATRIX.md) | Spec vs native vs polyfill parity tracking |
+| Document                                                           | Purpose                                                 |
+| ------------------------------------------------------------------ | ------------------------------------------------------- |
+| [CONTRIBUTING.md](./CONTRIBUTING.md)                               | How to contribute: setup, PR process, commit format     |
+| [CLAUDE.md](./CLAUDE.md)                                           | Quick reference for AI agents working in this repo      |
+| [AI Contribution Manifesto](./docs/AI_CONTRIBUTION_MANIFESTO.md)   | Safety rules and code quality bar                       |
+| [Package Philosophy](./docs/MCPB_PACKAGE_PHILOSOPHY.md)            | Package boundaries and layering model                   |
+| [Testing Philosophy](./docs/TESTING_PHILOSOPHY.md)                 | Test layers, mocking policy, coverage expectations      |
+| [E2E Testing](./docs/TESTING.md)                                   | Playwright setup, test apps, debugging                  |
+| [Relevant Links](./docs/RELEVANT_LINKS.md)                         | Curated external best practices for contributors        |
+| [Global Package Guide](./docs/global-guide.md)                     | Advanced usage for @mcp-b/global                        |
+| [React WebMCP Guide](./docs/react-webmcp-guide.md)                 | Advanced usage for @mcp-b/react-webmcp                  |
+| [Framework Examples](./examples/frameworks/README.md)              | Minimal WebMCP API usage in popular frontend frameworks |
+| [WebMCP Alignment Matrix](./docs/plans/WEBMCP_ALIGNMENT_MATRIX.md) | Spec vs native vs polyfill parity tracking              |
 
 ## Contributing
 

--- a/examples/frameworks/.gitignore
+++ b/examples/frameworks/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.next
+.vite

--- a/examples/frameworks/README.md
+++ b/examples/frameworks/README.md
@@ -1,0 +1,26 @@
+# Framework WebMCP Examples
+
+These are **real, runnable mini repos** for popular frontend frameworks.
+
+Each example demonstrates the smallest useful WebMCP flow:
+
+1. Initialize `@mcp-b/webmcp-polyfill`.
+2. Register one tool via `navigator.modelContext` (or `useWebMCP` for React).
+3. Return a text payload from `execute`.
+
+## Included examples
+
+- [React (Vite)](./react/)
+- [Next.js (App Router)](./nextjs/)
+- [Vue 3 (Vite)](./vue/)
+- [Svelte (Vite)](./svelte/)
+
+## Quick start
+
+```bash
+cd examples/frameworks/react # or nextjs / vue / svelte
+pnpm install
+pnpm dev
+```
+
+> Note: `examples/**` is explicitly excluded from the root `pnpm-workspace.yaml` to keep these samples standalone.

--- a/examples/frameworks/nextjs/README.md
+++ b/examples/frameworks/nextjs/README.md
@@ -1,0 +1,12 @@
+# Next.js (App Router) — WebMCP example
+
+## Run
+
+```bash
+pnpm install
+pnpm dev
+```
+
+## Key file
+
+- `app/page.tsx` initializes `@mcp-b/webmcp-polyfill` and registers `get_status` on `navigator.modelContext`.

--- a/examples/frameworks/nextjs/app/layout.tsx
+++ b/examples/frameworks/nextjs/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/frameworks/nextjs/app/page.tsx
+++ b/examples/frameworks/nextjs/app/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { initializeWebMCPPolyfill } from '@mcp-b/webmcp-polyfill';
+import { useEffect } from 'react';
+
+export default function Home() {
+  useEffect(() => {
+    initializeWebMCPPolyfill();
+
+    navigator.modelContext.registerTool({
+      name: 'get_status',
+      description: 'Returns app status',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+      execute: async () => ({
+        content: [{ type: 'text', text: 'Next.js app is running' }],
+      }),
+    });
+  }, []);
+
+  return <p>WebMCP tool "get_status" registered.</p>;
+}

--- a/examples/frameworks/nextjs/next-env.d.ts
+++ b/examples/frameworks/nextjs/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited.

--- a/examples/frameworks/nextjs/package.json
+++ b/examples/frameworks/nextjs/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "webmcp-example-nextjs",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "next build",
+    "dev": "next dev",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@mcp-b/webmcp-polyfill": "latest",
+    "next": "15.5.0",
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.17.2",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "typescript": "^5.8.3"
+  }
+}

--- a/examples/frameworks/nextjs/tsconfig.json
+++ b/examples/frameworks/nextjs/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/frameworks/react/README.md
+++ b/examples/frameworks/react/README.md
@@ -1,0 +1,12 @@
+# React (Vite) — WebMCP example
+
+## Run
+
+```bash
+pnpm install
+pnpm dev
+```
+
+## Key file
+
+- `src/App.tsx` uses `useWebMCP` from `usewebmcp` and initializes `@mcp-b/webmcp-polyfill`.

--- a/examples/frameworks/react/index.html
+++ b/examples/frameworks/react/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WebMCP React Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/frameworks/react/package.json
+++ b/examples/frameworks/react/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "webmcp-example-react",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mcp-b/webmcp-polyfill": "latest",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "usewebmcp": "latest"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "@vitejs/plugin-react": "^5.0.2",
+    "typescript": "^5.8.3",
+    "vite": "^7.1.2"
+  }
+}

--- a/examples/frameworks/react/src/App.tsx
+++ b/examples/frameworks/react/src/App.tsx
@@ -1,0 +1,25 @@
+import { initializeWebMCPPolyfill } from '@mcp-b/webmcp-polyfill';
+import { useEffect } from 'react';
+import { useWebMCP } from 'usewebmcp';
+
+export function App() {
+  useEffect(() => {
+    initializeWebMCPPolyfill();
+  }, []);
+
+  useWebMCP({
+    name: 'say_hello',
+    description: 'Returns a hello message',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+    },
+    execute: async (args) => ({
+      content: [{ type: 'text', text: `Hello ${args?.name ?? 'world'}!` }],
+    }),
+  });
+
+  return <p>WebMCP tool "say_hello" registered via useWebMCP.</p>;
+}

--- a/examples/frameworks/react/src/main.tsx
+++ b/examples/frameworks/react/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/examples/frameworks/react/tsconfig.json
+++ b/examples/frameworks/react/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/examples/frameworks/react/vite.config.ts
+++ b/examples/frameworks/react/vite.config.ts
@@ -1,0 +1,6 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/examples/frameworks/svelte/README.md
+++ b/examples/frameworks/svelte/README.md
@@ -1,0 +1,12 @@
+# Svelte (Vite) — WebMCP example
+
+## Run
+
+```bash
+pnpm install
+pnpm dev
+```
+
+## Key file
+
+- `src/App.svelte` initializes `@mcp-b/webmcp-polyfill` and registers `ping`.

--- a/examples/frameworks/svelte/index.html
+++ b/examples/frameworks/svelte/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WebMCP Svelte Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/frameworks/svelte/package.json
+++ b/examples/frameworks/svelte/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "webmcp-example-svelte",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mcp-b/webmcp-polyfill": "latest",
+    "svelte": "^5.38.10"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^6.1.3",
+    "typescript": "^5.8.3",
+    "vite": "^7.1.2"
+  }
+}

--- a/examples/frameworks/svelte/src/App.svelte
+++ b/examples/frameworks/svelte/src/App.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { initializeWebMCPPolyfill } from '@mcp-b/webmcp-polyfill';
+
+  onMount(() => {
+    initializeWebMCPPolyfill();
+
+    navigator.modelContext.registerTool({
+      name: 'ping',
+      description: 'Returns pong',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+      execute: async () => ({
+        content: [{ type: 'text', text: 'pong' }],
+      }),
+    });
+  });
+</script>
+
+<p>WebMCP tool "ping" registered.</p>

--- a/examples/frameworks/svelte/src/main.ts
+++ b/examples/frameworks/svelte/src/main.ts
@@ -1,0 +1,5 @@
+import App from './App.svelte';
+
+new App({
+  target: document.getElementById('app')!,
+});

--- a/examples/frameworks/svelte/svelte.config.js
+++ b/examples/frameworks/svelte/svelte.config.js
@@ -1,0 +1,5 @@
+export default {
+  compilerOptions: {
+    runes: true,
+  },
+};

--- a/examples/frameworks/svelte/tsconfig.json
+++ b/examples/frameworks/svelte/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["svelte"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte"]
+}

--- a/examples/frameworks/svelte/vite.config.ts
+++ b/examples/frameworks/svelte/vite.config.ts
@@ -1,0 +1,6 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [svelte()],
+});

--- a/examples/frameworks/vue/README.md
+++ b/examples/frameworks/vue/README.md
@@ -1,0 +1,12 @@
+# Vue 3 (Vite) — WebMCP example
+
+## Run
+
+```bash
+pnpm install
+pnpm dev
+```
+
+## Key file
+
+- `src/App.vue` initializes `@mcp-b/webmcp-polyfill` and registers `current_route`.

--- a/examples/frameworks/vue/index.html
+++ b/examples/frameworks/vue/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WebMCP Vue Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/frameworks/vue/package.json
+++ b/examples/frameworks/vue/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "webmcp-example-vue",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mcp-b/webmcp-polyfill": "latest",
+    "vue": "^3.5.20"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.1",
+    "typescript": "^5.8.3",
+    "vite": "^7.1.2"
+  }
+}

--- a/examples/frameworks/vue/src/App.vue
+++ b/examples/frameworks/vue/src/App.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { initializeWebMCPPolyfill } from "@mcp-b/webmcp-polyfill";
+
+onMounted(() => {
+  initializeWebMCPPolyfill();
+
+  navigator.modelContext.registerTool({
+    name: "current_route",
+    description: "Returns the current route path",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+    execute: async () => ({
+      content: [{ type: "text", text: window.location.pathname }],
+    }),
+  });
+});
+</script>
+
+<template>
+  <p>WebMCP tool "current_route" registered.</p>
+</template>

--- a/examples/frameworks/vue/src/main.ts
+++ b/examples/frameworks/vue/src/main.ts
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/examples/frameworks/vue/tsconfig.json
+++ b/examples/frameworks/vue/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}

--- a/examples/frameworks/vue/vite.config.ts
+++ b/examples/frameworks/vue/vite.config.ts
@@ -1,0 +1,6 @@
+import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [vue()],
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,24 +10,25 @@ packages:
   - e2e/vanilla-iife-zod3
   - e2e/vanilla-esm-zod3
   - e2e/react18-zod3
+  - "!examples/**"
 
 catalog:
-  '@cloudflare/vite-plugin': ^1.13.18
-  '@composio/json-schema-to-zod': ^0.1.19
-  '@hookform/resolvers': ^5.2.2
-  '@modelcontextprotocol/sdk': 1.25.2
-  '@radix-ui/react-collapsible': ^1.1.12
-  '@sentry/cloudflare': ^10.22.0
-  '@sentry/react': ^10.22.0
-  '@sentry/vite-plugin': ^4.6.0
-  '@types/chrome': ^0.0.326
-  '@types/node': 22.17.2
-  '@types/react': ^19.2.9
-  '@types/react-dom': ^19.1.2
-  '@use-gesture/react': ^10.3.1
-  '@vitest/browser': ^4.0.18
-  '@vitest/browser-playwright': ^4.0.18
-  '@vitest/coverage-v8': ^4.0.18
+  "@cloudflare/vite-plugin": ^1.13.18
+  "@composio/json-schema-to-zod": ^0.1.19
+  "@hookform/resolvers": ^5.2.2
+  "@modelcontextprotocol/sdk": 1.25.2
+  "@radix-ui/react-collapsible": ^1.1.12
+  "@sentry/cloudflare": ^10.22.0
+  "@sentry/react": ^10.22.0
+  "@sentry/vite-plugin": ^4.6.0
+  "@types/chrome": ^0.0.326
+  "@types/node": 22.17.2
+  "@types/react": ^19.2.9
+  "@types/react-dom": ^19.1.2
+  "@use-gesture/react": ^10.3.1
+  "@vitest/browser": ^4.0.18
+  "@vitest/browser-playwright": ^4.0.18
+  "@vitest/coverage-v8": ^4.0.18
   ai: ^5.0.83
   babel-plugin-react-compiler: ^1.0.0
   fast-check: ^4.0.0
@@ -45,8 +46,8 @@ catalog:
   zod: 3.25.76
 
 onlyBuiltDependencies:
-  - '@axodotdev/oranda'
-  - '@tailwindcss/oxide'
+  - "@axodotdev/oranda"
+  - "@tailwindcss/oxide"
   - dtrace-provider
   - esbuild
   - puppeteer


### PR DESCRIPTION
### Motivation

- Provide real, runnable mini repos for common frontend frameworks so integrators can quickly try the WebMCP API without copy/pasting snippets. 
- Keep the examples independent of the monorepo to avoid workspace resolution and dependency coupling for local experiments.

### Description

- Convert `examples/frameworks/{react,nextjs,vue,svelte}` into standalone mini repos by adding `package.json`, build/dev configs, entry files, and minimal app scaffolding that registers a single WebMCP tool. 
- Add a hub `examples/frameworks/README.md`, per-framework READMEs, and a local `.gitignore` for example artifacts. 
- Exclude `examples/**` from the root workspace by adding `- "!examples/**"` to `pnpm-workspace.yaml`. 
- Preserve the requested React pattern by keeping the React sample hook-based via `useWebMCP` and keep each sample's `execute` implementation intentionally minimal (text payloads).

### Testing

- Validated new JSON config files parse with `node -e "...JSON.parse(...)"`, which completed successfully. 
- Formatted and validated files with Prettier using `pnpm exec prettier --write pnpm-workspace.yaml examples/frameworks/**/*.{md,json,ts,tsx,vue,js,html,d.ts}` and `pnpm exec prettier --check ...`, both of which succeeded. 
- Confirmed examples are not treated as workspace packages with `pnpm -r list --depth -1`, which showed the examples absent from workspace package listing. 
- Automatic pre-commit lint/format tasks executed during the commit (lint-staged / Biome/format hooks) and passed as part of the automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925269b00c832b8e5d4bd1b72a35d0)