### PR TITLE
fix(webmcp-ts-sdk): remove noisy console.warn from toTransportSchema

### DIFF
--- a/packages/webmcp-ts-sdk/src/browser-server.ts
+++ b/packages/webmcp-ts-sdk/src/browser-server.ts
@@ -279,18 +279,12 @@ export class BrowserMcpServer extends BaseMcpServer {
 
     if (Object.keys(jsonSchema).length === 0) {
       if (requireObjectType) {
-        console.warn(
-          '[BrowserMcpServer] toTransportSchema received empty {} schema, normalizing to default object schema'
-        );
         return DEFAULT_INPUT_SCHEMA;
       }
       return jsonSchema as InputSchema;
     }
 
     if (requireObjectType && jsonSchema.type === undefined) {
-      console.warn(
-        '[BrowserMcpServer] toTransportSchema received schema without root type, prepending type:"object"'
-      );
       return { type: 'object', ...jsonSchema } as InputSchema;
     }
 


### PR DESCRIPTION
## Summary
- Remove two console.warn calls from toTransportSchema in BrowserMcpServer
- The normalization of empty {} schemas and schemas without a root type is correct behavior — consumers don't need to be warned about it
- inputSchema: {} is a common valid pattern for tools with no parameters

## Test plan
- [x] pnpm build passes
- [x] pnpm typecheck passes
- [x] pnpm test:unit passes (281 tests)