### PR TITLE
Normalize tool results, relax JSON-schema typing, and test/runtime polyfill improvements

### DIFF
--- a/packages/extension-tools/src/chrome-typecheck.d.ts
+++ b/packages/extension-tools/src/chrome-typecheck.d.ts
@@ -1,1 +1,1 @@
-declare const chrome: any;
+declare const chrome: unknown;

--- a/packages/react-webmcp/src/useElicitationHandler.test.ts
+++ b/packages/react-webmcp/src/useElicitationHandler.test.ts
@@ -1,5 +1,4 @@
 import { initializeWebModelContext } from '@mcp-b/global';
-import type { ModelContextTesting } from '@mcp-b/webmcp-types';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import { useElicitation, useElicitationHandler } from './useElicitationHandler.js';

--- a/packages/react-webmcp/src/useSamplingHandler.test.ts
+++ b/packages/react-webmcp/src/useSamplingHandler.test.ts
@@ -1,5 +1,4 @@
 import { initializeWebModelContext } from '@mcp-b/global';
-import type { ModelContextTesting } from '@mcp-b/webmcp-types';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import { useSampling, useSamplingHandler } from './useSamplingHandler.js';

--- a/packages/react-webmcp/src/useWebMCP.test.ts
+++ b/packages/react-webmcp/src/useWebMCP.test.ts
@@ -1,5 +1,4 @@
 import { initializeWebModelContext } from '@mcp-b/global';
-import type { ModelContextTesting } from '@mcp-b/webmcp-types';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import { z } from 'zod';

--- a/packages/react-webmcp/src/useWebMCPContext.test.ts
+++ b/packages/react-webmcp/src/useWebMCPContext.test.ts
@@ -1,5 +1,4 @@
 import { initializeWebModelContext } from '@mcp-b/global';
-import type { ModelContextTesting } from '@mcp-b/webmcp-types';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import { useWebMCPContext } from './useWebMCPContext.js';

--- a/packages/webmcp-polyfill/package.json
+++ b/packages/webmcp-polyfill/package.json
@@ -63,6 +63,7 @@
     "@vitest/browser": "catalog:",
     "@vitest/browser-playwright": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "happy-dom": "^15.11.7",
     "playwright": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/webmcp-polyfill/src/index.test.ts
+++ b/packages/webmcp-polyfill/src/index.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import type { InputSchema } from '@mcp-b/webmcp-types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -395,7 +396,53 @@ describe('@mcp-b/webmcp-polyfill', () => {
       expect(tools).toHaveLength(1);
       const schema = tools?.[0]?.inputSchema;
       expect(schema).toBeDefined();
