### PR TITLE
Tweak transport logging: use debug/warn levels and add transport prefixes

### DIFF
--- a/packages/transports/src/ExtensionClientTransport.ts
+++ b/packages/transports/src/ExtensionClientTransport.ts
@@ -267,7 +267,7 @@ export class ExtensionClientTransport implements Transport {
 
     // Check if we've exceeded max attempts
     if (this._reconnectAttempts >= this._maxReconnectAttempts) {
-      console.error('Maximum reconnection attempts reached');
+      console.warn('[ExtensionClientTransport] Maximum reconnection attempts reached');
       this._isReconnecting = false;
       this.onerror?.(new Error('Maximum reconnection attempts reached'));
       this.onclose?.();
@@ -276,8 +276,8 @@ export class ExtensionClientTransport implements Transport {
 
     this._reconnectAttempts++;
 
-    console.log(
-      `Scheduling reconnection attempt ${this._reconnectAttempts}/${this._maxReconnectAttempts} in ${this._currentReconnectDelay}ms`
+    console.debug(
+      `[ExtensionClientTransport] Scheduling reconnection attempt ${this._reconnectAttempts}/${this._maxReconnectAttempts} in ${this._currentReconnectDelay}ms`
     );
 
     this._reconnectTimer = setTimeout(() => {
@@ -312,10 +312,10 @@ export class ExtensionClientTransport implements Transport {
       // Attempt to connect
       await this._connect();
 
-      console.log('Reconnection successful');
+      console.debug('[ExtensionClientTransport] Reconnection successful');
       this._isReconnecting = false;
     } catch (error) {
-      console.error('Reconnection failed:', error);
+      console.warn('[ExtensionClientTransport] Reconnection failed, retrying', error);
 
       // Schedule another attempt
       this._scheduleReconnect();

--- a/packages/transports/src/ExtensionServerTransport.ts
+++ b/packages/transports/src/ExtensionServerTransport.ts
@@ -99,7 +99,7 @@ export class ExtensionServerTransport implements Transport {
 
     // Set up disconnect handler
     this._disconnectHandler = () => {
-      console.log(
+      console.debug(
         `[ExtensionServerTransport] Client disconnected after ${Date.now() - this._connectionInfo.connectedAt}ms, processed ${this._connectionInfo.messageCount} messages`
       );
       this._cleanup();
@@ -114,7 +114,7 @@ export class ExtensionServerTransport implements Transport {
       this._startKeepAlive();
     }
 
-    console.log(
+    console.debug(
       `[ExtensionServerTransport] Started with client: ${this._port.sender?.id || 'unknown'}`
     );
   }
@@ -190,7 +190,7 @@ export class ExtensionServerTransport implements Transport {
       return;
     }
 
-    console.log(
+    console.debug(
       `[ExtensionServerTransport] Starting keep-alive with ${this._options.keepAliveInterval}ms interval`
     );
 

--- a/packages/transports/src/IframeParentTransport.ts
+++ b/packages/transports/src/IframeParentTransport.ts
@@ -91,7 +91,6 @@ export class IframeParentTransport implements Transport {
       }
 
       if (typeof payload === 'string' && payload === 'mcp-server-stopped') {
-        console.log('[IframeParentTransport] Received mcp-server-stopped event, closing transport');
         this.close();
         return;
       }

--- a/packages/transports/src/TabClientTransport.ts
+++ b/packages/transports/src/TabClientTransport.ts
@@ -256,7 +256,6 @@ export class TabClientTransport implements Transport {
 
       // Handle server stopped signal
       if (typeof payload === 'string' && payload === 'mcp-server-stopped') {
-        console.log('[TabClientTransport] Received mcp-server-stopped event, closing transport');
         this.close();
         return;
       }

--- a/packages/transports/src/TabServerTransport.ts
+++ b/packages/transports/src/TabServerTransport.ts
@@ -150,12 +150,6 @@ export class TabServerTransport implements Transport {
     // Otherwise, use '*' for backwards compatibility with clients that don't do the handshake
     const targetOrigin = this._resolveTargetOrigin(this._clientOrigin);
 
-    if (!this._clientOrigin) {
-      console.debug(
-        '[TabServerTransport] Sending to unknown client origin (backwards compatibility mode)'
-      );
-    }
-
     window.postMessage(
       {
         channel: this._channelId,

--- a/packages/transports/src/UserScriptClientTransport.ts
+++ b/packages/transports/src/UserScriptClientTransport.ts
@@ -267,7 +267,7 @@ export class UserScriptClientTransport implements Transport {
 
     // Check if we've exceeded max attempts
     if (this._reconnectAttempts >= this._maxReconnectAttempts) {
-      console.error('Maximum reconnection attempts reached');
+      console.warn('[UserScriptClientTransport] Maximum reconnection attempts reached');
       this._isReconnecting = false;
       this.onerror?.(new Error('Maximum reconnection attempts reached'));
       this.onclose?.();
@@ -276,8 +276,8 @@ export class UserScriptClientTransport implements Transport {
 
     this._reconnectAttempts++;
 
-    console.log(
-      `Scheduling reconnection attempt ${this._reconnectAttempts}/${this._maxReconnectAttempts} in ${this._currentReconnectDelay}ms`
+    console.debug(
+      `[UserScriptClientTransport] Scheduling reconnection attempt ${this._reconnectAttempts}/${this._maxReconnectAttempts} in ${this._currentReconnectDelay}ms`
     );
 
     this._reconnectTimer = setTimeout(() => {
@@ -312,10 +312,10 @@ export class UserScriptClientTransport implements Transport {
       // Attempt to connect
       await this._connect();
 
-      console.log('Reconnection successful');
+      console.debug('[UserScriptClientTransport] Reconnection successful');
       this._isReconnecting = false;
     } catch (error) {
-      console.error('Reconnection failed:', error);
+      console.warn('[UserScriptClientTransport] Reconnection failed, retrying', error);
 
       // Schedule another attempt
       this._scheduleReconnect();

--- a/packages/transports/src/UserScriptServerTransport.ts
+++ b/packages/transports/src/UserScriptServerTransport.ts
@@ -102,7 +102,7 @@ export class UserScriptServerTransport implements Transport {
 
     // Set up disconnect handler
     this._disconnectHandler = () => {
-      console.log(
+      console.debug(
         `[UserScriptServerTransport] Client disconnected after ${Date.now() - this._connectionInfo.connectedAt}ms, processed ${this._connectionInfo.messageCount} messages`
       );
       this._cleanup();
@@ -117,7 +117,7 @@ export class UserScriptServerTransport implements Transport {
       this._startKeepAlive();
     }
 
-    console.log(
+    console.debug(
       `[UserScriptServerTransport] Started with client: ${this._port.sender?.id || 'unknown'}`
     );
   }
@@ -193,7 +193,7 @@ export class UserScriptServerTransport implements Transport {
       return;
     }
 
-    console.log(
+    console.debug(
       `[UserScriptServerTransport] Starting keep-alive with ${this._options.keepAliveInterval}ms interval`
     );
 


### PR DESCRIPTION
### Motivation
- Reduce console noise and make transport logs easier to filter by using appropriate log levels and tagging messages with transport names.
- Clarify reconnection and keep-alive behavior in logs while preserving error visibility for real failures.
- Remove a few redundant/noisy log lines emitted during normal lifecycle events.

### Description
- Replaced several `console.log` calls with `console.debug` across transport implementations to move verbose information to a lower log level and added transport-specific prefixes (e.g. `[ExtensionClientTransport]`).
- Changed reconnection failure / maximum attempts messages from `console.error`/`console.log` to `console.warn` and prefixed them with transport identifiers (e.g. `[UserScriptClientTransport]`).
- Updated server-side transports to use `console.debug` for start/disconnect/keep-alive startup messages and retained `console.error` for keep-alive failures; removed a noisy compatibility-mode debug message in `TabServerTransport` and some `mcp-server-stopped` debug logs in iframe/tab client transports.

### Testing
- Ran the TypeScript build and project test suite (`pnpm -w test` / equivalent) to ensure there are no compile or test regressions, and they passed.
- Ran linter/type-checking to confirm no typing or formatting issues, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a09904a30c832bbbb7dca2ec564201)