### PR TITLE
perf(agent-skills): optimize patch and diff hot paths

### DIFF
--- a/packages/agent-skills/src/disclosure.ts
+++ b/packages/agent-skills/src/disclosure.ts
@@ -92,7 +92,13 @@ export function handleSkillRead(
   skills: ReadonlyArray<ResolvedSkill>,
   args: SkillReadArgs
 ): SkillReadResult | SkillReadError {
-  const skill = skills.find((candidate) => candidate.name === args.name);
+  let skill: ResolvedSkill | undefined;
+  for (const candidate of skills) {
+    if (candidate.name === args.name) {
+      skill = candidate;
+      break;
+    }
+  }
   if (!skill) {
     return {
       ok: false,
@@ -108,7 +114,13 @@ export function handleSkillRead(
     };
   }
 
-  const resource = skill.resources.find((candidate) => candidate.name === args.resource);
+  let resource: SkillResource | undefined;
+  for (const candidate of skill.resources) {
+    if (candidate.name === args.resource) {
+      resource = candidate;
+      break;
+    }
+  }
   if (!resource) {
     return {
       ok: false,

--- a/packages/agent-skills/src/parser.ts
+++ b/packages/agent-skills/src/parser.ts
@@ -37,7 +37,6 @@ const CHAR_OPEN_PAREN = '(';
 const CHAR_CLOSE_PAREN = ')';
 const CHAR_NEWLINE = '\n';
 const URL_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
-const RESOURCE_URL_PARTS_SPLIT_LIMIT = 1;
 
 /**
  * Checks whether a value is a non-array object record.
@@ -131,7 +130,21 @@ const normalizeResourcePath = (path: string): string | null => {
     return null;
   }
 
-  const normalized = path.split(/[?#]/, RESOURCE_URL_PARTS_SPLIT_LIMIT)[0].replace(/^(\.\/)+/, '');
+  let cutoff = path.length;
+  const queryIndex = path.indexOf('?');
+  if (queryIndex !== -1 && queryIndex < cutoff) {
+    cutoff = queryIndex;
+  }
+  const hashIndex = path.indexOf('#');
+  if (hashIndex !== -1 && hashIndex < cutoff) {
+    cutoff = hashIndex;
+  }
+
+  let normalized = path.slice(0, cutoff);
+  while (normalized.startsWith('./')) {
+    normalized = normalized.slice(2);
+  }
+
   if (!normalized || normalized.includes('\\')) {
     return null;
   }
@@ -279,9 +292,13 @@ const extractMetadataStringMap = (document: Document.Parsed): SkillMetadataMap |
     return null;
   }
 
-  const metadataPair = root.items.find((pair) => {
-    return isScalarNode(pair.key) && pair.key.value === FIELD_METADATA;
-  });
+  let metadataPair: (typeof root.items)[number] | undefined;
+  for (const pair of root.items) {
+    if (isScalarNode(pair.key) && pair.key.value === FIELD_METADATA) {
+      metadataPair = pair;
+      break;
+    }
+  }
 
   if (!metadataPair || !isMapNode(metadataPair.value)) {
     return null;
@@ -573,20 +590,16 @@ export function parseFrontmatter<TMetadata extends SkillMetadataMap = SkillMetad
     throw new ParseError('SKILL.md must start with YAML frontmatter (---)');
   }
 
-  const firstDelimiter = normalizedContent.indexOf(FRONTMATTER_DELIMITER);
   const secondDelimiter = normalizedContent.indexOf(
     FRONTMATTER_DELIMITER,
-    firstDelimiter + FRONTMATTER_DELIMITER_LENGTH
+    FRONTMATTER_DELIMITER_LENGTH
   );
 
   if (secondDelimiter === -1) {
     throw new ParseError('SKILL.md frontmatter not properly closed with ---');
   }
 
-  const frontmatterStr = normalizedContent.substring(
-    firstDelimiter + FRONTMATTER_DELIMITER_LENGTH,
-    secondDelimiter
-  );
+  const frontmatterStr = normalizedContent.substring(FRONTMATTER_DELIMITER_LENGTH, secondDelimiter);
   const body = normalizedContent.substring(secondDelimiter + FRONTMATTER_DELIMITER_LENGTH).trim();
 
   const document = YAML.parseDocument(frontmatterStr, { keepSourceTokens: true });
@@ -629,11 +642,7 @@ export function extractBody(content: SkillContent): SkillBody {
     return content.trim();
   }
 
-  const firstDelimiter = content.indexOf(FRONTMATTER_DELIMITER);
-  const secondDelimiter = content.indexOf(
-    FRONTMATTER_DELIMITER,
-    firstDelimiter + FRONTMATTER_DELIMITER_LENGTH
-  );
+  const secondDelimiter = content.indexOf(FRONTMATTER_DELIMITER, FRONTMATTER_DELIMITER_LENGTH);
 
   if (secondDelimiter === -1) {
     return content.trim();

--- a/packages/agent-skills/src/patch.ts
+++ b/packages/agent-skills/src/patch.ts
@@ -577,6 +577,50 @@ const findMatches = (content: SkillContent, target: string): number[] => {
   return matches;
 };
 
+const applyTextReplacementAtMatches = (
+  content: SkillContent,
+  matches: ReadonlyArray<number>,
+  targetLength: number,
+  replacement: string
+): SkillContent => {
+  if (matches.length === 0) {
+    return content;
+  }
+
+  const pieces: string[] = [];
+  let cursor = 0;
+  for (const matchIndex of matches) {
+    pieces.push(content.slice(cursor, matchIndex));
+    pieces.push(replacement);
+    cursor = matchIndex + targetLength;
+  }
+  pieces.push(content.slice(cursor));
+  return pieces.join('');
+};
+
+const applyTextInsertAtMatches = (
+  content: SkillContent,
+  matches: ReadonlyArray<number>,
+  anchorLength: number,
+  text: string,
+  position: 'before' | 'after'
+): SkillContent => {
+  if (matches.length === 0) {
+    return content;
+  }
+
+  const pieces: string[] = [];
+  let cursor = 0;
+  for (const matchIndex of matches) {
+    const insertIndex = position === 'before' ? matchIndex : matchIndex + anchorLength;
+    pieces.push(content.slice(cursor, insertIndex));
+    pieces.push(text);
+    cursor = insertIndex;
+  }
+  pieces.push(content.slice(cursor));
+  return pieces.join('');
+};
+
 const resolveMatchIssue = (
   matchCount: number,
   expectedMatches: number,
@@ -672,13 +716,7 @@ const applyReplace = (
   if (issue) {
     return issue;
   }
-
-  let nextContent = content;
-  const sortedMatches = [...matches].sort((a, b) => b - a);
-  for (const index of sortedMatches) {
-    nextContent = nextContent.slice(0, index) + after + nextContent.slice(index + before.length);
-  }
-
+  const nextContent = applyTextReplacementAtMatches(content, matches, before.length, after);
   return { content: nextContent, matchCount: matches.length };
 };
 
@@ -703,13 +741,7 @@ const applyDelete = (
   if (issue) {
     return issue;
   }
-
-  let nextContent = content;
-  const sortedMatches = [...matches].sort((a, b) => b - a);
-  for (const index of sortedMatches) {
-    nextContent = nextContent.slice(0, index) + nextContent.slice(index + before.length);
-  }
-
+  const nextContent = applyTextReplacementAtMatches(content, matches, before.length, '');
   return { content: nextContent, matchCount: matches.length };
 };
 
@@ -736,14 +768,7 @@ const applyInsert = (
   if (issue) {
     return issue;
   }
-
-  const sortedMatches = [...matches].sort((a, b) => b - a);
-  let nextContent = content;
-  for (const index of sortedMatches) {
-    const insertIndex = position === 'before' ? index : index + anchor.length;
-    nextContent = nextContent.slice(0, insertIndex) + text + nextContent.slice(insertIndex);
-  }
-
+  const nextContent = applyTextInsertAtMatches(content, matches, anchor.length, text, position);
   return { content: nextContent, matchCount: matches.length };
 };
 
@@ -901,11 +926,12 @@ export function applySkillPatch(
   return { ok: true, content: nextContent, appliedOperations };
 }
 
-const computeDiffMatrix = (base: string[], updated: string[]): number[][] => {
+const computeDiffMatrix = (base: string[], updated: string[]): Uint32Array[] => {
   const baseLen = base.length;
   const updatedLen = updated.length;
-  const matrix: number[][] = Array.from({ length: baseLen + 1 }, () =>
-    Array(updatedLen + 1).fill(0)
+  const matrix: Uint32Array[] = Array.from(
+    { length: baseLen + 1 },
+    () => new Uint32Array(updatedLen + 1)
   );
 
   for (let i = 1; i <= baseLen; i += 1) {
@@ -919,6 +945,53 @@ const computeDiffMatrix = (base: string[], updated: string[]): number[][] => {
   }
 
   return matrix;
+};
+
+const appendDiffSegment = (
+  segments: SkillDiffSegment[],
+  type: SkillDiffSegmentType,
+  lines: string[]
+): void => {
+  if (lines.length === 0) {
+    return;
+  }
+  const last = segments[segments.length - 1];
+  if (last && last.type === type) {
+    last.lines.push(...lines);
+    return;
+  }
+  segments.push({ type, lines: [...lines] });
+};
+
+const computeCommonPrefixLength = (base: string[], updated: string[]): number => {
+  const limit = Math.min(base.length, updated.length);
+  let index = 0;
+  while (index < limit && base[index] === updated[index]) {
+    index += 1;
+  }
+  return index;
+};
+
+const computeCommonSuffixLength = (
+  base: string[],
+  updated: string[],
+  prefixLength: number
+): number => {
+  let baseIndex = base.length - 1;
+  let updatedIndex = updated.length - 1;
+  let suffixLength = 0;
+
+  while (
+    baseIndex >= prefixLength &&
+    updatedIndex >= prefixLength &&
+    base[baseIndex] === updated[updatedIndex]
+  ) {
+    suffixLength += 1;
+    baseIndex -= 1;
+    updatedIndex -= 1;
+  }
+
+  return suffixLength;
 };
 
 /**
@@ -936,40 +1009,48 @@ const computeDiffMatrix = (base: string[], updated: string[]): number[][] => {
 export function diffSkillContent(base: SkillContent, updated: SkillContent): SkillLineDiff {
   const baseLines = base.split('\n');
   const updatedLines = updated.split('\n');
-  const matrix = computeDiffMatrix(baseLines, updatedLines);
-
   const segments: SkillDiffSegment[] = [];
+  const prefixLength = computeCommonPrefixLength(baseLines, updatedLines);
+  const suffixLength = computeCommonSuffixLength(baseLines, updatedLines, prefixLength);
 
-  let i = baseLines.length;
-  let j = updatedLines.length;
-  const reversed: SkillDiffSegment[] = [];
+  const baseMiddle = baseLines.slice(prefixLength, baseLines.length - suffixLength);
+  const updatedMiddle = updatedLines.slice(prefixLength, updatedLines.length - suffixLength);
 
-  while (i > 0 || j > 0) {
-    if (i > 0 && j > 0 && baseLines[i - 1] === updatedLines[j - 1]) {
-      reversed.push({ type: 'equal', lines: [baseLines[i - 1]] });
+  appendDiffSegment(segments, 'equal', baseLines.slice(0, prefixLength));
+
+  if (baseMiddle.length > 0 || updatedMiddle.length > 0) {
+    const matrix = computeDiffMatrix(baseMiddle, updatedMiddle);
+    let i = baseMiddle.length;
+    let j = updatedMiddle.length;
+    const reversed: SkillDiffSegment[] = [];
+
+    while (i > 0 || j > 0) {
+      if (i > 0 && j > 0 && baseMiddle[i - 1] === updatedMiddle[j - 1]) {
+        reversed.push({ type: 'equal', lines: [baseMiddle[i - 1]] });
+        i -= 1;
+        j -= 1;
+        continue;
+      }
+
+      if (j > 0 && (i === 0 || matrix[i][j - 1] >= matrix[i - 1][j])) {
+        reversed.push({ type: 'insert', lines: [updatedMiddle[j - 1]] });
+        j -= 1;
+        continue;
+      }
+
+      reversed.push({ type: 'delete', lines: [baseMiddle[i - 1]] });
       i -= 1;
-      j -= 1;
-      continue;
     }
 
-    if (j > 0 && (i === 0 || matrix[i][j - 1] >= matrix[i - 1][j])) {
-      reversed.push({ type: 'insert', lines: [updatedLines[j - 1]] });
-      j -= 1;
-      continue;
+    reversed.reverse();
+    for (const segment of reversed) {
+      appendDiffSegment(segments, segment.type, segment.lines);
     }
-
-    reversed.push({ type: 'delete', lines: [baseLines[i - 1]] });
-    i -= 1;
   }
 
-  reversed.reverse().forEach((segment) => {
-    const last = segments[segments.length - 1];
-    if (last && last.type === segment.type) {
-      last.lines.push(...segment.lines);
-    } else {
-      segments.push({ type: segment.type, lines: [...segment.lines] });
-    }
-  });
+  if (suffixLength > 0) {
+    appendDiffSegment(segments, 'equal', baseLines.slice(baseLines.length - suffixLength));
+  }
 
   return {
     baseLineCount: baseLines.length,

--- a/packages/agent-skills/src/prompt.ts
+++ b/packages/agent-skills/src/prompt.ts
@@ -10,6 +10,14 @@ const XML_TAG_DESCRIPTION = 'description';
 const XML_TAG_LOCATION = 'location';
 const XML_TAG_RESOURCES = 'resources';
 const DISCLOSURE_INSTRUCTION_LINE_1 = 'Skills provide context for using tools effectively.';
+const XML_ESCAPE_PATTERN = /[&<>"']/g;
+const XML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#x27;',
+};
 
 /**
  * Prompt-ready skill metadata.
@@ -59,12 +67,7 @@ const pushXmlNode = (lines: string[], tag: string, value: string): void => {
 };
 
 const escapeXml = (value: string): string => {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;');
+  return value.replace(XML_ESCAPE_PATTERN, (char) => XML_ESCAPE_MAP[char] ?? char);
 };
 
 const appendSkill = (

--- a/packages/agent-skills/src/validator.ts
+++ b/packages/agent-skills/src/validator.ts
@@ -64,6 +64,7 @@ export const MAX_COMPATIBILITY_LENGTH = 500;
  * @see https://github.com/agentskills/agentskills/blob/main/skills-ref/src/skills_ref/validator.py
  */
 export const ALLOWED_FIELDS = new Set<string>(SKILL_FRONTMATTER_KEYS);
+const SKILL_NAME_CHARACTER_PATTERN = /^[\p{L}\p{N}-]+$/u;
 
 /**
  * Renders a deterministic list of frontmatter fields for error messages.
@@ -75,6 +76,7 @@ const formatFieldList = (fields: Iterable<string>): string => {
   const items = [...fields].sort();
   return `[${items.map((field) => `'${field}'`).join(', ')}]`;
 };
+const ALLOWED_FIELDS_RENDERED_LIST = formatFieldList(ALLOWED_FIELDS);
 
 /**
  * Validates frontmatter keys against the spec allowlist.
@@ -89,7 +91,7 @@ const validateFrontmatterFields = (metadata: object): string[] => {
   if (extraFields.length > 0) {
     errors.push(
       `Unexpected fields in frontmatter: ${extraFields.sort().join(', ')}. ` +
-        `Only ${formatFieldList(ALLOWED_FIELDS)} are allowed.`
+        `Only ${ALLOWED_FIELDS_RENDERED_LIST} are allowed.`
     );
   }
 
@@ -138,11 +140,7 @@ function validateName(name: SkillProperties['name']): string[] {
     errors.push('Skill name cannot contain consecutive hyphens');
   }
 
-  const isValid = [...normalized].every((c) => {
-    return /[\p{L}\p{N}-]/u.test(c);
-  });
-
-  if (!isValid) {
+  if (!SKILL_NAME_CHARACTER_PATTERN.test(normalized)) {
     errors.push(
       `Skill name '${normalized}' contains invalid characters. Only letters, digits, and hyphens are allowed.`
     );


### PR DESCRIPTION
## Summary
- optimize `applySkillPatch` replace/delete/insert operations to use single-pass chunk assembly instead of repeated full-string rewrites
- optimize `diffSkillContent` by trimming common prefix/suffix before LCS matrix computation
- switch diff matrix rows to `Uint32Array` to reduce memory overhead
- include small parser/validator/prompt/disclosure hot-path micro-optimizations

## Benchmarks (old vs new)
- `applySkillPatch replace-many`: `331.62ms -> 8.94ms` (~37.10x)
- `applySkillPatch insert-many`: `358.78ms -> 8.75ms` (~41.01x)
- `diffSkillContent` (prefix/suffix-heavy): `729.32ms -> 2.47ms` (~295.76x)

## Validation
- `pnpm --filter agent-skills-ts-sdk test` (281 tests, all passing)
