### PR TITLE
feat(webmcp-types): non-object outputSchema support and type ergonomics tests

### DIFF
--- a/packages/webmcp-types/src/global-register-tools.test-d.ts
+++ b/packages/webmcp-types/src/global-register-tools.test-d.ts
@@ -336,3 +336,263 @@ test('global registerTool accepts widened-schema tools returning raw values', ()
     },
   });
 });
+
+// ============================================================================
+// Non-object outputSchema integration tests
+// ============================================================================
+
+test('global registerTool accepts string outputSchema with raw string return', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  navigator.modelContext.registerTool({
+    name: 'string_output_raw',
+    description: 'Tool with string outputSchema returning raw string',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        message: { type: 'string' },
+      },
+      required: ['message'],
+    } as const satisfies JsonSchemaForInference,
+    outputSchema: {
+      type: 'string',
+      description: 'A status message',
+    } as const satisfies JsonSchemaForInference,
+    execute(args) {
+      return `Processed: ${args.message}`;
+    },
+  });
+});
+
+test('global registerTool accepts string outputSchema with CallToolResult return', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  navigator.modelContext.registerTool({
+    name: 'string_output_wrapped',
+    description: 'Tool with string outputSchema returning CallToolResult',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        message: { type: 'string' },
+      },
+      required: ['message'],
+    } as const satisfies JsonSchemaForInference,
+    outputSchema: {
+      type: 'string',
+      description: 'A status message',
+    } as const satisfies JsonSchemaForInference,
+    execute(args) {
+      return {
+        content: [{ type: 'text', text: args.message }],
+      };
+    },
+  });
+});
+
+test('global registerTool accepts array outputSchema', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  navigator.modelContext.registerTool({
+    name: 'array_output',
+    description: 'Tool with array outputSchema',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    } as const satisfies JsonSchemaForInference,
+    outputSchema: {
+      type: 'array',
+      items: { type: 'string' },
+    } as const satisfies JsonSchemaForInference,
+    execute() {
+      return ['item1', 'item2'];
+    },
+  });
+});
+
+test('global registerTool accepts number outputSchema', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  navigator.modelContext.registerTool({
+    name: 'number_output',
+    description: 'Tool with number outputSchema',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        a: { type: 'number' },
+        b: { type: 'number' },
+      },
+      required: ['a', 'b'],
+    } as const satisfies JsonSchemaForInference,
+    outputSchema: {
+      type: 'number',
+    } as const satisfies JsonSchemaForInference,
+    execute(args) {
+      return args.a + args.b;
+    },
+  });
+});
+
+test('global registerTool accepts boolean outputSchema', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  navigator.modelContext.registerTool({
+    name: 'boolean_output',
+    description: 'Tool with boolean outputSchema',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        value: { type: 'string' },
+      },
+      required: ['value'],
+    } as const satisfies JsonSchemaForInference,
+    outputSchema: {
+      type: 'boolean',
+    } as const satisfies JsonSchemaForInference,
+    execute(args) {
+      return args.value.length > 0;
+    },
+  });
+});
+
+test('global registerTool rejects mismatched return for string outputSchema', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  // @ts-expect-error - execute returns number but outputSchema expects string
+  navigator.modelContext.registerTool({
+    name: 'string_output_mismatch',
+    description: 'Mismatched return type for string outputSchema',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    } as const satisfies JsonSchemaForInference,
+    outputSchema: {
+      type: 'string',
+    } as const satisfies JsonSchemaForInference,
+    execute() {
+      return 42;
+    },
+  });
+});
+
+test('global registerTool rejects mismatched return for number outputSchema', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  // @ts-expect-error - execute returns string but outputSchema expects number
+  navigator.modelContext.registerTool({
+    name: 'number_output_mismatch',
+    description: 'Mismatched return type for number outputSchema',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    } as const satisfies JsonSchemaForInference,
+    outputSchema: {
+      type: 'number',
+    } as const satisfies JsonSchemaForInference,
+    execute() {
+      return 'not a number';
+    },
+  });
+});
+
+// ============================================================================
+// Real-world usage patterns — "don't fight users" contract
+//
+// These tests codify patterns seen in the wild (e.g. Google's react-flightsearch
+// demo) that must always compile. Type inference via `as const satisfies` is an
+// opt-in bonus, not a requirement. The type system should never fight what
+// developers are already doing.
+// ============================================================================
+
+test('global registerTool accepts empty inputSchema {}', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  // inputSchema: {} is common for no-arg tools — must compile
+  navigator.modelContext.registerTool({
+    name: 'empty_schema_tool',
+    description: 'Tool with empty inputSchema object',
+    inputSchema: {},
+    execute() {
+      return { content: [{ type: 'text', text: 'done' }] };
+    },
+  });
+});
+
+test('global registerTool accepts widened primitive outputSchema with raw return', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  // Primitive outputSchema WITHOUT as const satisfies + raw return
+  navigator.modelContext.registerTool({
+    name: 'primitive_output_raw',
+    description: 'Widened primitive outputSchema with raw string return',
+    inputSchema: { type: 'object', properties: {} },
+    outputSchema: { type: 'string' },
+    execute() {
+      return 'done';
+    },
+  });
+});
+
+test('global registerTool accepts full literal schemas with as const satisfies', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  // Full inference path — inputSchema + outputSchema with as const satisfies
+  navigator.modelContext.registerTool({
+    name: 'full_inference',
+    description: 'Fully inferred tool',
+    inputSchema: {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+    } as const satisfies JsonSchemaForInference,
+    outputSchema: {
+      type: 'object',
+      properties: { count: { type: 'integer' } },
+      required: ['count'],
+    } as const satisfies JsonSchemaForInference,
+    execute(args) {
+      const q: string = args.query;
+      void q;
+      return { count: 42 };
+    },
+  });
+});
+
+test('global registerTool accepts literal inputSchema with raw return and no outputSchema', () => {
+  if (!shouldInvokeRegisterTool) {
+    return;
+  }
+
+  // Literal inputSchema for arg inference, but raw return (no outputSchema)
+  navigator.modelContext.registerTool({
+    name: 'inferred_args_raw_return',
+    description: 'Inferred args with raw return',
+    inputSchema: {
+      type: 'object',
+      properties: { id: { type: 'string' } },
+      required: ['id'],
+    } as const satisfies JsonSchemaForInference,
+    async execute(args) {
+      return `Found: ${args.id}`;
+    },
+  });
+});