-      expect(JSON.parse(schema!)).toEqual({ type: 'object', properties: {} });
+      expect(JSON.parse(schema ?? '{}')).toEqual({ type: 'object', properties: {} });
+    });
+
+    it('defaults inputSchema.type to object when schema omits root type', async () => {
+      initializeWebMCPPolyfill();
+      navigator.modelContext.registerTool({
+        name: 'implicit_object_schema',
+        description: 'Implicit object schema tool',
+        inputSchema: {
+          properties: {
+            query: { type: 'string' },
+          },
+          required: ['query'],
+        },
+        execute: async ({ query }) => ({ content: [{ type: 'text', text: String(query) }] }),
+      });
+
+      const tools = navigator.modelContextTesting?.listTools();
+      expect(tools).toHaveLength(1);
+      expect(JSON.parse(tools?.[0]?.inputSchema ?? '{}')).toEqual({
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+      });
+
+      await expect(
+        navigator.modelContextTesting?.executeTool('implicit_object_schema', '{}')
+      ).rejects.toThrow('Instance does not have required property "query"');
+    });
+
+    it('accepts annotation boolean strings during tool registration', async () => {
+      initializeWebMCPPolyfill();
+      navigator.modelContext.registerTool({
+        name: 'annotation_coercion',
+        description: 'Annotation coercion tool',
+        annotations: {
+          readOnlyHint: 'true',
+          destructiveHint: 'false',
+          openWorldHint: 'true',
+          idempotentHint: 'false',
+        },
+        execute: async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+      });
+
+      await expect(
+        navigator.modelContextTesting?.executeTool('annotation_coercion', '{}')
+      ).resolves.toContain('ok');
     });
 
     it('accepts Standard Schema validators for input validation', async () => {
@@ -1348,8 +1395,40 @@ describe('@mcp-b/webmcp-polyfill', () => {
 
       const result = await navigator.modelContextTesting?.executeTool('normal_tool', '{}');
       expect(result).toBeDefined();
-      const parsed = JSON.parse(result!);
+      const parsed = JSON.parse(result ?? '{}');
       expect(parsed.content[0].text).toBe('hello');
+    });
+
+    it('executeTool wraps raw object returns into content and structuredContent', async () => {
+      initializeWebMCPPolyfill();
+      navigator.modelContext.registerTool({
+        name: 'raw_object_tool',
+        description: 'Raw object tool',
+        execute: async () => ({ ok: true, nested: { count: 2 } }),
+      });
+
+      const result = await navigator.modelContextTesting?.executeTool('raw_object_tool', '{}');
+      const parsed = JSON.parse(result ?? '{}');
+      expect(parsed.isError).toBe(false);
+      expect(parsed.content?.[0]?.type).toBe('text');
+      expect(parsed.structuredContent).toEqual({ ok: true, nested: { count: 2 } });
+    });
+
+    it('executeTool does not set structuredContent for non-json-safe objects', async () => {
+      initializeWebMCPPolyfill();
+      navigator.modelContext.registerTool({
+        name: 'non_json_structured_content_tool',
+        description: 'Non JSON structured content tool',
+        execute: async () => ({ value: Number.NaN }),
+      });
+
+      const result = await navigator.modelContextTesting?.executeTool(
+        'non_json_structured_content_tool',
+        '{}'
+      );
+      const parsed = JSON.parse(result ?? '{}');
+      expect(parsed.content?.[0]?.type).toBe('text');
+      expect(parsed.structuredContent).toBeUndefined();
     });
 
     it('registerToolsChangedCallback throws when callback is not a function', () => {
@@ -1830,7 +1909,7 @@ describe('@mcp-b/webmcp-polyfill', () => {
       ).rejects.toThrow('Tool was executed but the invocation failed');
     });
 
-    it('handles isError=true with no content array', async () => {
+    it('treats malformed isError payloads as raw return values', async () => {
       initializeWebMCPPolyfill();
       navigator.modelContext.registerTool({
         name: 'no_content_error_tool',
@@ -1841,9 +1920,14 @@ describe('@mcp-b/webmcp-polyfill', () => {
         }),
       });
 
-      await expect(
-        navigator.modelContextTesting?.executeTool('no_content_error_tool', '{}')
-      ).rejects.toThrow('Tool was executed but the invocation failed');
+      const result = await navigator.modelContextTesting?.executeTool(
+        'no_content_error_tool',
+        '{}'
+      );
+      const parsed = JSON.parse(result ?? '{}');
+      expect(parsed.isError).toBe(false);
+      expect(parsed.content?.[0]?.type).toBe('text');
+      expect(parsed.structuredContent).toBeUndefined();
     });
 
     it('handles metadata.willNavigate=false (does not return null)', async () => {

--- a/packages/webmcp-polyfill/src/index.ts
+++ b/packages/webmcp-polyfill/src/index.ts
@@ -1,6 +1,7 @@
 import { type Schema, Validator } from '@cfworker/json-schema';
 import type {
   InputSchema,
+  JsonObject,
   ModelContext,
   ModelContextClient,
   ModelContextOptions,
@@ -59,8 +60,7 @@ interface PolyfillModelContext extends ModelContext {
   [POLYFILL_MARKER_PROPERTY]: true;
 }
 
-interface PolyfillToolDescriptor
-  extends ToolDescriptor<Record<string, unknown>, ToolResponse, string> {
+interface PolyfillToolDescriptor extends ToolDescriptor<Record<string, unknown>, unknown, string> {
   inputSchema: InputSchema;
   [STANDARD_VALIDATOR_SYMBOL]: StandardInputValidatorSchema;
 }
@@ -213,8 +213,8 @@ class StrictWebMCPContext {
 
     try {
       const execution = tool.execute(args, client);
-      const result = await withAbortSignal(Promise.resolve(execution), options?.signal);
-      return toSerializedTestingResult(result);
+      const rawResult = await withAbortSignal(Promise.resolve(execution), options?.signal);
+      return toSerializedTestingResult(normalizeToolResponse(rawResult));
     } catch (error) {
       const detail =
         error instanceof Error
@@ -369,9 +369,13 @@ function normalizeInputSchema(inputSchema: ToolInputSchema | undefined): Normali
   }
 
   validateInputSchema(inputSchema);
+  const normalizedSchema =
+    inputSchema.type === undefined
+      ? ({ type: 'object', ...inputSchema } as InputSchema)
+      : inputSchema;
   return {
-    inputSchema,
-    standardValidator: createStandardValidatorFromJsonSchema(inputSchema),
+    inputSchema: normalizedSchema,
+    standardValidator: createStandardValidatorFromJsonSchema(normalizedSchema),
   };
 }
 
@@ -495,8 +499,36 @@ function normalizeToolDescriptor(
 
   const normalizedInputSchema = normalizeInputSchema(tool.inputSchema);
 
+  const annotations = tool.annotations;
+  const normalizedAnnotations = annotations
+    ? {
+        ...annotations,
+        ...(annotations.readOnlyHint === 'true'
+          ? { readOnlyHint: true }
+          : annotations.readOnlyHint === 'false'
+            ? { readOnlyHint: false }
+            : {}),
+        ...(annotations.destructiveHint === 'true'
+          ? { destructiveHint: true }
+          : annotations.destructiveHint === 'false'
+            ? { destructiveHint: false }
+            : {}),
+        ...(annotations.idempotentHint === 'true'
+          ? { idempotentHint: true }
+          : annotations.idempotentHint === 'false'
+            ? { idempotentHint: false }
+            : {}),
+        ...(annotations.openWorldHint === 'true'
+          ? { openWorldHint: true }
+          : annotations.openWorldHint === 'false'
+            ? { openWorldHint: false }
+            : {}),
+      }
+    : undefined;
+
   return {
     ...tool,
+    ...(normalizedAnnotations ? { annotations: normalizedAnnotations } : {}),
     inputSchema: normalizedInputSchema.inputSchema,
     [STANDARD_VALIDATOR_SYMBOL]: normalizedInputSchema.standardValidator,
   };
@@ -580,6 +612,75 @@ async function validateArgsForTool(
   tool: PolyfillToolDescriptor
 ): Promise<string | null> {
   return validateArgsWithStandardSchema(args, tool[STANDARD_VALIDATOR_SYMBOL]);
+}
+
+function isCallToolResult(value: unknown): value is ToolResponse {
+  return isPlainObject(value) && Array.isArray(value.content);
+}
+
+function isJsonPrimitive(value: unknown): value is string | number | boolean | null {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  );
+}
+
+function isJsonValue(value: unknown): boolean {
+  if (isJsonPrimitive(value)) {
+    return Number.isFinite(value as number) || typeof value !== 'number';
+  }
+
+  if (Array.isArray(value)) {
+    return value.every((entry) => isJsonValue(entry));
+  }
+
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  return Object.values(value).every((entry) => isJsonValue(entry));
+}
+
+function toStructuredContent(value: unknown): JsonObject | undefined {
+  if (!isPlainObject(value) || !isJsonValue(value)) {
+    return undefined;
+  }
+
+  return value as JsonObject;
+}
+
+function serializeTextContent(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  try {
+    const candidate = JSON.stringify(value);
+    return candidate ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function normalizeToolResponse(value: unknown): ToolResponse {
+  if (isCallToolResult(value)) {
+    return value;
+  }
+
+  const structuredContent = toStructuredContent(value);
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: serializeTextContent(value),
+      },
+    ],
+    ...(structuredContent ? { structuredContent } : {}),
+    isError: false,
+  };
 }
 
 function getFirstTextBlock(result: ToolResponse): string | null {

--- a/packages/webmcp-ts-sdk/src/browser-server.ts
+++ b/packages/webmcp-ts-sdk/src/browser-server.ts
@@ -1,6 +1,6 @@
 import type {
-  CallToolResult,
   InputSchema,
+  JsonObject,
   ModelContextClient,
   ModelContextCore,
   ModelContextExtensions,
@@ -39,6 +39,74 @@ import { PolyfillJsonSchemaValidator } from './polyfill-validator.js';
 const DEFAULT_INPUT_SCHEMA: InputSchema = { type: 'object', properties: {} };
 const DEFAULT_CLIENT_REQUEST_TIMEOUT = 10_000;
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isCallToolResult(value: unknown): value is ToolResponse {
+  return isPlainObject(value) && Array.isArray(value.content);
+}
+
+function isJsonPrimitive(value: unknown): value is string | number | boolean | null {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  );
+}
+
+function isJsonValue(value: unknown): boolean {
+  if (isJsonPrimitive(value)) {
+    return Number.isFinite(value as number) || typeof value !== 'number';
+  }
+
+  if (Array.isArray(value)) {
+    return value.every((entry) => isJsonValue(entry));
+  }
+
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  return Object.values(value).every((entry) => isJsonValue(entry));
+}
+
+function toStructuredContent(value: unknown): JsonObject | undefined {
+  if (!isPlainObject(value) || !isJsonValue(value)) {
+    return undefined;
+  }
+
+  return value as JsonObject;
+}
+
+function serializeTextContent(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  try {
+    const candidate = JSON.stringify(value);
+    return candidate ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function normalizeToolResponse(value: unknown): ToolResponse {
+  if (isCallToolResult(value)) {
+    return value;
+  }
+
+  const structuredContent = toStructuredContent(value);
+
+  return {
+    content: [{ type: 'text', text: serializeTextContent(value) }],
+    ...(structuredContent ? { structuredContent } : {}),
+    isError: false,
+  };
+}
+
 function withDefaultTimeout(options?: RequestOptions): RequestOptions {
   if (options?.signal) return options;
   return { ...options, signal: AbortSignal.timeout(DEFAULT_CLIENT_REQUEST_TIMEOUT) };
@@ -49,7 +117,7 @@ interface ParentRegisteredTool {
   inputSchema?: unknown;
   outputSchema?: unknown;
   annotations?: unknown;
-  handler: (args: Record<string, unknown>, extra: unknown) => Promise<CallToolResult>;
+  handler: (args: Record<string, unknown>, extra: unknown) => Promise<ToolResponse>;
   enabled: boolean;
   remove: () => void;
 }
@@ -81,7 +149,7 @@ export interface BrowserMcpServerOptions extends ServerOptions {
 type ParentRegisterToolFn = (
   name: string,
   config: Record<string, unknown>,
-  cb: (args: Record<string, unknown>, extra: unknown) => Promise<CallToolResult>
+  cb: (args: Record<string, unknown>, extra: unknown) => Promise<ToolResponse>
 ) => void;
 
 type ParentRegisterResourceFn = (
@@ -216,7 +284,11 @@ export class BrowserMcpServer extends BaseMcpServer {
   }
 
   private registerToolInServer(tool: ToolDescriptor): { unregister: () => void } {
-    const inputSchema = tool.inputSchema ?? DEFAULT_INPUT_SCHEMA;
+    const inputSchema = tool.inputSchema
+      ? tool.inputSchema.type === undefined
+        ? ({ type: 'object', ...tool.inputSchema } as InputSchema)
+        : tool.inputSchema
+      : DEFAULT_INPUT_SCHEMA;
 
     // Cast needed: parent expects Zod-compatible schemas, we pass JSON Schema objects.
     (super.registerTool as unknown as ParentRegisterToolFn)(
@@ -231,7 +303,7 @@ export class BrowserMcpServer extends BaseMcpServer {
         const client: ModelContextClient = {
           requestUserInteraction: async (cb: () => Promise<unknown>) => cb(),
         };
-        return tool.execute(args, client);
+        return normalizeToolResponse(await tool.execute(args, client));
       }
     );
     return {

--- a/packages/webmcp-types/src/common.ts
+++ b/packages/webmcp-types/src/common.ts
@@ -50,7 +50,7 @@ export interface InputSchema {
   /**
    * JSON Schema type for the root value (usually `'object'` for tool args).
    */
-  type: string;
+  type?: string;
 
   /**
    * Property definitions for object schemas.

--- a/packages/webmcp-types/src/index.ts
+++ b/packages/webmcp-types/src/index.ts
@@ -69,8 +69,10 @@ export type {
   ToolAnnotations,
   ToolDescriptor,
   ToolDescriptorFromSchema,
+  ToolExecuteResult,
   ToolExecutionContext,
   ToolListItem,
+  ToolRawResult,
   ToolResultFromOutputSchema,
 } from './tool.js';
 

--- a/packages/webmcp-types/src/json-schema.test-d.ts
+++ b/packages/webmcp-types/src/json-schema.test-d.ts
@@ -153,6 +153,21 @@ test('InferArgsFromInputSchema keeps extras unknown when named properties are pr
   expectTypeOf(args.limit).toEqualTypeOf<unknown>();
 });
 
+test('InferArgsFromInputSchema infers object properties when type is omitted', () => {
+  const schema = {
+    properties: {
+      query: { type: 'string' },
+      limit: { type: 'integer' },
+    },
+    required: ['query'],
+  } as const;
+
+  type Args = InferArgsFromInputSchema<typeof schema>;
+  const args: Args = { query: 'webmcp' };
+  expectTypeOf(args.query).toEqualTypeOf<string>();
+  expectTypeOf(args.limit).toEqualTypeOf<number | undefined>();
+});
+
 test('InferArgsFromInputSchema supports object type unions for argument inference', () => {
   type Args = InferArgsFromInputSchema<typeof schemaWithObjectTypeUnion>;
   const args: Args = { query: 'webmcp' };
@@ -174,25 +189,19 @@ test('ToolDescriptorFromSchema execute args reject missing required keys', () =>
   void args;
 });
 
-test('ToolDescriptorFromSchema infers structuredContent from outputSchema', () => {
+test('ToolDescriptorFromSchema infers raw return type from outputSchema', () => {
   type ExecuteResult = Awaited<
     ReturnType<ToolDescriptorFromSchema<typeof closedSchema, typeof outputSchema>['execute']>
   >;
-  type StructuredContent = ExecuteResult['structuredContent'];
 
-  const structuredContent: NonNullable<StructuredContent> = {
-    total: 1,
-    items: ['a'],
+  const rawResult: ExecuteResult = { total: 1, items: ['a'] };
+  const wrappedResult: ExecuteResult = {
+    content: [{ type: 'text', text: 'ok' }],
+    structuredContent: { total: 1, items: ['a'] },
   };
-  expectTypeOf(structuredContent.total).toEqualTypeOf<number>();
-  expectTypeOf(structuredContent.items).toEqualTypeOf<string[] | undefined>();
-  expectTypeOf<StructuredContent>().toMatchTypeOf<
-    | {
-        total: number;
-        items?: string[];
-      }
-    | undefined
-  >();
+
+  void rawResult;
+  void wrappedResult;
 });
 
 test('ModelContext.registerTool infers execute args from literal schema', () => {
@@ -322,7 +331,7 @@ test('ModelContext.registerTool accepts async output schema handlers with loose 
 
 test('ModelContext.registerTool rejects invalid structuredContent for inferred outputSchema', () => {
   if (shouldInvokeRegisterTool) {
-    // @ts-expect-error - structuredContent must satisfy outputSchema (missing total, extra test)
+    // @ts-expect-error - raw return must satisfy outputSchema (missing total, extra test)
     registerTool({
       name: 'search_summary',
       description: 'Async tool with inferred structured output',
@@ -347,12 +356,9 @@ test('ModelContext.registerTool rejects invalid structuredContent for inferred o
       } as const satisfies JsonSchemaForInference,
       async execute(args) {
         return {
-          content: [{ text: `summary for ${args.query}`, data: 'opaque' }],
-          structuredContent: {
-            test: 'test',
-            tags: [args.query],
-            mode: 'compact',
-          },
+          test: 'test',
+          tags: [args.query],
+          mode: 'compact',
         };
       },
     });
@@ -361,7 +367,7 @@ test('ModelContext.registerTool rejects invalid structuredContent for inferred o
 
 test('ModelContext.registerTool rejects structuredContent enum/type mismatches', () => {
   if (shouldInvokeRegisterTool) {
-    // @ts-expect-error - total must be number and mode must match enum literals
+    // @ts-expect-error - raw output mode must match enum literals
     registerTool({
       name: 'search_summary_mismatch',
       description: 'Invalid structured output',
@@ -375,13 +381,10 @@ test('ModelContext.registerTool rejects structuredContent enum/type mismatches',
         required: ['total'],
         additionalProperties: false,
       } as const satisfies JsonSchemaForInference,
-      execute(args) {
+      execute(_args) {
         return {
-          content: [{ type: 'text', text: args.query }],
-          structuredContent: {
-            total: '1',
-            mode: 'verbose',
-          },
+          total: 1,
+          mode: 'verbose',
         };
       },
     });

--- a/packages/webmcp-types/src/json-schema.ts
+++ b/packages/webmcp-types/src/json-schema.ts
@@ -222,11 +222,17 @@ type InferObject<TSchema> = Simplify<
     AdditionalPropsOf<TSchema>
 >;
 
-type TypeKeywordOf<TSchema> = TSchema extends { type: infer TType } ? TType : never;
+type TypeKeywordOf<TSchema> = TSchema extends { type?: infer TType }
+  ? 'type' extends keyof TSchema
+    ? TType
+    : undefined
+  : undefined;
 
-type TypeOptionsOf<TSchema> = TypeKeywordOf<TSchema> extends readonly unknown[]
-  ? Extract<TypeKeywordOf<TSchema>[number], JsonSchemaType>
-  : Extract<TypeKeywordOf<TSchema>, JsonSchemaType>;
+type TypeOptionsOf<TSchema> = [TypeKeywordOf<TSchema>] extends [undefined]
+  ? 'object'
+  : TypeKeywordOf<TSchema> extends readonly unknown[]
+    ? Extract<TypeKeywordOf<TSchema>[number], JsonSchemaType>
+    : Extract<TypeKeywordOf<TSchema>, JsonSchemaType>;
 
 type InferFromTypeOption<TSchema, TType extends JsonSchemaType> = TType extends 'object'
   ? InferObject<TSchema>
@@ -282,9 +288,10 @@ type IncludesObjectType<TSchema> = TypeOptionsOf<TSchema> extends never
  * `InputSchema` loaded at runtime), this intentionally falls back to
  * `Record<string, unknown>`.
  */
-export type InferArgsFromInputSchema<TSchema extends { type: string | readonly string[] }> =
-  IsWidenedTypeKeyword<TSchema['type']> extends true
-    ? Record<string, unknown>
-    : IncludesObjectType<TSchema> extends true
-      ? InferObject<TSchema>
-      : Record<string, unknown>;
+export type InferArgsFromInputSchema<TSchema> = IsWidenedTypeKeyword<
+  TypeKeywordOf<TSchema>
+> extends true
+  ? Record<string, unknown>
+  : IncludesObjectType<TSchema> extends true
+    ? InferObject<TSchema>
+    : Record<string, unknown>;

--- a/packages/webmcp-types/src/model-context.ts
+++ b/packages/webmcp-types/src/model-context.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult, InputSchema, ToolResponse } from './common.js';
+import type { InputSchema, ToolResponse } from './common.js';
 import type { JsonSchemaForInference, JsonSchemaObject } from './json-schema.js';
 import type { ToolDescriptor, ToolDescriptorFromSchema, ToolListItem } from './tool.js';
 
@@ -81,7 +81,7 @@ export interface ModelContextTestingPolyfillExtensions {
  *
  * Uses `never` for args so descriptors with stricter argument objects remain assignable.
  */
-export type AnyToolDescriptor = ToolDescriptor<never, CallToolResult, string>;
+export type AnyToolDescriptor = ToolDescriptor<never, unknown, string>;
 
 /**
  * Infers argument shape from a tool descriptor.
@@ -205,7 +205,7 @@ export interface ModelContextCore {
   registerTool<
     TInputSchema extends InputSchema,
     TArgs extends Record<string, unknown> = Record<string, unknown>,
-    TResult extends CallToolResult = CallToolResult,
+    TResult = unknown,
     TName extends string = string,
   >(
     tool: ToolDescriptor<TArgs, TResult, TName> & {
@@ -223,7 +223,7 @@ export interface ModelContextCore {
    */
   registerTool<
     TArgs extends Record<string, unknown> = Record<string, unknown>,
-    TResult extends CallToolResult = CallToolResult,
+    TResult = unknown,
     TName extends string = string,
   >(
     tool: Omit<ToolDescriptor<TArgs, TResult, TName>, 'inputSchema'> & {

--- a/packages/webmcp-types/src/tool.test-d.ts
+++ b/packages/webmcp-types/src/tool.test-d.ts
@@ -24,10 +24,10 @@ test('ToolDescriptor has required fields', () => {
   expectTypeOf<ToolDescriptor>().toHaveProperty('execute');
 });
 
-test('ToolDescriptor.execute accepts Record and returns MaybePromise<CallToolResult>', () => {
+test('ToolDescriptor.execute accepts Record and returns MaybePromise<unknown> by default', () => {
   expectTypeOf<ToolDescriptor['execute']>().parameter(0).toEqualTypeOf<Record<string, unknown>>();
   expectTypeOf<ToolDescriptor['execute']>().parameter(1).toEqualTypeOf<ModelContextClient>();
-  expectTypeOf<ToolDescriptor['execute']>().returns.toEqualTypeOf<MaybePromise<CallToolResult>>();
+  expectTypeOf<ToolDescriptor['execute']>().returns.toEqualTypeOf<MaybePromise<unknown>>();
 });
 
 test('ToolExecutionContext.elicitInput accepts ElicitationParams and returns ElicitationResult', () => {
@@ -157,8 +157,10 @@ test('ToolDescriptor.annotations is optional ToolAnnotations', () => {
 test('ToolAnnotations has optional behavioral hints', () => {
   expectTypeOf<ToolAnnotations>().toMatchTypeOf<{
     title?: string;
-    destructiveHint?: boolean;
-    readOnlyHint?: boolean;
+    destructiveHint?: boolean | 'true' | 'false';
+    readOnlyHint?: boolean | 'true' | 'false';
+    idempotentHint?: boolean | 'true' | 'false';
+    openWorldHint?: boolean | 'true' | 'false';
   }>();
 });
 

--- a/packages/webmcp-types/src/tool.ts
+++ b/packages/webmcp-types/src/tool.ts
@@ -24,23 +24,35 @@ export interface ToolAnnotations {
   /**
    * Indicates the tool is read-only.
    */
-  readOnlyHint?: boolean;
+  readOnlyHint?: boolean | 'true' | 'false';
 
   /**
    * Indicates the tool may perform destructive actions.
    */
-  destructiveHint?: boolean;
+  destructiveHint?: boolean | 'true' | 'false';
 
   /**
    * Indicates the tool can be called repeatedly without changing outcome.
    */
-  idempotentHint?: boolean;
+  idempotentHint?: boolean | 'true' | 'false';
 
   /**
    * Indicates the tool may reach beyond local context (network, external systems, etc.).
    */
-  openWorldHint?: boolean;
+  openWorldHint?: boolean | 'true' | 'false';
 }
+
+/**
+ * Raw tool result values accepted by execute handlers before runtime normalization.
+ */
+export type ToolRawResult = unknown;
+
+/**
+ * Tool execute return value accepted by WebMCP descriptor types.
+ */
+export type ToolExecuteResult<TResult = ToolRawResult> = TResult extends CallToolResult
+  ? TResult
+  : CallToolResult | TResult;
 
 // ============================================================================
 // Tool Descriptor
@@ -81,14 +93,14 @@ export type MaybePromise<T> = T | Promise<T>;
  * information. This interface uses JSON Schema for input/output typing.
  *
  * @template TArgs - Tool input arguments.
- * @template TResult - Tool execution result shape.
+ * @template TResult - Tool execution raw result shape (or full CallToolResult).
  * @template TName - Tool name literal type.
  *
  * @see {@link https://spec.modelcontextprotocol.io/specification/server/tools/}
  */
 export interface ToolDescriptor<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
-  TResult extends CallToolResult = CallToolResult,
+  TResult = ToolRawResult,
   TName extends string = string,
 > {
   /**
@@ -119,15 +131,14 @@ export interface ToolDescriptor<
   /**
    * Tool execution function.
    */
-  execute: (args: TArgs, client: ModelContextClient) => MaybePromise<TResult>;
+  execute: (args: TArgs, client: ModelContextClient) => MaybePromise<ToolExecuteResult<TResult>>;
 }
 
 /**
  * Tool response shape inferred from an `outputSchema`.
  *
  * When a literal object output schema is provided, `structuredContent` is
- * narrowed to the inferred schema type. Otherwise, this resolves to the
- * base `CallToolResult`.
+ * narrowed to the inferred schema type for wrapped MCP responses.
  *
  * @template TOutputSchema - Optional literal JSON object schema.
  */
@@ -136,6 +147,15 @@ export type ToolResultFromOutputSchema<
 > = TOutputSchema extends JsonSchemaObject
   ? CallToolResult & { structuredContent?: InferJsonSchema<TOutputSchema> }
   : CallToolResult;
+
+/**
+ * Execute result typing derived from an optional output schema.
+ */
+export type ToolExecuteResultFromOutputSchema<
+  TOutputSchema extends JsonSchemaObject | undefined = undefined,
+> = TOutputSchema extends JsonSchemaObject
+  ? InferJsonSchema<TOutputSchema> | ToolResultFromOutputSchema<TOutputSchema>
+  : ToolExecuteResult;
 
 /**
  * Tool descriptor whose `execute` args are inferred from a JSON Schema.
@@ -149,13 +169,13 @@ export type ToolResultFromOutputSchema<
  * @template TResult - Optional result type override constrained by inferred output schema.
  */
 export type ToolDescriptorFromSchema<
-  TInputSchema extends { type: string | readonly string[] },
+  TInputSchema extends { type?: string | readonly string[] },
   TOutputSchema extends JsonSchemaObject | undefined = undefined,
   TName extends string = string,
 > = Omit<
   ToolDescriptor<
     InferArgsFromInputSchema<TInputSchema>,
-    ToolResultFromOutputSchema<TOutputSchema>,
+    ToolExecuteResultFromOutputSchema<TOutputSchema>,
     TName
   >,
   'inputSchema' | 'outputSchema'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ catalogs:
       version: 5.9.3
     vite:
       specifier: ^7.1.2
-      version: 7.1.2
+      version: 7.3.1
     vite-plugin-monkey:
       specifier: ^6.0.1
       version: 6.0.1
@@ -153,13 +153,13 @@ importers:
         version: 19.2.3(@types/react@19.2.9)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@7.1.2(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 4.7.0(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 7.1.2(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
 
   e2e/react18-zod3:
     dependencies:
@@ -193,13 +193,13 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@7.1.2(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 4.7.0(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 7.1.2(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
 
   e2e/test-app:
     dependencies:
@@ -252,7 +252,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 7.1.2(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
 
   e2e/vanilla-iife-json:
     devDependencies:
@@ -261,7 +261,7 @@ importers:
         version: link:../../packages/global
       vite:
         specifier: 'catalog:'
-        version: 7.1.2(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
 
   e2e/vanilla-iife-zod3:
     devDependencies:
@@ -270,7 +270,7 @@ importers:
         version: link:../../packages/global
       vite:
         specifier: 'catalog:'
-        version: 7.1.2(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
 
   e2e/web-standards-showcase:
     dependencies:
@@ -322,10 +322,10 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.21.2
-        version: 1.21.2(vite@7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(workerd@1.20260120.0)(wrangler@4.60.0)
+        version: 1.21.2(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(workerd@1.20260120.0)(wrangler@4.60.0)
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.1.18(vite@7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 4.1.18(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
       '@types/node':
         specifier: 'catalog:'
         version: 22.17.2
@@ -337,7 +337,7 @@ importers:
         version: 19.2.3(@types/react@19.2.9)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.1.0(vite@7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 5.1.0(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -349,7 +349,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
       wrangler:
         specifier: ^4.60.0
         version: 4.60.0
@@ -688,13 +688,13 @@ importers:
         version: 22.17.2
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.0.18(vite@6.4.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+        version: 4.0.18(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.0.18(playwright@1.58.0)(vite@6.4.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+        version: 4.0.18(playwright@1.58.0)(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(@vitest/browser@4.0.18(vite@6.4.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
       fast-check:
         specifier: 'catalog:'
         version: 4.5.3
@@ -709,7 +709,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/mcp-iframe:
     dependencies:
@@ -789,7 +789,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
       vitest-browser-react:
         specifier: ^2.0.4
         version: 2.0.4(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18)
@@ -811,10 +811,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
       vite-plugin-monkey:
         specifier: 'catalog:'
-        version: 6.0.1(postcss@8.5.6)(vite@7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 6.0.1(postcss@8.5.6)(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
 
   packages/smart-dom-reader/mcp-server:
     dependencies:
@@ -873,7 +873,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/usewebmcp:
     dependencies:
@@ -919,7 +919,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
       vitest-browser-react:
         specifier: ^2.0.4
         version: 2.0.4(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18)
@@ -938,13 +938,16 @@ importers:
     devDependencies:
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.0.18(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+        version: 4.0.18(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.0.18(playwright@1.58.0)(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+        version: 4.0.18(playwright@1.58.0)(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
+      happy-dom:
+        specifier: ^15.11.7
+        version: 15.11.7
       playwright:
         specifier: 'catalog:'
         version: 1.58.0
@@ -956,7 +959,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/webmcp-ts-sdk:
     dependencies:
@@ -1005,7 +1008,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
 
   skills/webmcp-setup: {}
 
@@ -3688,11 +3691,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm-eabi@4.53.3':
-    resolution: {integrity: sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.57.1':
     resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
     cpu: [arm]
@@ -3700,11 +3698,6 @@ packages:
 
   '@rollup/rollup-android-arm64@4.46.2':
     resolution: {integrity: sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.53.3':
-    resolution: {integrity: sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==}
     cpu: [arm64]
     os: [android]
 
@@ -3718,11 +3711,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-arm64@4.53.3':
-    resolution: {integrity: sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.57.1':
     resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
     cpu: [arm64]
@@ -3730,11 +3718,6 @@ packages:
 
   '@rollup/rollup-darwin-x64@4.46.2':
     resolution: {integrity: sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.53.3':
-    resolution: {integrity: sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -3748,11 +3731,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-arm64@4.53.3':
-    resolution: {integrity: sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.57.1':
     resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
     cpu: [arm64]
@@ -3760,11 +3738,6 @@ packages:
 
   '@rollup/rollup-freebsd-x64@4.46.2':
     resolution: {integrity: sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.53.3':
-    resolution: {integrity: sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==}
     cpu: [x64]
     os: [freebsd]
 
@@ -3778,11 +3751,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.3':
-    resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
@@ -3790,11 +3758,6 @@ packages:
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.53.3':
-    resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
 
@@ -3808,11 +3771,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.53.3':
-    resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
@@ -3823,19 +3781,9 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.53.3':
-    resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loong64-gnu@4.53.3':
-    resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
-    cpu: [loong64]
     os: [linux]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
@@ -3858,11 +3806,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.53.3':
-    resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
-    cpu: [ppc64]
-    os: [linux]
-
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
@@ -3878,11 +3821,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.3':
-    resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
-    cpu: [riscv64]
-    os: [linux]
-
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
@@ -3890,11 +3828,6 @@ packages:
 
   '@rollup/rollup-linux-riscv64-musl@4.46.2':
     resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-musl@4.53.3':
-    resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
 
@@ -3908,11 +3841,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.53.3':
-    resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
-    cpu: [s390x]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
@@ -3920,11 +3848,6 @@ packages:
 
   '@rollup/rollup-linux-x64-gnu@4.46.2':
     resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-gnu@4.53.3':
-    resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
 
@@ -3938,11 +3861,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.53.3':
-    resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
@@ -3953,11 +3871,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.53.3':
-    resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@rollup/rollup-openharmony-arm64@4.57.1':
     resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
     cpu: [arm64]
@@ -3965,11 +3878,6 @@ packages:
 
   '@rollup/rollup-win32-arm64-msvc@4.46.2':
     resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-arm64-msvc@4.53.3':
-    resolution: {integrity: sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==}
     cpu: [arm64]
     os: [win32]
 
@@ -3983,19 +3891,9 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.53.3':
-    resolution: {integrity: sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.57.1':
     resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
     cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.53.3':
-    resolution: {integrity: sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==}
-    cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-gnu@4.57.1':
@@ -4005,11 +3903,6 @@ packages:
 
   '@rollup/rollup-win32-x64-msvc@4.46.2':
     resolution: {integrity: sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.53.3':
-    resolution: {integrity: sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==}
     cpu: [x64]
     os: [win32]
 
@@ -4921,6 +4814,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   beasties@0.3.5:
     resolution: {integrity: sha512-NaWu+f4YrJxEttJSm16AzMIFtVldCvaJ68b1L098KpqXmxt9xOLtKoLkKxb8ekhOrLqEJAbvT6n6SEvB/sac7A==}
@@ -5996,6 +5890,10 @@ packages:
   h3@1.15.5:
     resolution: {integrity: sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==}
 
+  happy-dom@15.11.7:
+    resolution: {integrity: sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==}
+    engines: {node: '>=18.0.0'}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -6134,9 +6032,6 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
-
-  import-meta-resolve@4.1.0:
-    resolution: {integrity: sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -7704,11 +7599,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rollup@4.53.3:
-    resolution: {integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.57.1:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -8594,46 +8484,6 @@ packages:
       yaml:
         optional: true
 
-  vite@7.1.2:
-    resolution: {integrity: sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@7.3.0:
     resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -8800,10 +8650,18 @@ packages:
   webdriver-bidi-protocol@0.4.0:
     resolution: {integrity: sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -9161,7 +9019,7 @@ snapshots:
       lmdb: 3.4.4
       postcss: 8.5.6
       tailwindcss: 4.1.18
-      vitest: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -9710,12 +9568,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260120.0
 
-  '@cloudflare/vite-plugin@1.21.2(vite@7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(workerd@1.20260120.0)(wrangler@4.60.0)':
+  '@cloudflare/vite-plugin@1.21.2(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(workerd@1.20260120.0)(wrangler@4.60.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.11.0(unenv@2.0.0-rc.24)(workerd@1.20260120.0)
       miniflare: 4.20260120.0
       unenv: 2.0.0-rc.24
-      vite: 7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
       wrangler: 4.60.0
       ws: 8.18.0
     transitivePeerDependencies:
@@ -9759,7 +9617,7 @@ snapshots:
   '@commitlint/config-validator@19.8.1':
     dependencies:
       '@commitlint/types': 19.8.1
-      ajv: 8.17.1
+      ajv: 8.18.0
 
   '@commitlint/ensure@19.8.1':
     dependencies:
@@ -9826,7 +9684,7 @@ snapshots:
       '@commitlint/config-validator': 19.8.1
       '@commitlint/types': 19.8.1
       global-directory: 4.0.1
-      import-meta-resolve: 4.1.0
+      import-meta-resolve: 4.2.0
       lodash.mergewith: 4.6.2
       resolve-from: 5.0.0
 
@@ -11519,16 +11377,10 @@ snapshots:
   '@rollup/rollup-android-arm-eabi@4.46.2':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.53.3':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.57.1':
     optional: true
 
   '@rollup/rollup-android-arm64@4.46.2':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.53.3':
     optional: true
 
   '@rollup/rollup-android-arm64@4.57.1':
@@ -11537,16 +11389,10 @@ snapshots:
   '@rollup/rollup-darwin-arm64@4.46.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.53.3':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.57.1':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.46.2':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.53.3':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.57.1':
@@ -11555,16 +11401,10 @@ snapshots:
   '@rollup/rollup-freebsd-arm64@4.46.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.53.3':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.57.1':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.46.2':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.53.3':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.57.1':
@@ -11573,16 +11413,10 @@ snapshots:
   '@rollup/rollup-linux-arm-gnueabihf@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.3':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
@@ -11591,22 +11425,13 @@ snapshots:
   '@rollup/rollup-linux-arm64-gnu@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.53.3':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.53.3':
-    optional: true
-
   '@rollup/rollup-linux-arm64-musl@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-gnu@4.53.3':
     optional: true
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
@@ -11621,9 +11446,6 @@ snapshots:
   '@rollup/rollup-linux-ppc64-gnu@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.53.3':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     optional: true
 
@@ -11633,16 +11455,10 @@ snapshots:
   '@rollup/rollup-linux-riscv64-gnu@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.3':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.46.2':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.53.3':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
@@ -11651,16 +11467,10 @@ snapshots:
   '@rollup/rollup-linux-s390x-gnu@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.53.3':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.46.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.53.3':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
@@ -11669,16 +11479,10 @@ snapshots:
   '@rollup/rollup-linux-x64-musl@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.53.3':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.57.1':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.57.1':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.53.3':
     optional: true
 
   '@rollup/rollup-openharmony-arm64@4.57.1':
@@ -11687,31 +11491,19 @@ snapshots:
   '@rollup/rollup-win32-arm64-msvc@4.46.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.53.3':
-    optional: true
-
   '@rollup/rollup-win32-arm64-msvc@4.57.1':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.46.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.53.3':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.57.1':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.53.3':
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.57.1':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.46.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.53.3':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.57.1':
@@ -11909,12 +11701,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))':
+  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -12282,7 +12074,7 @@ snapshots:
     dependencies:
       vite: 7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
 
-  '@vitejs/plugin-react@4.7.0(vite@7.1.2(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -12290,11 +12082,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.2(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.1.0(vite@7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vitejs/plugin-react@5.1.0(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -12302,7 +12094,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.43
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12324,32 +12116,18 @@ snapshots:
       vite: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
       vue: 3.5.28(typescript@5.9.3)
 
-  '@vitest/browser-playwright@4.0.18(playwright@1.58.0)(vite@6.4.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
+  '@vitest/browser-playwright@4.0.18(playwright@1.58.0)(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(vite@6.4.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/browser': 4.0.18(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
       playwright: 1.58.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
-
-  '@vitest/browser-playwright@4.0.18(playwright@1.58.0)(vite@7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
-    dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(vite@7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
-      playwright: 1.58.0
-      tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
 
   '@vitest/browser-playwright@4.0.18(playwright@1.58.0)(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
     dependencies:
@@ -12357,7 +12135,7 @@ snapshots:
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
       playwright: 1.58.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -12370,47 +12148,29 @@ snapshots:
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
       playwright: 1.58.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.18(vite@6.4.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
     dependencies:
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
       '@vitest/utils': 4.0.18
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
-
-  '@vitest/browser@4.0.18(vite@7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
-    dependencies:
-      '@vitest/mocker': 4.0.18(vite@7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
-      '@vitest/utils': 4.0.18
-      magic-string: 0.30.21
-      pixelmatch: 7.1.0
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
 
   '@vitest/browser@4.0.18(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)':
     dependencies:
@@ -12421,7 +12181,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -12438,7 +12198,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -12446,7 +12206,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@6.4.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -12458,9 +12218,9 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@6.4.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
 
   '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
@@ -12474,7 +12234,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
     optionalDependencies:
       '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
 
@@ -12490,7 +12250,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
     optionalDependencies:
       '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
 
@@ -12518,15 +12278,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
-
-  '@vitest/mocker@4.0.18(vite@7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))':
-    dependencies:
-      '@vitest/spy': 4.0.18
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
-    optional: true
 
   '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -14287,6 +14038,12 @@ snapshots:
       ufo: 1.6.3
       uncrypto: 0.1.3
 
+  happy-dom@15.11.7:
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -14475,8 +14232,6 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-
-  import-meta-resolve@4.1.0: {}
 
   import-meta-resolve@4.2.0: {}
 
@@ -16356,34 +16111,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.46.2
       fsevents: 2.3.3
 
-  rollup@4.53.3:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.53.3
-      '@rollup/rollup-android-arm64': 4.53.3
-      '@rollup/rollup-darwin-arm64': 4.53.3
-      '@rollup/rollup-darwin-x64': 4.53.3
-      '@rollup/rollup-freebsd-arm64': 4.53.3
-      '@rollup/rollup-freebsd-x64': 4.53.3
-      '@rollup/rollup-linux-arm-gnueabihf': 4.53.3
-      '@rollup/rollup-linux-arm-musleabihf': 4.53.3
-      '@rollup/rollup-linux-arm64-gnu': 4.53.3
-      '@rollup/rollup-linux-arm64-musl': 4.53.3
-      '@rollup/rollup-linux-loong64-gnu': 4.53.3
-      '@rollup/rollup-linux-ppc64-gnu': 4.53.3
-      '@rollup/rollup-linux-riscv64-gnu': 4.53.3
-      '@rollup/rollup-linux-riscv64-musl': 4.53.3
-      '@rollup/rollup-linux-s390x-gnu': 4.53.3
-      '@rollup/rollup-linux-x64-gnu': 4.53.3
-      '@rollup/rollup-linux-x64-musl': 4.53.3
-      '@rollup/rollup-openharmony-arm64': 4.53.3
-      '@rollup/rollup-win32-arm64-msvc': 4.53.3
-      '@rollup/rollup-win32-ia32-msvc': 4.53.3
-      '@rollup/rollup-win32-x64-gnu': 4.53.3
-      '@rollup/rollup-win32-x64-msvc': 4.53.3
-      fsevents: 2.3.3
-
   rollup@4.57.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -17046,7 +16773,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.3
       get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
@@ -17349,12 +17076,12 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-monkey@6.0.1(postcss@8.5.6)(vite@7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)):
+  vite-plugin-monkey@6.0.1(postcss@8.5.6)(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)):
     dependencies:
       acorn-walk: 8.3.4
       cross-spawn: 7.0.6
       htmlparser2: 10.1.0
-      import-meta-resolve: 4.1.0
+      import-meta-resolve: 4.2.0
       magic-string: 0.30.21
       mrmime: 2.0.1
       open: 10.2.0
@@ -17362,7 +17089,7 @@ snapshots:
       postcss-url: 10.1.3(postcss@8.5.6)
       systemjs: 6.15.1
     optionalDependencies:
-      vite: 7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - postcss
 
@@ -17400,43 +17127,9 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.1
 
-  vite@7.1.2(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1):
-    dependencies:
-      esbuild: 0.25.9
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.3
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.17.2
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      sass: 1.97.1
-      tsx: 4.21.0
-      yaml: 2.8.1
-
-  vite@7.1.2(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1):
-    dependencies:
-      esbuild: 0.25.9
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.3
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.9.2
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      sass: 1.97.1
-      tsx: 4.21.0
-      yaml: 2.8.1
-
   vite@7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -17453,7 +17146,7 @@ snapshots:
 
   vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -17467,11 +17160,10 @@ snapshots:
       sass: 1.97.1
       tsx: 4.21.0
       yaml: 2.8.1
-    optional: true
 
   vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -17498,12 +17190,12 @@ snapshots:
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vitest: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1)
     optionalDependencies:
       '@types/react': 19.2.9
       '@types/react-dom': 19.2.3(@types/react@19.2.9)
 
-  vitest@4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1):
+  vitest@4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -17527,7 +17219,8 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.17.2
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.0)(vite@6.4.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(playwright@1.58.0)(vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+      happy-dom: 15.11.7
     transitivePeerDependencies:
       - jiti
       - less
@@ -17541,7 +17234,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1):
+  vitest@4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -17565,7 +17258,8 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.9.2
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.0)(vite@7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(playwright@1.58.0)(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.18)
+      happy-dom: 15.11.7
     transitivePeerDependencies:
       - jiti
       - less
@@ -17609,9 +17303,13 @@ snapshots:
 
   webdriver-bidi-protocol@0.4.0: {}
 
+  webidl-conversions@7.0.0: {}
+
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@4.0.0: {}
 


### PR DESCRIPTION
### Motivation

- Make tool return handling more flexible by accepting raw return values and normalizing them into MCP `ToolResponse` shapes for runtime and SDK integrations.
- Allow input schemas that omit the root `type` to be treated as object schemas for better ergonomics and inference parity.
- Improve annotation handling and browser/test harness setup to support string-boolean annotations and DOM-based tests.

### Description

- Implemented runtime normalization of tool results with `normalizeToolResponse`, `toStructuredContent`, and helpers in `@mcp-b/webmcp-polyfill` to wrap raw returns into `content`/`structuredContent` and to avoid structuredContent for non-JSON-safe objects. (changes in `packages/webmcp-polyfill/src/index.ts` and tests)
- Coerce string boolean annotation values (`'true'`/`'false'`) into real booleans during tool registration in the polyfill. (polyfill normalization in `normalizeToolDescriptor`)
- Default input schemas that omit `type` to an object schema at runtime in both the polyfill and the TS SDK, and update schema normalization/validation accordingly. (polyfill and `webmcp-ts-sdk` changes)
- Broadened types in `@mcp-b/webmcp-types` so `InputSchema.type` is optional and tool execute/result generics accept raw/unknown returns, and updated JSON-schema inference logic to treat omitted `type` as `object`. (changes across `webmcp-types` files)
- Updated browser/server SDK to normalize tool execution results from tool handlers before returning to parent protocol, including helpers duplicated from the polyfill. (changes in `packages/webmcp-ts-sdk/src/browser-server.ts`)
- Added `happy-dom` as a test environment dependency and switched the polyfill unit test to the `happy-dom` Vitest environment, plus multiple test updates to assert the new behavior and guard against `null`/`undefined` parsing. (changes in `packages/webmcp-polyfill/package.json` and `src/index.test.ts`)
- Minor typings and declaration updates: changed `chrome` declaration to `unknown` and updated lockfile/package snapshots to reflect dependency updates (vite/esbuild etc.). (changes in `chrome-typecheck.d.ts` and `pnpm-lock.yaml`)

### Testing

- Ran unit tests for the polyfill and types with Vitest (`vitest run`) and updated browser tests with the `happy-dom` environment (`// @vitest-environment happy-dom`); the modified test suite for `@mcp-b/webmcp-polyfill` executed the new cases for schema defaults, annotation coercion, raw returns, and malformed `isError` payloads and they passed.
- Ran integration tests exercising `BrowserMcpServer`/registration paths (tests updated to expect normalized `ToolResponse`) and they passed under the updated normalization behavior.
- Performed a workspace package install/lock update resulting in `pnpm-lock.yaml` changes and dependency bumps; local test runs succeeded after the lockfile update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a08964697c832b9299bdd2011fb5df)