### PR TITLE
fix(webmcp-types): accept raw return values in registerTool overloads

### DIFF
--- a/packages/webmcp-types/src/global-register-tools.test-d.ts
+++ b/packages/webmcp-types/src/global-register-tools.test-d.ts
@@ -295,3 +295,44 @@ test('global registerTool implementation-first examples compile', () => {
 
   navigator.modelContext.unregisterTool('feature_toggle_summary');
 });
+
+test('global registerTool accepts widened-schema tools returning raw values', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  navigator.modelContext.registerTool({
+    name: 'raw_string_result',
+    description: 'Widened schema tool returning raw string',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+      },
+      required: ['query'],
+    },
+    async execute(args) {
+      return `Results for ${args.query}`;
+    },
+  });
+
+  navigator.modelContext.registerTool({
+    name: 'raw_array_result',
+    description: 'Widened schema tool returning raw array',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    execute() {
+      return [{ id: 1, name: 'item' }];
+    },
+  });
+
+  navigator.modelContext.registerTool({
+    name: 'raw_no_schema_string',
+    description: 'No-schema tool returning raw string',
+    execute() {
+      return 'pong';
+    },
+  });
+});

--- a/packages/webmcp-types/src/model-context.ts
+++ b/packages/webmcp-types/src/model-context.ts
@@ -1,6 +1,11 @@
 import type { InputSchema, ToolResponse } from './common.js';
 import type { JsonSchemaForInference, JsonSchemaObject } from './json-schema.js';
-import type { ToolDescriptor, ToolDescriptorFromSchema, ToolListItem } from './tool.js';
+import type {
+  ToolDescriptor,
+  ToolDescriptorFromSchema,
+  ToolListItem,
+  ToolRawResult,
+} from './tool.js';
 
 // ============================================================================
 // Model Context Input
@@ -205,10 +210,9 @@ export interface ModelContextCore {
   registerTool<
     TInputSchema extends InputSchema,
     TArgs extends Record<string, unknown> = Record<string, unknown>,
-    TResult = unknown,
     TName extends string = string,
   >(
-    tool: ToolDescriptor<TArgs, TResult, TName> & {
+    tool: ToolDescriptor<TArgs, ToolRawResult, TName> & {
       inputSchema: TInputSchema;
     } & (TInputSchema extends InputSchema
         ? string extends TInputSchema['type']
@@ -223,10 +227,9 @@ export interface ModelContextCore {
    */
   registerTool<
     TArgs extends Record<string, unknown> = Record<string, unknown>,
-    TResult = unknown,
     TName extends string = string,
   >(
-    tool: Omit<ToolDescriptor<TArgs, TResult, TName>, 'inputSchema'> & {
+    tool: Omit<ToolDescriptor<TArgs, ToolRawResult, TName>, 'inputSchema'> & {
       inputSchema?: undefined;
     }
   ): void;


### PR DESCRIPTION
## Summary
- Fix `registerTool` overloads 2 (widened schemas) and 3 (no schema) to accept raw execute return values like `string`, `Array<T>`, etc.
- TypeScript cannot infer `TResult` through the conditional `ToolExecuteResult<TResult>` type, causing false type errors when `execute` returns anything other than `CallToolResult`
- Fix: pin `TResult` to `ToolRawResult` in these overloads since inference was already broken — overload 1 (`as const` schemas) remains fully type-safe

## Test plan
- [x] Added type test covering widened-schema tools returning raw strings, raw arrays, and no-schema tools returning raw strings
- [x] `pnpm build` passes (21/21)
- [x] `pnpm typecheck` passes (30/30)
- [x] `pnpm test:unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)