--- a/packages/webmcp-types/src/json-schema.test-d.ts
+++ b/packages/webmcp-types/src/json-schema.test-d.ts
@@ -428,3 +428,121 @@ test('ModelContext.registerTool keeps execute args unknown for runtime schemas',
     });
   }
 });
+
+// ============================================================================
+// Non-object outputSchema support for ToolDescriptorFromSchema
+// ============================================================================
+
+const stringOutputSchema = {
+  type: 'string',
+  description: 'A status message',
+} as const satisfies JsonSchemaForInference;
+
+const arrayOutputSchema = {
+  type: 'array',
+  items: { type: 'number' },
+} as const satisfies JsonSchemaForInference;
+
+const numberOutputSchema = {
+  type: 'number',
+} as const satisfies JsonSchemaForInference;
+
+test('ToolDescriptorFromSchema infers string return type from string outputSchema', () => {
+  type ExecuteResult = Awaited<
+    ReturnType<ToolDescriptorFromSchema<typeof closedSchema, typeof stringOutputSchema>['execute']>
+  >;
+
+  const rawResult: ExecuteResult = 'success';
+  void rawResult;
+});
+
+test('ToolDescriptorFromSchema infers array return type from array outputSchema', () => {
+  type ExecuteResult = Awaited<
+    ReturnType<ToolDescriptorFromSchema<typeof closedSchema, typeof arrayOutputSchema>['execute']>
+  >;
+
+  const rawResult: ExecuteResult = [1, 2, 3];
+  void rawResult;
+});
+
+test('ToolDescriptorFromSchema infers number return type from number outputSchema', () => {
+  type ExecuteResult = Awaited<
+    ReturnType<ToolDescriptorFromSchema<typeof closedSchema, typeof numberOutputSchema>['execute']>
+  >;
+
+  const rawResult: ExecuteResult = 42;
+  void rawResult;
+});
+
+test('ToolDescriptorFromSchema requires outputSchema when string output generic is provided', () => {
+  // @ts-expect-error - outputSchema is required when output generic parameter is set
+  const tool: ToolDescriptorFromSchema<typeof closedSchema, typeof stringOutputSchema> = {
+    name: 'missing_string_output_schema',
+    description: 'Missing string output schema should fail',
+    inputSchema: closedSchema,
+    execute() {
+      return 'result';
+    },
+  };
+  void tool;
+});
+
+test('ToolDescriptorFromSchema with object outputSchema preserves structuredContent', () => {
+  type ExecuteResult = Awaited<
+    ReturnType<ToolDescriptorFromSchema<typeof closedSchema, typeof outputSchema>['execute']>
+  >;
+
+  // Object outputSchema should allow structuredContent
+  const wrappedResult: ExecuteResult = {
+    content: [{ type: 'text', text: 'ok' }],
+    structuredContent: { total: 1, items: ['a'] },
+  };
+
+  // Object outputSchema should also allow raw return
+  const rawResult: ExecuteResult = { total: 1, items: ['a'] };
+
+  void wrappedResult;
+  void rawResult;
+});
+
+test('ModelContext.registerTool accepts string outputSchema', () => {
+  if (shouldInvokeRegisterTool) {
+    registerTool({
+      name: 'string_output_tool',
+      description: 'Tool with string output schema',
+      inputSchema: closedSchema,
+      outputSchema: stringOutputSchema,
+      execute(args) {
+        return `Results for ${args.query}`;
+      },
+    });
+  }
+});
+
+test('ModelContext.registerTool accepts array outputSchema', () => {
+  if (shouldInvokeRegisterTool) {
+    registerTool({
+      name: 'array_output_tool',
+      description: 'Tool with array output schema',
+      inputSchema: closedSchema,
+      outputSchema: arrayOutputSchema,
+      execute() {
+        return [1, 2, 3];
+      },
+    });
+  }
+});
+
+test('ModelContext.registerTool accepts number outputSchema', () => {
+  if (shouldInvokeRegisterTool) {
+    registerTool({
+      name: 'number_output_tool',
+      description: 'Tool with number output schema',
+      inputSchema: closedSchema,
+      outputSchema: numberOutputSchema,
+      execute() {
+        return 42;
+      },
+    });
+  }
+});

--- a/packages/webmcp-types/src/model-context.ts
+++ b/packages/webmcp-types/src/model-context.ts
@@ -1,5 +1,5 @@
 import type { InputSchema, ToolResponse } from './common.js';
-import type { JsonSchemaForInference, JsonSchemaObject } from './json-schema.js';
+import type { JsonSchemaForInference } from './json-schema.js';
 import type {
   ToolDescriptor,
   ToolDescriptorFromSchema,
@@ -200,7 +200,7 @@ export interface ModelContextCore {
    */
   registerTool<
     TInputSchema extends JsonSchemaForInference,
-    TOutputSchema extends JsonSchemaObject | undefined = undefined,
+    TOutputSchema extends JsonSchemaForInference | undefined = undefined,
     TName extends string = string,
   >(tool: ToolDescriptorFromSchema<TInputSchema, TOutputSchema, TName>): void;
 

--- a/packages/webmcp-types/src/tool.test-d.ts
+++ b/packages/webmcp-types/src/tool.test-d.ts
@@ -12,6 +12,7 @@ import type {
   ModelContextClient,
   ToolAnnotations,
   ToolDescriptor,
+  ToolExecuteResultFromOutputSchema,
   ToolExecutionContext,
   ToolListItem,
   ToolResultFromOutputSchema,
@@ -173,4 +174,60 @@ test('ToolListItem mirrors ToolDescriptor metadata without execute', () => {
 
 test('ToolListItem supports literal tool names via generics', () => {
   expectTypeOf<ToolListItem<'search'>['name']>().toEqualTypeOf<'search'>();
+});
+
+// ============================================================================
+// Non-object outputSchema support
+// ============================================================================
+
+test('ToolResultFromOutputSchema returns plain CallToolResult for string schema', () => {
+  type StringSchema = { type: 'string' };
+  type Result = ToolResultFromOutputSchema<StringSchema>;
+  expectTypeOf<Result>().toEqualTypeOf<CallToolResult>();
+});
+
+test('ToolResultFromOutputSchema returns plain CallToolResult for array schema', () => {
+  type ArraySchema = { type: 'array'; items: { type: 'number' } };
+  type Result = ToolResultFromOutputSchema<ArraySchema>;
+  expectTypeOf<Result>().toEqualTypeOf<CallToolResult>();
+});
+
+test('ToolResultFromOutputSchema returns plain CallToolResult for number schema', () => {
+  type NumberSchema = { type: 'number' };
+  type Result = ToolResultFromOutputSchema<NumberSchema>;
+  expectTypeOf<Result>().toEqualTypeOf<CallToolResult>();
+});
+
+test('ToolResultFromOutputSchema returns plain CallToolResult for boolean schema', () => {
+  type BooleanSchema = { type: 'boolean' };
+  type Result = ToolResultFromOutputSchema<BooleanSchema>;
+  expectTypeOf<Result>().toEqualTypeOf<CallToolResult>();
+});
+
+test('ToolExecuteResultFromOutputSchema allows string return for string schema', () => {
+  type StringSchema = { type: 'string' };
+  type Result = ToolExecuteResultFromOutputSchema<StringSchema>;
+  expectTypeOf<string>().toMatchTypeOf<Result>();
+  expectTypeOf<CallToolResult>().toMatchTypeOf<Result>();
+});
+
+test('ToolExecuteResultFromOutputSchema allows number return for number schema', () => {
+  type NumberSchema = { type: 'number' };
+  type Result = ToolExecuteResultFromOutputSchema<NumberSchema>;
+  expectTypeOf<number>().toMatchTypeOf<Result>();
+  expectTypeOf<CallToolResult>().toMatchTypeOf<Result>();
+});
+
+test('ToolExecuteResultFromOutputSchema allows boolean return for boolean schema', () => {
+  type BooleanSchema = { type: 'boolean' };
+  type Result = ToolExecuteResultFromOutputSchema<BooleanSchema>;
+  expectTypeOf<boolean>().toMatchTypeOf<Result>();
+  expectTypeOf<CallToolResult>().toMatchTypeOf<Result>();
+});
+
+test('ToolExecuteResultFromOutputSchema allows array return for array schema', () => {
+  type ArraySchema = { type: 'array'; items: { type: 'number' } };
+  type Result = ToolExecuteResultFromOutputSchema<ArraySchema>;
+  expectTypeOf<number[]>().toMatchTypeOf<Result>();
+  expectTypeOf<CallToolResult>().toMatchTypeOf<Result>();
 });

--- a/packages/webmcp-types/src/tool.ts
+++ b/packages/webmcp-types/src/tool.ts
@@ -4,7 +4,12 @@ import type {
   ElicitationResult,
   InputSchema,
 } from './common.js';
-import type { InferArgsFromInputSchema, InferJsonSchema, JsonSchemaObject } from './json-schema.js';
+import type {
+  InferArgsFromInputSchema,
+  InferJsonSchema,
+  JsonSchemaForInference,
+  JsonSchemaObject,
+} from './json-schema.js';
 
 // ============================================================================
 // Tool Annotations
@@ -143,7 +148,7 @@ export interface ToolDescriptor<
  * @template TOutputSchema - Optional literal JSON object schema.
  */
 export type ToolResultFromOutputSchema<
-  TOutputSchema extends JsonSchemaObject | undefined = undefined,
+  TOutputSchema extends JsonSchemaForInference | undefined = undefined,
 > = TOutputSchema extends JsonSchemaObject
   ? CallToolResult & { structuredContent?: InferJsonSchema<TOutputSchema> }
   : CallToolResult;
@@ -152,10 +157,12 @@ export type ToolResultFromOutputSchema<
  * Execute result typing derived from an optional output schema.
  */
 export type ToolExecuteResultFromOutputSchema<
-  TOutputSchema extends JsonSchemaObject | undefined = undefined,
+  TOutputSchema extends JsonSchemaForInference | undefined = undefined,
 > = TOutputSchema extends JsonSchemaObject
   ? InferJsonSchema<TOutputSchema> | ToolResultFromOutputSchema<TOutputSchema>
-  : ToolExecuteResult;
+  : TOutputSchema extends JsonSchemaForInference
+    ? InferJsonSchema<TOutputSchema> | CallToolResult
+    : ToolExecuteResult;
 
 /**
  * Tool descriptor whose `execute` args are inferred from a JSON Schema.
@@ -170,7 +177,7 @@ export type ToolExecuteResultFromOutputSchema<
  */
 export type ToolDescriptorFromSchema<
   TInputSchema extends { type?: string | readonly string[] },
-  TOutputSchema extends JsonSchemaObject | undefined = undefined,
+  TOutputSchema extends JsonSchemaForInference | undefined = undefined,
   TName extends string = string,
 > = Omit<
   ToolDescriptor<
@@ -181,7 +188,7 @@ export type ToolDescriptorFromSchema<
   'inputSchema' | 'outputSchema'
 > & {
   inputSchema: TInputSchema;
-} & (TOutputSchema extends JsonSchemaObject
+} & (TOutputSchema extends JsonSchemaForInference
     ? {
         outputSchema: TOutputSchema;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,69 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    '@cfworker/json-schema':
-      specifier: ^4.1.1
-      version: 4.1.1
-    '@composio/json-schema-to-zod':
-      specifier: ^0.1.19
-      version: 0.1.19
-    '@modelcontextprotocol/sdk':
-      specifier: 1.26.0
-      version: 1.26.0
-    '@types/chrome':
-      specifier: ^0.0.326
-      version: 0.0.326
-    '@types/node':
-      specifier: 22.17.2
-      version: 22.17.2
-    '@types/react':
-      specifier: ^19.2.9
-      version: 19.2.9
-    '@types/react-dom':
-      specifier: ^19.1.2
-      version: 19.2.3
-    '@vitest/browser':
-      specifier: ^4.0.18
-      version: 4.0.18
-    '@vitest/browser-playwright':
-      specifier: ^4.0.18
-      version: 4.0.18
-    '@vitest/coverage-v8':
-      specifier: ^4.0.18
-      version: 4.0.18
-    fast-check:
-      specifier: ^4.0.0
-      version: 4.5.3
-    playwright:
-      specifier: ^1.58.0
-      version: 1.58.0
-    react:
-      specifier: ^19.1.0
-      version: 19.2.3
-    react-dom:
-      specifier: ^19.1.0
-      version: 19.2.3
-    tsdown:
-      specifier: ^0.15.10
-      version: 0.15.10
-    typescript:
-      specifier: ^5.8.3
-      version: 5.9.3
-    vite:
-      specifier: ^7.1.11
-      version: 7.3.1
-    vite-plugin-monkey:
-      specifier: ^6.0.1
-      version: 6.0.1
-    vitest:
-      specifier: ^4.0.18
-      version: 4.0.18
-    zod:
-      specifier: 3.25.76
-      version: 3.25.76
-
 overrides:
   ajv@8: '>=8.18.0'
   basic-ftp: '>=5.2.0'
@@ -1080,6 +1017,61 @@ importers:
         version: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(happy-dom@20.7.0)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
 
   skills/webmcp-setup: {}
+
+  webmcp-tools/demos/react-flightsearch:
+    dependencies:
+      '@types/react-router-dom':
+        specifier: ^5.3.3
+        version: 5.3.3
+      rc-slider:
+        specifier: ^11.1.8
+        version: 11.1.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react:
+        specifier: ^19.1.1
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.1.1
+        version: 19.2.3(react@19.2.3)
+      react-router-dom:
+        specifier: ^7.13.0
+        version: 7.13.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.33.0
+        version: 9.39.2
+      '@mcp-b/webmcp-types':
+        specifier: ^2.0.7
+        version: 2.0.7
+      '@types/react':
+        specifier: ^19.1.10
+        version: 19.2.9
+      '@types/react-dom':
+        specifier: ^19.1.7
+        version: 19.2.3(@types/react@19.2.9)
+      '@vitejs/plugin-react-swc':
+        specifier: ^4.0.0
+        version: 4.2.3(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2))
+      eslint:
+        specifier: ^9.33.0
+        version: 9.39.2(jiti@2.6.1)
+      eslint-plugin-react-hooks:
+        specifier: ^5.2.0
+        version: 5.2.0(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.20
+        version: 0.4.26(eslint@9.39.2(jiti@2.6.1))
+      globals:
+        specifier: ^16.3.0
+        version: 16.4.0
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      typescript-eslint:
+        specifier: ^8.39.1
+        version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -2747,6 +2739,9 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@mcp-b/webmcp-types@2.0.7':
+    resolution: {integrity: sha512-6ILuJM0F6YxIcyCDsMHvE6byez8eAr9yyfWvxFqzwVrBGbQoadBoWLBThJ/6lWlXMxxnfiRROzzJsB2bcVUcDg==}
+
   '@modelcontextprotocol/sdk@1.26.0':
     resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
     engines: {node: '>=18'}
@@ -3982,8 +3977,83 @@ packages:
       svelte: '>=5.53.5'
       vite: ^6.3.0 || ^7.0.0
 
+  '@swc/core-darwin-arm64@1.15.17':
+    resolution: {integrity: sha512-eB9qdyt4E60323IS0rgV/rd79DJ+YWSyIKi+sT1dlIgR3ns4xlBiunREM3lVH0FKcUbhttiBvdVubT4QoOuZ+w==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.17':
+    resolution: {integrity: sha512-k1TZARYs8947jJpSioqcPrusz+wEeABF4iiSdwcSyQh2rIUdIEk5FOyaqJASFPJ6dZfx7ZVOyjtDATVAegs2/Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.17':
+    resolution: {integrity: sha512-p6282NQZo5bzx0wphz1ETGjhcRB9CN+/XUAjQwApyoyX9iCloI5IT/RC3vjbflo42g8RPTxUTaItAO0hlLSesQ==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.17':
+    resolution: {integrity: sha512-TGnDS4ejy8y9jqxXqZCyA+DvFc64nXUHS9rxdyeJ9B9uyIdtKVhBrA2xfghYRS/sSPSyHZ0yu89NxBICvONH+A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.15.17':
+    resolution: {integrity: sha512-D0/6Hj4CkgSTTahtlGxv9IDsLTuvQz30mkZEMDp8TqwYhCL8AomznkibwlQU8HtY4q/dqd1OGRPH+FmNb4BBEA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.17':
+    resolution: {integrity: sha512-1s2OFsg6DeRkWU7c+PIfIHZsFCbiZ34akXFHrg7KjpF8zIvpHZNoUUZimoWEwcB6GquXSkAO+1b5KpG5nusTeQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.15.17':
+    resolution: {integrity: sha512-gtxGMGYtRWWmCcgx6xM2Yos43uiE/j8kZwkeL/LNGG9zM0tatd23NsfL9PnQJ45hY7QZ+dx2rM68e4ArgG4kJg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.15.17':
+    resolution: {integrity: sha512-gxi+/Miytez/O9vJ/QiheIivA3oWZjPp9nJu3VmAfLMWUzcZORMwgaI1ygtDTLjz7CzcwlGMJz/Ab66Y5DfNpg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.17':
+    resolution: {integrity: sha512-KUsRqNbTp7SpNK0T9m4+i8GlngzNjwb69a3ttKA6XJ5r6Pewm+NSYji93pNkawXIivbWY2jhvceGMAyd+4hWaQ==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.17':
+    resolution: {integrity: sha512-zqtEGE0/rTKvEC5sOtpANLHeWEPjsTD4/rwpUxo6ymztcLI/Z+L9Wi9xQvIGmLTUih1gvNZcAwROqdfRP3oAWQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.17':
+    resolution: {integrity: sha512-Mu3eOrYlkdQPl7yqotNckitTr6FZ0yd7mlWIBEzK+EGIyybgMENJHmbS2DeA7BMleJiBElP6ke+Nz93pkKmKJw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@swc/types@0.1.25':
+    resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
 
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
@@ -4134,6 +4204,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/history@4.7.11':
+    resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -4173,6 +4246,12 @@ packages:
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
+
+  '@types/react-router-dom@5.3.3':
+    resolution: {integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==}
+
+  '@types/react-router@5.1.20':
+    resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
 
   '@types/react@18.3.27':
     resolution: {integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==}
@@ -4409,6 +4488,12 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0
+
+  '@vitejs/plugin-react-swc@4.2.3':
+    resolution: {integrity: sha512-QIluDil2prhY1gdA3GGwxZzTAmLdi8cQ2CcuMW4PB/Wu4e/1pzqrwhYWVd09LInCRlDUidQjd0B70QWbjWtLxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4 || ^5 || ^6 || ^7
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -4944,6 +5029,9 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
@@ -5502,6 +5590,17 @@ packages:
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
+
+  eslint-plugin-react-hooks@5.2.0:
+    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react-refresh@0.4.26:
+    resolution: {integrity: sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==}
+    peerDependencies:
+      eslint: '>=8.40'
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -7304,6 +7403,19 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  rc-slider@11.1.9:
+    resolution: {integrity: sha512-h8IknhzSh3FEM9u8ivkskh+Ef4Yo4JRIY2nj7MrH6GQmrwV6mcpJf5/4KgH5JaVI1H3E52yCdpOlVyGZIeph5A==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  rc-util@5.44.4:
+    resolution: {integrity: sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -7346,6 +7458,23 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  react-router-dom@7.13.1:
+    resolution: {integrity: sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.13.1:
+    resolution: {integrity: sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
         optional: true
 
   react-style-singleton@2.2.3:
@@ -7599,6 +7728,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -8134,6 +8266,11 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -10356,6 +10493,8 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@mcp-b/webmcp-types@2.0.7': {}
+
   '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.3)
@@ -11491,9 +11630,61 @@ snapshots:
       vite: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
       vitefu: 1.1.1(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2))
 
+  '@swc/core-darwin-arm64@1.15.17':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.17':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.17':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.17':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.17':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.17':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.17':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.17':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.17':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.17':
+    optional: true
+
+  '@swc/core@1.15.17':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.25
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.17
+      '@swc/core-darwin-x64': 1.15.17
+      '@swc/core-linux-arm-gnueabihf': 1.15.17
+      '@swc/core-linux-arm64-gnu': 1.15.17
+      '@swc/core-linux-arm64-musl': 1.15.17
+      '@swc/core-linux-x64-gnu': 1.15.17
+      '@swc/core-linux-x64-musl': 1.15.17
+      '@swc/core-win32-arm64-msvc': 1.15.17
+      '@swc/core-win32-ia32-msvc': 1.15.17
+      '@swc/core-win32-x64-msvc': 1.15.17
+
+  '@swc/counter@0.1.3': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@swc/types@0.1.25':
+    dependencies:
+      '@swc/counter': 0.1.3
 
   '@tailwindcss/node@4.1.18':
     dependencies:
@@ -11634,6 +11825,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/history@4.7.11': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -11670,6 +11863,17 @@ snapshots:
 
   '@types/react-dom@19.2.3(@types/react@19.2.9)':
     dependencies:
+      '@types/react': 19.2.9
+
+  '@types/react-router-dom@5.3.3':
+    dependencies:
+      '@types/history': 4.7.11
+      '@types/react': 19.2.9
+      '@types/react-router': 5.1.20
+
+  '@types/react-router@5.1.20':
+    dependencies:
+      '@types/history': 4.7.11
       '@types/react': 19.2.9
 
   '@types/react@18.3.27':
@@ -11726,6 +11930,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.53.1
+      '@typescript-eslint/type-utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.53.1
+      eslint: 9.39.2(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.4.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -11754,6 +11974,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.53.1
+      '@typescript-eslint/types': 8.53.1
+      '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.53.1
+      debug: 4.4.3
+      eslint: 9.39.2(jiti@2.6.1)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.53.1
@@ -11772,6 +12004,15 @@ snapshots:
       '@typescript-eslint/types': 8.46.2
       debug: 4.4.3
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.53.1(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.53.1(typescript@5.8.3)
+      '@typescript-eslint/types': 8.53.1
+      debug: 4.4.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11798,9 +12039,25 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  '@typescript-eslint/tsconfig-utils@8.53.1(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
   '@typescript-eslint/tsconfig-utils@8.53.1(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.53.1
+      '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      debug: 4.4.3
+      eslint: 9.39.2(jiti@2.6.1)
+      ts-api-utils: 2.4.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/type-utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -11834,6 +12091,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.53.1(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.53.1(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.53.1(typescript@5.8.3)
+      '@typescript-eslint/types': 8.53.1
+      '@typescript-eslint/visitor-keys': 8.53.1
+      debug: 4.4.3
+      minimatch: 10.2.4
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@8.53.1(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.53.1(typescript@5.9.3)
@@ -11846,6 +12118,17 @@ snapshots:
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.53.1
+      '@typescript-eslint/types': 8.53.1
+      '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.8.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11934,6 +12217,14 @@ snapshots:
   '@vitejs/plugin-basic-ssl@2.1.0(vite@7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       vite: 7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitejs/plugin-react-swc@4.2.3(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.2
+      '@swc/core': 1.15.17
+      vite: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -12769,6 +13060,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classnames@2.5.1: {}
+
   cli-boxes@3.0.0: {}
 
   cli-cursor@5.0.0:
@@ -13433,6 +13726,14 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.2(jiti@2.6.1)
+
+  eslint-plugin-react-refresh@0.4.26(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.2(jiti@2.6.1)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -15578,6 +15879,21 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
+  rc-slider@11.1.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@babel/runtime': 7.28.6
+      classnames: 2.5.1
+      rc-util: 5.44.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  rc-util@5.44.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@babel/runtime': 7.28.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-is: 18.3.1
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -15615,6 +15931,20 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.2.9)(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.9
+
+  react-router-dom@7.13.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-router: 7.13.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+
+  react-router@7.13.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.3
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.3(react@19.2.3)
 
   react-style-singleton@2.2.3(@types/react@19.2.9)(react@19.2.3):
     dependencies:
@@ -15999,6 +16329,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -16488,6 +16820,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-api-utils@2.4.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -16535,7 +16871,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.3
       get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
@@ -16628,6 +16964,17 @@ snapshots:
 
   typed-query-selector@2.12.0: {}
 
+  typescript-eslint@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   typescript-eslint@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -16638,6 +16985,8 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+
+  typescript@5.8.3: {}
 
   typescript@5.9.3: {}
 
@@ -16908,7 +17257,7 @@ snapshots:
 
   vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6

--- a/skills/webmcp-setup/SKILL.md
+++ b/skills/webmcp-setup/SKILL.md
@@ -1291,6 +1291,62 @@ mcp__docs__SearchWebMcpDocumentation("tool annotations destructiveHint")
 - Debugging (use Chrome DevTools MCP)
 - Implementation details (use WebMCP Docs MCP)
 
+## Writing Skill Content (`<script type="agent-context">`)
+
+Skills provide domain knowledge that tools can't structurally express — workflow guidance, lookup tables, inference rules, and constraints. Add skill content to your HTML using `<script type="agent-context">` tags.
+
+### Reference Tool Names Directly
+
+Skills should reference tool names explicitly. This helps models map domain knowledge to the correct tool calls:
+
+```html
+<script type="agent-context">
+---
+name: my-app
+description: Manage tasks in my app.
+tools:
+  - create_task
+  - list_tasks
+  - update_task
+---
+Create and manage tasks. Use `create_task` for new items
+and `list_tasks` to browse existing ones.
+
+Resources:
+- [workflow](references/workflow) — Step-by-step tool sequence for common tasks.
+</script>
+```
+
+### Skill Content Guidelines
+
+- **`tools` array in frontmatter** — List every tool the skill relates to. This creates an explicit coupling between the skill and its tools.
+- **Reference tools in resource content** — When describing workflows, parameters, or mappings, name the specific tool (e.g., "Pass the emoji to `add_topping`" not "Add the emoji as a topping").
+- **Don't duplicate tool descriptions** — The tool already describes *what* it does and *how* to call it. The skill describes *when* to use it, *why*, and domain knowledge the tool can't carry (lookup tables, business rules, workflow order).
+- **Resources for progressive disclosure** — Put detailed reference data (code tables, conversion tables, constraint lists) in separate `<script type="agent-context/reference">` tags. This lets smaller models fetch knowledge on demand instead of loading everything upfront.
+
+### Example: Tool Reference in a Resource
+
+```html
+<script type="agent-context/reference" data-skill="my-app" data-name="workflow">
+## Build Order
+
+1. `set_size` — Choose the size first
+2. `set_style` — Pick a style
+3. `add_item` — Add items on top
+4. `share` — Share when done
+
+## Size Inference
+
+When the user mentions a group size, infer the right value for `set_size`:
+
+| Group size | Value       |
+|------------|-------------|
+| 1-2 people | Small       |
+| 3-4 people | Medium      |
+| 5+ people  | Large       |
+</script>
+```
+
 ## Workflow Summary
 
 1. **Understand the app** - What can humans do?


### PR DESCRIPTION
## Summary

- Widen `TOutputSchema` constraint from `JsonSchemaObject` to `JsonSchemaForInference` so primitive outputSchemas (`{ type: "string" }`, `{ type: "number" }`, etc.) work in `registerTool` overload 1
- Add comprehensive type tests codifying real-world usage patterns as a "don't fight users" contract — empty `inputSchema: {}`, widened schemas, raw returns, primitive outputSchemas all compile cleanly
- Update webmcp-setup skill with agent-context documentation

## Test plan

- [x] `pnpm build` passes (all 20 tasks)
- [x] `pnpm typecheck` passes (all 28 tasks, no type errors)
- [x] `pnpm --filter @mcp-b/webmcp-types test` passes (176 tests, 0 failures)
- [x] Conformance tests pass (2/2)
- [x] Verified against react-flightsearch demo using local `file:` path — all patterns typecheck clean
- [x] Verified type mismatch detection: deliberate schema/function mismatches produce correct errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)