### PR TITLE
feat: add MCP-style Zod 3/4 compatibility across react-webmcp core surface

### DIFF
--- a/e2e/playwright-validation-matrix.config.ts
+++ b/e2e/playwright-validation-matrix.config.ts
@@ -4,9 +4,9 @@ import { defineConfig, devices } from '@playwright/test';
  * Playwright config for Validation Matrix tests
  *
  * This config starts all test apps and runs validation tests across
- * all Zod 3/build/framework combinations.
+ * all Zod 3/Zod 4/build/framework combinations.
  *
- * Note: Only Zod 3.25+ is supported. Zod 4 is NOT supported.
+ * Supports both Zod 3.25+ and Zod 4.
  */
 export default defineConfig({
   testDir: './tests',
@@ -56,10 +56,26 @@ export default defineConfig({
       stdout: 'ignore',
       stderr: 'pipe',
     },
+    {
+      command: 'pnpm --filter vanilla-iife-zod4-test-app dev',
+      url: 'http://localhost:3012',
+      reuseExistingServer: !process.env.CI,
+      timeout: 60 * 1000,
+      stdout: 'ignore',
+      stderr: 'pipe',
+    },
     // ESM apps (Vite with bundling)
     {
       command: 'pnpm --filter vanilla-esm-zod3-test-app dev',
       url: 'http://localhost:3013',
+      reuseExistingServer: !process.env.CI,
+      timeout: 60 * 1000,
+      stdout: 'ignore',
+      stderr: 'pipe',
+    },
+    {
+      command: 'pnpm --filter vanilla-esm-zod4-test-app dev',
+      url: 'http://localhost:3014',
       reuseExistingServer: !process.env.CI,
       timeout: 60 * 1000,
       stdout: 'ignore',
@@ -75,8 +91,24 @@ export default defineConfig({
       stderr: 'pipe',
     },
     {
+      command: 'pnpm --filter react18-zod4-test-app dev',
+      url: 'http://localhost:3016',
+      reuseExistingServer: !process.env.CI,
+      timeout: 60 * 1000,
+      stdout: 'ignore',
+      stderr: 'pipe',
+    },
+    {
       command: 'pnpm --filter react-webmcp-test-app dev',
       url: 'http://localhost:8888',
+      reuseExistingServer: !process.env.CI,
+      timeout: 60 * 1000,
+      stdout: 'ignore',
+      stderr: 'pipe',
+    },
+    {
+      command: 'pnpm --filter react-webmcp-test-app-zod4 dev',
+      url: 'http://localhost:8889',
       reuseExistingServer: !process.env.CI,
       timeout: 60 * 1000,
       stdout: 'ignore',

--- a/e2e/react-webmcp-test-app-zod4/README.md
+++ b/e2e/react-webmcp-test-app-zod4/README.md
@@ -1,0 +1,173 @@
+# React WebMCP Test App
+
+A comprehensive React application for testing the `@mcp-b/react-webmcp` package with Playwright E2E tests.
+
+## Overview
+
+This test app demonstrates and validates all features of the `@mcp-b/react-webmcp` hooks library:
+
+- **Tool Registration** - 7 different MCP tools with various configurations
+- **State Management** - Execution tracking, error handling, and result management
+- **React StrictMode** - Validates duplicate registration prevention
+- **Type Safety** - Zod schema validation for inputs
+- **Real MCP Stack** - Uses real `@mcp-b/global`, `@mcp-b/transports`, and MCP SDK
+
+## Features Tested
+
+### Counter Tools (Mutation & Query)
+- `counter_increment` - Increment counter (mutation, non-idempotent)
+- `counter_decrement` - Decrement counter (mutation, non-idempotent)
+- `counter_reset` - Reset to zero (destructive operation with elicitation)
+- `counter_get` - Get current value (read-only, idempotent query)
+
+### Posts Tools (Complex Operations)
+- `posts_like` - Like a post by ID (mutation, idempotent)
+- `posts_search` - Search posts with filtering (read-only query)
+
+### Context Tool
+- `context_app_state` - Expose current app state (read-only context)
+
+## Running the App
+
+### Development Server
+```bash
+pnpm --filter react-webmcp-test-app-zod4 dev
+```
+
+The app will be available at http://localhost:5174
+
+### Build
+```bash
+pnpm --filter react-webmcp-test-app-zod4 build
+```
+
+## Running Tests
+
+### Run all React WebMCP tests
+```bash
+pnpm --filter mcp-e2e-tests test:react-webmcp
+```
+
+### Run with UI
+```bash
+pnpm --filter mcp-e2e-tests test:react-webmcp:ui
+```
+
+### Run in headed mode (see the browser)
+```bash
+pnpm --filter mcp-e2e-tests test:react-webmcp:headed
+```
+
+### Debug mode
+```bash
+pnpm --filter mcp-e2e-tests test:react-webmcp:debug
+```
+
+## Test Coverage
+
+The Playwright test suite includes 18 comprehensive tests:
+
+1. **Initialization Tests**
+   - App loads and initializes MCP
+   - All tools are registered on mount
+
+2. **Counter Operation Tests**
+   - Increment counter via button
+   - Decrement counter via button
+   - Reset counter via button
+   - Get counter value via button
+
+3. **Posts Operation Tests**
+   - Like a post via button
+   - Search posts via button
+   - Update total likes when posts are liked
+
+4. **Direct MCP API Tests**
+   - Call tool directly via MCP API
+   - List all registered tools
+   - Call context tool and get app state
+
+5. **State Management Tests**
+   - Handle multiple rapid clicks
+   - Track execution counts correctly
+   - Maintain state across multiple operations
+
+6. **Error Handling Tests**
+   - Handle tool validation errors
+
+7. **UI Interaction Tests**
+   - Clear event log
+
+8. **React StrictMode Tests**
+   - Handle StrictMode double-mounting correctly
+
+## Real MCP Implementation
+
+The test app uses the **complete real MCP stack** for true end-to-end testing:
+
+### Architecture Flow
+
+1. **Tool Registration**: `useWebMCP()` hooks register tools with `navigator.modelContext` (provided by `@mcp-b/global`)
+2. **MCP Server**: `@mcp-b/global` creates a real MCP server that handles tool execution
+3. **Transport Layer**: `TabClientTransport` from `@mcp-b/transports` connects client to server via browser tab messaging
+4. **MCP Client**: Real `@modelcontextprotocol/sdk` Client instance connects to the server
+5. **Tool Consumption**: `useMcpClient()` hook provides access to call tools via the real MCP protocol
+
+This is **not a mock** - it uses the actual workspace packages and real MCP protocol messages over real browser postMessage APIs.
+
+## Architecture
+
+```
+src/
+├── App.tsx             # Main React component with all tool implementations
+├── ClientConsumer.tsx  # Component that consumes tools via MCP client
+├── main.tsx            # React app entry point + MCP client setup
+└── testMiddleware.ts   # Optional middleware for observing MCP events
+```
+
+## Key Test Patterns
+
+### Testing Tool Registration
+```typescript
+const tools = await page.evaluate(() => {
+  return (window as any).mcpTools;
+});
+expect(tools).toContain('counter_increment');
+```
+
+### Testing Tool Execution via Real MCP Client
+```typescript
+const result = await page.evaluate(async () => {
+  return await (window as any).mcpClient.callTool({
+    name: 'counter_increment',
+    arguments: { amount: 5 }
+  });
+});
+expect(result.content).toBeDefined();
+```
+
+### Testing UI State
+```typescript
+const counter = page.locator('[data-testid="counter-display"]');
+await expect(counter).toContainText('5');
+```
+
+## Development
+
+The test app uses:
+
+- **React 19** with StrictMode
+- **Vite** for fast development
+- **TypeScript** for type safety
+- **Zod** for runtime validation
+- **@mcp-b/react-webmcp** for MCP tool registration (real package from workspace)
+- **@mcp-b/global** for navigator.modelContext polyfill (real package from workspace)
+- **@mcp-b/transports** for TabClientTransport (real package from workspace)
+- **@modelcontextprotocol/sdk** for MCP Client (real SDK)
+
+## Notes
+
+- All tests run in headless Chromium by default
+- The dev server starts automatically when running tests
+- Tests include screenshots on failure for debugging
+- HTML reports are generated after each test run

--- a/e2e/react-webmcp-test-app-zod4/index.html
+++ b/e2e/react-webmcp-test-app-zod4/index.html
@@ -1,0 +1,276 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React WebMCP Test App</title>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+        padding: 2rem;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        min-height: 100vh;
+      }
+
+      #root {
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+
+      .app-container {
+        background: white;
+        border-radius: 12px;
+        padding: 2rem;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      }
+
+      h1 {
+        color: #2d3748;
+        margin-bottom: 0.5rem;
+        font-size: 2rem;
+      }
+
+      .subtitle {
+        color: #718096;
+        margin-bottom: 2rem;
+        font-size: 0.95rem;
+      }
+
+      .section {
+        margin-bottom: 2rem;
+        padding: 1.5rem;
+        background: #f7fafc;
+        border-radius: 8px;
+        border: 1px solid #e2e8f0;
+      }
+
+      .section h2 {
+        color: #2d3748;
+        margin-bottom: 1rem;
+        font-size: 1.25rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .status-badge {
+        display: inline-block;
+        padding: 0.25rem 0.75rem;
+        border-radius: 12px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+
+      .status-badge.ready {
+        background: #c6f6d5;
+        color: #22543d;
+      }
+
+      .status-badge.executing {
+        background: #fef3c7;
+        color: #78350f;
+      }
+
+      .status-badge.error {
+        background: #fed7d7;
+        color: #742a2a;
+      }
+
+      .counter-display {
+        font-size: 4rem;
+        font-weight: bold;
+        color: #667eea;
+        text-align: center;
+        padding: 2rem;
+        background: white;
+        border-radius: 8px;
+        margin: 1rem 0;
+        border: 3px solid #667eea;
+      }
+
+      .button-group {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+        margin-top: 1rem;
+      }
+
+      button {
+        padding: 0.75rem 1.5rem;
+        border: none;
+        border-radius: 6px;
+        font-size: 0.95rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      button.primary {
+        background: #667eea;
+        color: white;
+      }
+
+      button.primary:hover:not(:disabled) {
+        background: #5568d3;
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+      }
+
+      button.secondary {
+        background: #48bb78;
+        color: white;
+      }
+
+      button.secondary:hover:not(:disabled) {
+        background: #38a169;
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(72, 187, 120, 0.4);
+      }
+
+      button.danger {
+        background: #f56565;
+        color: white;
+      }
+
+      button.danger:hover:not(:disabled) {
+        background: #e53e3e;
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(245, 101, 101, 0.4);
+      }
+
+      .info-box {
+        padding: 1rem;
+        background: white;
+        border-radius: 6px;
+        margin-top: 1rem;
+        border-left: 4px solid #4299e1;
+      }
+
+      .info-box h3 {
+        color: #2d3748;
+        font-size: 0.95rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .info-box p {
+        color: #4a5568;
+        font-size: 0.85rem;
+        line-height: 1.5;
+      }
+
+      .error-message {
+        padding: 1rem;
+        background: #fff5f5;
+        border: 1px solid #fc8181;
+        border-radius: 6px;
+        color: #742a2a;
+        margin-top: 1rem;
+        font-size: 0.9rem;
+      }
+
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 1rem;
+        margin-top: 1rem;
+      }
+
+      .stat-card {
+        background: white;
+        padding: 1rem;
+        border-radius: 6px;
+        text-align: center;
+      }
+
+      .stat-card .label {
+        color: #718096;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 0.5rem;
+      }
+
+      .stat-card .value {
+        color: #2d3748;
+        font-size: 1.5rem;
+        font-weight: bold;
+      }
+
+      .log {
+        background: #1a202c;
+        border-radius: 6px;
+        padding: 1rem;
+        max-height: 300px;
+        overflow-y: auto;
+        font-family: 'Monaco', 'Menlo', monospace;
+        font-size: 0.85rem;
+        color: #a0aec0;
+        margin-top: 1rem;
+      }
+
+      .log-entry {
+        padding: 0.25rem 0;
+        border-bottom: 1px solid #2d3748;
+      }
+
+      .log-entry:last-child {
+        border-bottom: none;
+      }
+
+      .log-entry.success {
+        color: #68d391;
+      }
+
+      .log-entry.error {
+        color: #fc8181;
+      }
+
+      .log-entry.info {
+        color: #63b3ed;
+      }
+
+      .spinner {
+        display: inline-block;
+        width: 1rem;
+        height: 1rem;
+        border: 2px solid rgba(255, 255, 255, 0.3);
+        border-radius: 50%;
+        border-top-color: white;
+        animation: spin 0.8s linear infinite;
+      }
+
+      @keyframes spin {
+        to { transform: rotate(360deg); }
+      }
+
+      code {
+        background: #edf2f7;
+        padding: 0.2rem 0.4rem;
+        border-radius: 3px;
+        font-family: 'Monaco', 'Menlo', monospace;
+        font-size: 0.85em;
+        color: #d63384;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/e2e/react-webmcp-test-app-zod4/package.json
+++ b/e2e/react-webmcp-test-app-zod4/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "react-webmcp-test-app-zod4",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite --port 8889",
+    "preview": "vite preview --port 8889",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mcp-b/global": "workspace:*",
+    "@mcp-b/react-webmcp": "workspace:*",
+    "@mcp-b/transports": "workspace:*",
+    "@modelcontextprotocol/sdk": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/e2e/react-webmcp-test-app-zod4/src/App.tsx
+++ b/e2e/react-webmcp-test-app-zod4/src/App.tsx
@@ -1,0 +1,792 @@
+import {
+  useMcpClient,
+  useWebMCP,
+  useWebMCPContext,
+  useWebMCPPrompt,
+  useWebMCPResource,
+} from '@mcp-b/react-webmcp';
+import { useState } from 'react';
+import { z } from 'zod';
+
+// Counter state (shared across the app)
+let globalCounter = 0;
+
+const COUNTER_AMOUNT_INPUT_SCHEMA = {
+  amount: z.number().min(1).max(100).default(1).describe('Amount to increment'),
+};
+
+const INCREMENT_ANNOTATIONS = {
+  title: 'Increment Counter',
+  readOnlyHint: false,
+  idempotentHint: false,
+};
+
+const DECREMENT_ANNOTATIONS = {
+  title: 'Decrement Counter',
+  readOnlyHint: false,
+  idempotentHint: false,
+};
+
+const RESET_ANNOTATIONS = {
+  title: 'Reset Counter',
+  readOnlyHint: false,
+  destructiveHint: true,
+};
+
+const GET_COUNTER_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    counter: { type: 'number', description: 'The current counter value' },
+    timestamp: { type: 'string', description: 'ISO timestamp when the value was retrieved' },
+  },
+  required: ['counter', 'timestamp'],
+} as const;
+
+const GET_COUNTER_ANNOTATIONS = {
+  title: 'Get Counter',
+  readOnlyHint: true,
+  idempotentHint: true,
+};
+
+const LIKE_POST_INPUT_SCHEMA = {
+  postId: z.string().describe('The post ID to like'),
+};
+
+const LIKE_POST_ANNOTATIONS = {
+  title: 'Like Post',
+  readOnlyHint: false,
+  idempotentHint: true,
+};
+
+const SEARCH_POSTS_INPUT_SCHEMA = {
+  query: z.string().min(1).describe('Search query'),
+  limit: z.number().min(1).max(10).default(10).describe('Max results'),
+};
+
+const SEARCH_POSTS_ANNOTATIONS = {
+  title: 'Search Posts',
+  readOnlyHint: true,
+  idempotentHint: true,
+};
+
+const CODE_REVIEW_ARGS_SCHEMA = {
+  code: z.string().describe('The code to review'),
+  language: z.string().optional().describe('Programming language (optional)'),
+};
+
+const SUMMARIZE_ARGS_SCHEMA = {
+  text: z.string().min(1).describe('The text to summarize'),
+  maxLength: z.number().optional().describe('Maximum summary length'),
+};
+
+function App() {
+  const [posts, setPosts] = useState([
+    { id: '1', title: 'First Post', likes: 0 },
+    { id: '2', title: 'Second Post', likes: 5 },
+    { id: '3', title: 'Third Post', likes: 10 },
+  ]);
+  const [searchResults, setSearchResults] = useState<string[]>([]);
+  const [logs, setLogs] = useState<
+    Array<{ id: string; message: string; type: 'info' | 'success' | 'error' }>
+  >([]);
+
+  // MCP Client for displaying registered tools
+  const { tools: clientTools } = useMcpClient();
+
+  // Helper to add logs
+  const addLog = (message: string, type: 'info' | 'success' | 'error' = 'info') => {
+    const timestamp = new Date().toLocaleTimeString();
+    const id = `${Date.now()}-${Math.random()}`;
+    setLogs((prev) => [...prev, { id, message: `[${timestamp}] ${message}`, type }]);
+  };
+
+  // Tool 1: Counter Increment (Mutation)
+  const incrementTool = useWebMCP({
+    name: 'counter_increment',
+    description: 'Increment the counter by a specified amount',
+    inputSchema: COUNTER_AMOUNT_INPUT_SCHEMA,
+    annotations: INCREMENT_ANNOTATIONS,
+    handler: async (input) => {
+      await new Promise((resolve) => setTimeout(resolve, 500)); // Simulate async
+      globalCounter += input.amount;
+      addLog(`Incremented counter by ${input.amount}. New value: ${globalCounter}`, 'success');
+      return { counter: globalCounter, incremented: input.amount };
+    },
+    onError: (error) => {
+      addLog(`Error incrementing: ${error.message}`, 'error');
+    },
+  });
+
+  // Tool 2: Counter Decrement (Mutation)
+  const decrementTool = useWebMCP({
+    name: 'counter_decrement',
+    description: 'Decrement the counter by a specified amount',
+    inputSchema: COUNTER_AMOUNT_INPUT_SCHEMA,
+    annotations: DECREMENT_ANNOTATIONS,
+    handler: async (input) => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      globalCounter -= input.amount;
+      addLog(`Decremented counter by ${input.amount}. New value: ${globalCounter}`, 'success');
+      return { counter: globalCounter, decremented: input.amount };
+    },
+  });
+
+  // Tool 3: Counter Reset (Destructive)
+  const resetTool = useWebMCP({
+    name: 'counter_reset',
+    description: 'Reset the counter to zero. This action cannot be undone.',
+    annotations: RESET_ANNOTATIONS,
+    handler: async () => {
+      const oldValue = globalCounter;
+      globalCounter = 0;
+      addLog(`Reset counter from ${oldValue} to 0`, 'success');
+      return { oldValue, newValue: 0 };
+    },
+  });
+
+  // Tool 4: Get Counter (Read-only query with outputSchema for structuredContent testing)
+  const getCounterTool = useWebMCP({
+    name: 'counter_get',
+    description: 'Get the current counter value',
+    outputSchema: GET_COUNTER_OUTPUT_SCHEMA,
+    annotations: GET_COUNTER_ANNOTATIONS,
+    handler: async () => {
+      const timestamp = new Date().toISOString();
+      addLog(`Retrieved counter value: ${globalCounter}`, 'info');
+      return { counter: globalCounter, timestamp };
+    },
+  });
+
+  // Tool 5: Like Post
+  const likePostTool = useWebMCP({
+    name: 'posts_like',
+    description: 'Like a post by ID. Increments the like count.',
+    inputSchema: LIKE_POST_INPUT_SCHEMA,
+    annotations: LIKE_POST_ANNOTATIONS,
+    handler: async (input) => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      setPosts((prev) =>
+        prev.map((post) => (post.id === input.postId ? { ...post, likes: post.likes + 1 } : post))
+      );
+      const post = posts.find((p) => p.id === input.postId);
+      if (!post) {
+        throw new Error(`Post not found: ${input.postId}`);
+      }
+      addLog(`Liked post: ${post.title}`, 'success');
+      return { postId: input.postId, newLikes: post.likes + 1 };
+    },
+  });
+
+  // Tool 6: Search Posts
+  const searchPostsTool = useWebMCP({
+    name: 'posts_search',
+    description: 'Search posts by keyword',
+    inputSchema: SEARCH_POSTS_INPUT_SCHEMA,
+    annotations: SEARCH_POSTS_ANNOTATIONS,
+    handler: async (input) => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      const results = posts
+        .filter((post) => post.title.toLowerCase().includes(input.query.toLowerCase()))
+        .slice(0, input.limit);
+      setSearchResults(results.map((p) => p.title));
+      addLog(`Found ${results.length} posts matching "${input.query}"`, 'info');
+      return {
+        query: input.query,
+        results: results.map((p) => ({ id: p.id, title: p.title, likes: p.likes })),
+        count: results.length,
+      };
+    },
+    formatOutput: (output) => {
+      const typedOutput = output as {
+        count: number;
+        results: Array<{ title: string; likes: number }>;
+      };
+      const results = typedOutput.results;
+      return `Found ${typedOutput.count} posts:\n${results.map((r) => `• ${r.title} (${r.likes} likes)`).join('\n')}`;
+    },
+  });
+
+  // Tool 7: Context tool - Current State
+  useWebMCPContext('context_app_state', 'Get the current application state', () => ({
+    counter: globalCounter,
+    totalPosts: posts.length,
+    totalLikes: posts.reduce((sum, post) => sum + post.likes, 0),
+    searchResultsCount: searchResults.length,
+  }));
+
+  // ==================== PROMPTS ====================
+
+  // Prompt 1: Simple help prompt (no arguments)
+  const helpPrompt = useWebMCPPrompt({
+    name: 'help',
+    description: 'Get help with using the application',
+    get: async () => ({
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: 'How do I use this application? Please provide a brief overview of the available features.',
+          },
+        },
+      ],
+    }),
+  });
+
+  // Prompt 2: Code review prompt (with typed arguments)
+  const codeReviewPrompt = useWebMCPPrompt({
+    name: 'review_code',
+    description: 'Review code for best practices and potential issues',
+    argsSchema: CODE_REVIEW_ARGS_SCHEMA,
+    get: async ({ code, language }) => ({
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: `Please review the following ${language ?? 'code'} for best practices, potential bugs, and improvements:\n\n\`\`\`${language ?? ''}\n${code}\n\`\`\``,
+          },
+        },
+      ],
+    }),
+  });
+
+  // Prompt 3: Summarize prompt
+  const summarizePrompt = useWebMCPPrompt({
+    name: 'summarize',
+    description: 'Summarize a piece of text',
+    argsSchema: SUMMARIZE_ARGS_SCHEMA,
+    get: async ({ text, maxLength }) => ({
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: maxLength
+              ? `Please summarize the following text in at most ${maxLength} characters:\n\n${text}`
+              : `Please summarize the following text:\n\n${text}`,
+          },
+        },
+      ],
+    }),
+  });
+
+  // ==================== RESOURCES ====================
+
+  // Resource 1: Static app configuration
+  const appConfigResource = useWebMCPResource({
+    uri: 'config://app-settings',
+    name: 'App Settings',
+    description: 'Application configuration and settings',
+    mimeType: 'application/json',
+    read: async (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          text: JSON.stringify(
+            {
+              appName: 'React WebMCP Test App',
+              version: '1.0.0',
+              theme: 'light',
+              features: {
+                counter: true,
+                posts: true,
+                prompts: true,
+                resources: true,
+              },
+              currentState: {
+                counter: globalCounter,
+                totalPosts: posts.length,
+              },
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    }),
+  });
+
+  // Resource 2: Dynamic user profile resource (URI template)
+  const userProfileResource = useWebMCPResource({
+    uri: 'user://{userId}/profile',
+    name: 'User Profile',
+    description: 'Get user profile data by user ID',
+    mimeType: 'application/json',
+    read: async (uri, params) => {
+      const userId = params?.userId ?? 'unknown';
+      // Simulated user data
+      const users: Record<string, { name: string; email: string; role: string }> = {
+        '1': { name: 'Alice Johnson', email: 'alice@example.com', role: 'admin' },
+        '2': { name: 'Bob Smith', email: 'bob@example.com', role: 'user' },
+        '3': { name: 'Charlie Brown', email: 'charlie@example.com', role: 'moderator' },
+      };
+      const user = users[userId] ?? {
+        name: 'Unknown',
+        email: 'unknown@example.com',
+        role: 'guest',
+      };
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            text: JSON.stringify({ userId, ...user }, null, 2),
+          },
+        ],
+      };
+    },
+  });
+
+  // Resource 3: Posts list resource
+  const postsResource = useWebMCPResource({
+    uri: 'data://posts',
+    name: 'Posts Data',
+    description: 'Current posts data in the application',
+    mimeType: 'application/json',
+    read: async (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          text: JSON.stringify(
+            { posts, totalLikes: posts.reduce((sum, p) => sum + p.likes, 0) },
+            null,
+            2
+          ),
+        },
+      ],
+    }),
+  });
+
+  // Manual test buttons
+  const handleIncrement = async () => {
+    try {
+      await incrementTool.execute({ amount: 1 });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleDecrement = async () => {
+    try {
+      await decrementTool.execute({ amount: 1 });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleReset = async () => {
+    try {
+      await resetTool.execute({});
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleGet = async () => {
+    try {
+      await getCounterTool.execute({});
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleLikePost = async (postId: string) => {
+    try {
+      await likePostTool.execute({ postId });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleSearch = async () => {
+    try {
+      await searchPostsTool.execute({ query: 'post', limit: 10 });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const clearLogs = () => {
+    setLogs([]);
+  };
+
+  // Calculate total executions
+  const totalExecutions =
+    incrementTool.state.executionCount +
+    decrementTool.state.executionCount +
+    resetTool.state.executionCount +
+    getCounterTool.state.executionCount +
+    likePostTool.state.executionCount +
+    searchPostsTool.state.executionCount;
+
+  const isAnyExecuting =
+    incrementTool.state.isExecuting ||
+    decrementTool.state.isExecuting ||
+    resetTool.state.isExecuting ||
+    getCounterTool.state.isExecuting ||
+    likePostTool.state.isExecuting ||
+    searchPostsTool.state.isExecuting;
+
+  return (
+    <div className="app-container">
+      <h1>React WebMCP Test App</h1>
+      <p className="subtitle">
+        Testing <code>@mcp-b/react-webmcp</code> hooks with various tool types
+      </p>
+
+      {/* Status Badge */}
+      <div style={{ marginBottom: '2rem' }}>
+        <span
+          className={`status-badge ${isAnyExecuting ? 'executing' : 'ready'}`}
+          data-testid="app-status"
+        >
+          {isAnyExecuting ? 'Executing' : 'Ready'}
+        </span>
+      </div>
+
+      {/* Counter Section */}
+      <div className="section">
+        <h2>Counter Tools (Mutation & Query)</h2>
+        <div className="counter-display" data-testid="counter-display">
+          {globalCounter}
+        </div>
+
+        <div className="button-group">
+          <button
+            type="button"
+            className="primary"
+            onClick={handleIncrement}
+            disabled={incrementTool.state.isExecuting}
+            data-testid="increment-btn"
+          >
+            {incrementTool.state.isExecuting && <span className="spinner" />}
+            Increment (+1)
+          </button>
+          <button
+            type="button"
+            className="primary"
+            onClick={handleDecrement}
+            disabled={decrementTool.state.isExecuting}
+            data-testid="decrement-btn"
+          >
+            {decrementTool.state.isExecuting && <span className="spinner" />}
+            Decrement (-1)
+          </button>
+          <button
+            type="button"
+            className="danger"
+            onClick={handleReset}
+            disabled={resetTool.state.isExecuting}
+            data-testid="reset-btn"
+          >
+            {resetTool.state.isExecuting && <span className="spinner" />}
+            Reset
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={handleGet}
+            disabled={getCounterTool.state.isExecuting}
+            data-testid="get-counter-btn"
+          >
+            {getCounterTool.state.isExecuting && <span className="spinner" />}
+            Get Value
+          </button>
+        </div>
+
+        {(incrementTool.state.error || decrementTool.state.error || resetTool.state.error) && (
+          <div className="error-message" data-testid="counter-error">
+            {incrementTool.state.error?.message ||
+              decrementTool.state.error?.message ||
+              resetTool.state.error?.message}
+          </div>
+        )}
+      </div>
+
+      {/* Posts Section */}
+      <div className="section">
+        <h2>Posts Tools (Like & Search)</h2>
+
+        <div style={{ marginBottom: '1rem' }}>
+          {posts.map((post) => (
+            <div
+              key={post.id}
+              style={{
+                background: 'white',
+                padding: '1rem',
+                borderRadius: '6px',
+                marginBottom: '0.5rem',
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}
+              data-testid={`post-${post.id}`}
+            >
+              <div>
+                <strong>{post.title}</strong>
+                <div style={{ color: '#718096', fontSize: '0.85rem' }}>
+                  Likes: <span data-testid={`post-${post.id}-likes`}>{post.likes}</span>
+                </div>
+              </div>
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => handleLikePost(post.id)}
+                disabled={likePostTool.state.isExecuting}
+                data-testid={`like-post-${post.id}`}
+              >
+                Like
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <div className="button-group">
+          <button
+            type="button"
+            className="primary"
+            onClick={handleSearch}
+            disabled={searchPostsTool.state.isExecuting}
+            data-testid="search-posts-btn"
+          >
+            {searchPostsTool.state.isExecuting && <span className="spinner" />}
+            Search "post"
+          </button>
+        </div>
+
+        {searchResults.length > 0 && (
+          <div className="info-box" data-testid="search-results">
+            <h3>Search Results ({searchResults.length})</h3>
+            <p>{searchResults.join(', ')}</p>
+          </div>
+        )}
+
+        {likePostTool.state.error && (
+          <div className="error-message" data-testid="posts-error">
+            {likePostTool.state.error.message}
+          </div>
+        )}
+      </div>
+
+      {/* Prompts Section */}
+      <div className="section">
+        <h2>Registered Prompts</h2>
+        <p className="subtitle">MCP prompts registered via useWebMCPPrompt hook</p>
+
+        <div className="stats" style={{ marginBottom: '1rem' }}>
+          <div className="stat-card">
+            <div className="label">help</div>
+            <div
+              className="value"
+              data-testid="prompt-help-status"
+              style={{ color: helpPrompt.isRegistered ? '#38a169' : '#e53e3e' }}
+            >
+              {helpPrompt.isRegistered ? 'Registered' : 'Pending'}
+            </div>
+          </div>
+          <div className="stat-card">
+            <div className="label">review_code</div>
+            <div
+              className="value"
+              data-testid="prompt-review-status"
+              style={{ color: codeReviewPrompt.isRegistered ? '#38a169' : '#e53e3e' }}
+            >
+              {codeReviewPrompt.isRegistered ? 'Registered' : 'Pending'}
+            </div>
+          </div>
+          <div className="stat-card">
+            <div className="label">summarize</div>
+            <div
+              className="value"
+              data-testid="prompt-summarize-status"
+              style={{ color: summarizePrompt.isRegistered ? '#38a169' : '#e53e3e' }}
+            >
+              {summarizePrompt.isRegistered ? 'Registered' : 'Pending'}
+            </div>
+          </div>
+        </div>
+
+        <div
+          className="info-box"
+          data-testid="prompts-info"
+          style={{ background: '#e6fffa', borderColor: '#38b2ac' }}
+        >
+          <strong>Prompts Available:</strong>
+          <ul style={{ margin: '0.5rem 0 0 1rem', padding: 0 }}>
+            <li data-testid="prompt-help-info">
+              <code>help</code> - Get help with using the application
+            </li>
+            <li data-testid="prompt-review-info">
+              <code>review_code</code> - Review code for best practices (args: code, language?)
+            </li>
+            <li data-testid="prompt-summarize-info">
+              <code>summarize</code> - Summarize text (args: text, maxLength?)
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Resources Section */}
+      <div className="section">
+        <h2>Registered Resources</h2>
+        <p className="subtitle">MCP resources registered via useWebMCPResource hook</p>
+
+        <div className="stats" style={{ marginBottom: '1rem' }}>
+          <div className="stat-card">
+            <div className="label">config://app-settings</div>
+            <div
+              className="value"
+              data-testid="resource-config-status"
+              style={{ color: appConfigResource.isRegistered ? '#38a169' : '#e53e3e' }}
+            >
+              {appConfigResource.isRegistered ? 'Registered' : 'Pending'}
+            </div>
+          </div>
+          <div className="stat-card">
+            <div className="label">user://&#123;userId&#125;/profile</div>
+            <div
+              className="value"
+              data-testid="resource-user-status"
+              style={{ color: userProfileResource.isRegistered ? '#38a169' : '#e53e3e' }}
+            >
+              {userProfileResource.isRegistered ? 'Registered' : 'Pending'}
+            </div>
+          </div>
+          <div className="stat-card">
+            <div className="label">data://posts</div>
+            <div
+              className="value"
+              data-testid="resource-posts-status"
+              style={{ color: postsResource.isRegistered ? '#38a169' : '#e53e3e' }}
+            >
+              {postsResource.isRegistered ? 'Registered' : 'Pending'}
+            </div>
+          </div>
+        </div>
+
+        <div
+          className="info-box"
+          data-testid="resources-info"
+          style={{ background: '#ebf8ff', borderColor: '#4299e1' }}
+        >
+          <strong>Resources Available:</strong>
+          <ul style={{ margin: '0.5rem 0 0 1rem', padding: 0 }}>
+            <li data-testid="resource-config-info">
+              <code>config://app-settings</code> - Static app configuration (JSON)
+            </li>
+            <li data-testid="resource-user-info">
+              <code>user://&#123;userId&#125;/profile</code> - Dynamic user profile by ID (URI
+              template)
+            </li>
+            <li data-testid="resource-posts-info">
+              <code>data://posts</code> - Current posts data (JSON)
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Statistics */}
+      <div className="section">
+        <h2>Statistics</h2>
+        <div className="stats">
+          <div className="stat-card">
+            <div className="label">Total Executions</div>
+            <div className="value" data-testid="total-executions">
+              {totalExecutions}
+            </div>
+          </div>
+          <div className="stat-card">
+            <div className="label">Counter Ops</div>
+            <div className="value" data-testid="counter-executions">
+              {incrementTool.state.executionCount +
+                decrementTool.state.executionCount +
+                resetTool.state.executionCount +
+                getCounterTool.state.executionCount}
+            </div>
+          </div>
+          <div className="stat-card">
+            <div className="label">Post Ops</div>
+            <div className="value" data-testid="post-executions">
+              {likePostTool.state.executionCount + searchPostsTool.state.executionCount}
+            </div>
+          </div>
+          <div className="stat-card">
+            <div className="label">Total Likes</div>
+            <div className="value" data-testid="total-likes">
+              {posts.reduce((sum, post) => sum + post.likes, 0)}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Event Log */}
+      <div className="section">
+        <h2>
+          Event Log
+          <button
+            type="button"
+            onClick={clearLogs}
+            style={{
+              marginLeft: 'auto',
+              background: '#e2e8f0',
+              color: '#2d3748',
+              padding: '0.5rem 1rem',
+              fontSize: '0.85rem',
+            }}
+            data-testid="clear-log-btn"
+          >
+            Clear
+          </button>
+        </h2>
+        <div className="log" data-testid="event-log">
+          {logs.length === 0 ? (
+            <div style={{ color: '#718096', fontStyle: 'italic' }}>No events yet...</div>
+          ) : (
+            logs.map((log) => (
+              <div key={log.id} className={`log-entry ${log.type}`}>
+                {log.message}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Registered Tools Section */}
+      <div className="section">
+        <h2>Registered MCP Tools</h2>
+        <p className="subtitle">
+          All tools registered via useWebMCP hooks are available through the MCP protocol
+        </p>
+
+        {/* Available Tools List */}
+        <div style={{ marginBottom: '1rem' }}>
+          <h3>Available Tools ({clientTools.length})</h3>
+          <div
+            style={{
+              background: 'white',
+              padding: '1rem',
+              borderRadius: '6px',
+              maxHeight: '200px',
+              overflowY: 'auto',
+            }}
+            data-testid="client-tools-list"
+          >
+            {clientTools.length === 0 ? (
+              <p style={{ color: '#718096', fontStyle: 'italic' }}>Loading tools...</p>
+            ) : (
+              <ul style={{ margin: 0, paddingLeft: '1.5rem' }}>
+                {clientTools.map((tool) => (
+                  <li key={tool.name} data-testid={`client-tool-${tool.name}`}>
+                    <strong>{tool.name}</strong> - {tool.description}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/e2e/react-webmcp-test-app-zod4/src/ClientConsumer.tsx
+++ b/e2e/react-webmcp-test-app-zod4/src/ClientConsumer.tsx
@@ -1,0 +1,219 @@
+import { useMcpClient } from '@mcp-b/react-webmcp';
+import { useState } from 'react';
+
+/**
+ * Component that demonstrates consuming MCP tools via the client API
+ * This shows how to:
+ * - List available tools from the server
+ * - Call tools via client.callTool()
+ * - Handle tool list changes (notifications)
+ */
+export function ClientConsumer() {
+  const { client, tools, isConnected, isLoading, error, capabilities } = useMcpClient();
+  const [callResult, setCallResult] = useState<string>('');
+  const [isExecuting, setIsExecuting] = useState(false);
+
+  const handleCallTool = async (toolName: string, args: Record<string, unknown>) => {
+    if (!client || !isConnected) {
+      setCallResult('Error: Client not connected');
+      return;
+    }
+
+    setIsExecuting(true);
+    setCallResult('');
+
+    try {
+      const result = await client.callTool({
+        name: toolName,
+        arguments: args,
+      });
+
+      // Extract text content from result
+      const content = result.content as Array<
+        { type: 'text'; text: string } | { type: string; [key: string]: unknown }
+      >;
+      const textContent = content
+        .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+        .map((c) => c.text)
+        .join('\n');
+
+      setCallResult(`Success: ${textContent}`);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      setCallResult(`Error: ${errorMessage}`);
+    } finally {
+      setIsExecuting(false);
+    }
+  };
+
+  // Test buttons for various tools
+  const testIncrementCounter = () => handleCallTool('counter_increment', { amount: 1 });
+  const testIncrementBy5 = () => handleCallTool('counter_increment', { amount: 5 });
+  const testInvalidIncrement = () => handleCallTool('counter_increment', { amount: 'invalid' });
+  const testGetCounter = () => handleCallTool('counter_get', {});
+  const testLikePost = () => handleCallTool('posts_like', { postId: '1' });
+  const testSearchPosts = () => handleCallTool('posts_search', { query: 'post', limit: 5 });
+  const testContextTool = () => handleCallTool('context_app_state', {});
+
+  if (isLoading) {
+    return (
+      <div className="section">
+        <h2>MCP Client Consumer</h2>
+        <p>Connecting to MCP server...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="section">
+        <h2>MCP Client Consumer</h2>
+        <div className="error-message" data-testid="client-error">
+          Connection Error: {error.message}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="section">
+      <h2>MCP Client Consumer</h2>
+      <p className="subtitle">
+        Consuming tools via <code>McpClientProvider</code> and <code>useMcpClient</code>
+      </p>
+
+      {/* Connection Status */}
+      <div style={{ marginBottom: '1rem' }}>
+        <div data-testid="client-connection-status">
+          <strong>Connection Status:</strong>{' '}
+          <span className={isConnected ? 'success-text' : 'error-text'}>
+            {isConnected ? 'Connected ✓' : 'Disconnected ✗'}
+          </span>
+        </div>
+        <div data-testid="client-capabilities">
+          <strong>Server Capabilities:</strong>{' '}
+          {capabilities ? (
+            <>
+              {capabilities.tools && 'Tools '}
+              {capabilities.resources && 'Resources '}
+              {capabilities.prompts && 'Prompts'}
+            </>
+          ) : (
+            'None'
+          )}
+        </div>
+      </div>
+
+      {/* Available Tools List */}
+      <div style={{ marginBottom: '1rem' }}>
+        <h3>Available Tools ({tools.length})</h3>
+        <div
+          style={{
+            background: 'white',
+            padding: '1rem',
+            borderRadius: '6px',
+            maxHeight: '200px',
+            overflowY: 'auto',
+          }}
+          data-testid="client-tools-list"
+        >
+          {tools.length === 0 ? (
+            <p style={{ color: '#718096', fontStyle: 'italic' }}>No tools available</p>
+          ) : (
+            <ul style={{ margin: 0, paddingLeft: '1.5rem' }}>
+              {tools.map((tool) => (
+                <li key={tool.name} data-testid={`client-tool-${tool.name}`}>
+                  <strong>{tool.name}</strong> - {tool.description}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* Test Tool Calls */}
+      <div style={{ marginBottom: '1rem' }}>
+        <h3>Call Tools via Client</h3>
+        <div className="button-group">
+          <button
+            type="button"
+            className="secondary"
+            onClick={testIncrementCounter}
+            disabled={!isConnected || isExecuting}
+            data-testid="client-call-increment"
+          >
+            {isExecuting && <span className="spinner" />}
+            Call counter_increment
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={testIncrementBy5}
+            disabled={!isConnected || isExecuting}
+            data-testid="client-call-increment-by-5"
+          >
+            Call counter_increment (amount: 5)
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={testGetCounter}
+            disabled={!isConnected || isExecuting}
+            data-testid="client-call-get-counter"
+          >
+            Call counter_get
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={testLikePost}
+            disabled={!isConnected || isExecuting}
+            data-testid="client-call-like-post"
+          >
+            Call posts_like
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={testSearchPosts}
+            disabled={!isConnected || isExecuting}
+            data-testid="client-call-search"
+          >
+            Call posts_search
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={testContextTool}
+            disabled={!isConnected || isExecuting}
+            data-testid="client-call-context"
+          >
+            Call context_app_state
+          </button>
+          <button
+            type="button"
+            className="danger"
+            onClick={testInvalidIncrement}
+            disabled={!isConnected || isExecuting}
+            data-testid="client-call-invalid"
+          >
+            Call with invalid args
+          </button>
+        </div>
+      </div>
+
+      {/* Call Result */}
+      {callResult && (
+        <div
+          className={callResult.startsWith('Error') ? 'error-message' : 'info-box'}
+          data-testid="client-call-result"
+          style={{ whiteSpace: 'pre-wrap' }}
+        >
+          <strong>Last Call Result:</strong>
+          <br />
+          {callResult}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/e2e/react-webmcp-test-app-zod4/src/main.tsx
+++ b/e2e/react-webmcp-test-app-zod4/src/main.tsx
@@ -1,0 +1,49 @@
+import '@mcp-b/global'; // Initialize navigator.modelContext polyfill
+import type { McpClientProviderProps } from '@mcp-b/react-webmcp';
+import { McpClientProvider } from '@mcp-b/react-webmcp';
+import { TabClientTransport } from '@mcp-b/transports';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { testMiddleware } from './testMiddleware';
+
+// Expose for testing
+console.log('React WebMCP Test App initialized');
+console.log('navigator.modelContext:', navigator.modelContext);
+
+// Extend Window interface for testing
+declare global {
+  interface Window {
+    mcpClient?: unknown;
+  }
+}
+
+// Create MCP client that connects to the MCP server exposed by @mcp-b/global
+// The server is automatically started when @mcp-b/global is imported
+const client = new Client({ name: 'ReactWebMCPTestClient', version: '1.0.0' });
+
+// Wrap client with test middleware to observe MCP events
+const wrappedClient = testMiddleware.wrapClient(client);
+
+// Expose the wrapped client globally for e2e testing
+window.mcpClient = wrappedClient;
+
+// Use TabClientTransport to connect to the MCP server
+// @mcp-b/global uses TabServerTransport's default channel: 'mcp-default'
+const transport = new TabClientTransport({
+  targetOrigin: '*',
+  channelId: 'mcp-default',
+});
+const providerClient = wrappedClient as unknown as McpClientProviderProps['client'];
+const providerTransport = transport as unknown as McpClientProviderProps['transport'];
+
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <McpClientProvider client={providerClient} transport={providerTransport}>
+    <App />
+  </McpClientProvider>
+);

--- a/e2e/react-webmcp-test-app-zod4/src/testMiddleware.ts
+++ b/e2e/react-webmcp-test-app-zod4/src/testMiddleware.ts
@@ -1,0 +1,148 @@
+/**
+ * Test Middleware for observing MCP events
+ *
+ * This middleware intercepts and logs MCP protocol events for test verification
+ * without mocking or faking any behavior. All events still flow through the real
+ * MCP stack unchanged.
+ */
+
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+export interface McpEvent {
+  type: 'tool_call' | 'tool_result' | 'tool_error' | 'connection' | 'tools_listed';
+  timestamp: number;
+  data: unknown;
+}
+
+class McpTestMiddleware {
+  private events: McpEvent[] = [];
+
+  /**
+   * Log an event
+   */
+  private log(type: McpEvent['type'], data: unknown): void {
+    this.events.push({
+      type,
+      timestamp: Date.now(),
+      data,
+    });
+  }
+
+  /**
+   * Get all logged events
+   */
+  getEvents(): McpEvent[] {
+    return [...this.events];
+  }
+
+  /**
+   * Get events of a specific type
+   */
+  getEventsByType(type: McpEvent['type']): McpEvent[] {
+    return this.events.filter((e) => e.type === type);
+  }
+
+  /**
+   * Clear all events
+   */
+  clearEvents(): void {
+    this.events = [];
+  }
+
+  /**
+   * Get the last N events
+   */
+  getLastEvents(n: number): McpEvent[] {
+    return this.events.slice(-n);
+  }
+
+  /**
+   * Wrap the MCP client to intercept calls
+   */
+  wrapClient(client: Client): Client {
+    // Store original methods
+    const originalCallTool = client.callTool.bind(client);
+    const originalListTools = client.listTools.bind(client);
+
+    // Type-safe way to override methods
+    type CallToolRequest = Parameters<typeof client.callTool>[0];
+    type CallToolResult = ReturnType<typeof client.callTool>;
+
+    // Override callTool to log calls and results
+    client.callTool = async (request: CallToolRequest): Promise<Awaited<CallToolResult>> => {
+      this.log('tool_call', {
+        tool: request.name,
+        arguments: request.arguments,
+      });
+
+      try {
+        const result = await originalCallTool(request);
+
+        this.log('tool_result', {
+          tool: request.name,
+          result,
+          isError: result.isError ?? false,
+          hasStructuredContent:
+            'structuredContent' in result && result.structuredContent !== undefined,
+          structuredContent: result.structuredContent,
+        });
+
+        return result;
+      } catch (error) {
+        this.log('tool_error', {
+          tool: request.name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+
+        throw error;
+      }
+    };
+
+    // Override listTools to log when tools are listed
+    client.listTools = async () => {
+      const result = await originalListTools();
+
+      this.log('tools_listed', {
+        count: result.tools.length,
+        tools: result.tools.map((t) => t.name),
+      });
+
+      return result;
+    };
+
+    return client;
+  }
+
+  /**
+   * Log a connection event
+   */
+  logConnection(connected: boolean): void {
+    this.log('connection', { connected });
+  }
+}
+
+// Create singleton instance
+const testMiddleware = new McpTestMiddleware();
+
+// Expose globally for testing
+declare global {
+  interface Window {
+    mcpEventLog: {
+      getEvents: () => McpEvent[];
+      getEventsByType: (type: McpEvent['type']) => McpEvent[];
+      clearEvents: () => void;
+      getLastEvents: (n: number) => McpEvent[];
+    };
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.mcpEventLog = {
+    getEvents: () => testMiddleware.getEvents(),
+    getEventsByType: (type) => testMiddleware.getEventsByType(type),
+    clearEvents: () => testMiddleware.clearEvents(),
+    getLastEvents: (n) => testMiddleware.getLastEvents(n),
+  };
+}
+
+export { testMiddleware };

--- a/e2e/react-webmcp-test-app-zod4/tsconfig.json
+++ b/e2e/react-webmcp-test-app-zod4/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/e2e/react-webmcp-test-app-zod4/vite.config.ts
+++ b/e2e/react-webmcp-test-app-zod4/vite.config.ts
@@ -1,0 +1,9 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 8888,
+  },
+});

--- a/e2e/react18-zod4/index.html
+++ b/e2e/react18-zod4/index.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React 18 + Zod 4 Test App</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        padding: 2rem;
+        background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+        min-height: 100vh;
+      }
+      #root {
+        max-width: 900px;
+        margin: 0 auto;
+      }
+      .app-container {
+        background: white;
+        border-radius: 12px;
+        padding: 2rem;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      }
+      h1 { color: #2d3748; margin-bottom: 0.5rem; font-size: 1.75rem; }
+      .subtitle { color: #718096; margin-bottom: 2rem; font-size: 0.95rem; }
+      .badge {
+        display: inline-block;
+        padding: 0.25rem 0.75rem;
+        border-radius: 12px;
+        font-size: 0.7rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        margin-right: 0.5rem;
+      }
+      .badge.react18 { background: #61dafb; color: #000; }
+      .badge.zod4 { background: #dbeafe; color: #1e3a8a; }
+      .section {
+        margin-bottom: 2rem;
+        padding: 1.5rem;
+        background: #f7fafc;
+        border-radius: 8px;
+        border: 1px solid #e2e8f0;
+      }
+      .section h2 {
+        color: #2d3748;
+        margin-bottom: 1rem;
+        font-size: 1.1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      .status-badge {
+        display: inline-block;
+        padding: 0.25rem 0.75rem;
+        border-radius: 12px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+      }
+      .status-badge.ready { background: #c6f6d5; color: #22543d; }
+      .status-badge.executing { background: #fef3c7; color: #78350f; }
+      .counter-display {
+        font-size: 3rem;
+        font-weight: bold;
+        color: #f5576c;
+        text-align: center;
+        padding: 1.5rem;
+        background: white;
+        border-radius: 8px;
+        margin: 1rem 0;
+        border: 3px solid #f5576c;
+      }
+      .button-group { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 1rem; }
+      button {
+        padding: 0.75rem 1.5rem;
+        border: none;
+        border-radius: 6px;
+        font-size: 0.9rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      button:disabled { opacity: 0.5; cursor: not-allowed; }
+      button.primary { background: #f5576c; color: white; }
+      button.primary:hover:not(:disabled) { background: #e5465c; }
+      button.secondary { background: #48bb78; color: white; }
+      button.secondary:hover:not(:disabled) { background: #38a169; }
+      button.danger { background: #e53e3e; color: white; }
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        gap: 1rem;
+        margin-top: 1rem;
+      }
+      .stat-card {
+        background: white;
+        padding: 1rem;
+        border-radius: 6px;
+        text-align: center;
+      }
+      .stat-card .label {
+        color: #718096;
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 0.25rem;
+      }
+      .stat-card .value { color: #2d3748; font-size: 1.25rem; font-weight: bold; }
+      .log {
+        background: #1a202c;
+        border-radius: 6px;
+        padding: 1rem;
+        max-height: 250px;
+        overflow-y: auto;
+        font-family: 'Monaco', 'Menlo', monospace;
+        font-size: 0.8rem;
+        color: #a0aec0;
+        margin-top: 1rem;
+      }
+      .log-entry { padding: 0.25rem 0; border-bottom: 1px solid #2d3748; }
+      .log-entry:last-child { border-bottom: none; }
+      .log-entry.success { color: #68d391; }
+      .log-entry.error { color: #fc8181; }
+      .log-entry.info { color: #63b3ed; }
+      .spinner {
+        display: inline-block;
+        width: 1rem;
+        height: 1rem;
+        border: 2px solid rgba(255, 255, 255, 0.3);
+        border-radius: 50%;
+        border-top-color: white;
+        animation: spin 0.8s linear infinite;
+      }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      code {
+        background: #edf2f7;
+        padding: 0.2rem 0.4rem;
+        border-radius: 3px;
+        font-family: 'Monaco', 'Menlo', monospace;
+        font-size: 0.85em;
+        color: #d63384;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/e2e/react18-zod4/package.json
+++ b/e2e/react18-zod4/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "react18-zod4-test-app",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite --port 3016",
+    "preview": "vite preview --port 3016",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mcp-b/global": "workspace:*",
+    "@mcp-b/react-webmcp": "workspace:*",
+    "@mcp-b/transports": "workspace:*",
+    "@modelcontextprotocol/sdk": "catalog:",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/e2e/react18-zod4/src/App.tsx
+++ b/e2e/react18-zod4/src/App.tsx
@@ -1,0 +1,348 @@
+import { useMcpClient, useWebMCP } from '@mcp-b/react-webmcp';
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+
+// Counter state
+let globalCounter = 0;
+
+function App() {
+  const [logs, setLogs] = useState<
+    Array<{ id: string; message: string; type: 'info' | 'success' | 'error' }>
+  >([]);
+  const [zodInfo, setZodInfo] = useState<{
+    isZod4: boolean;
+    hasDef: boolean;
+    hasZod: boolean;
+  } | null>(null);
+
+  // MCP Client for displaying registered tools
+  const { tools: clientTools } = useMcpClient();
+
+  const addLog = (message: string, type: 'info' | 'success' | 'error' = 'info') => {
+    const timestamp = new Date().toLocaleTimeString();
+    const id = `${Date.now()}-${Math.random()}`;
+    setLogs((prev) => [...prev, { id, message: `[${timestamp}] ${message}`, type }]);
+  };
+
+  // Check Zod version on mount
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Run only once on mount
+  useEffect(() => {
+    const testSchema = z.string();
+    const hasZod = '_zod' in testSchema;
+    const hasDef = '_def' in testSchema;
+    const isZod4 = hasZod && !hasDef;
+    setZodInfo({ isZod4, hasDef, hasZod });
+
+    if (!isZod4) {
+      addLog('WARNING: Expected Zod 4.x but detected different version!', 'error');
+    } else {
+      addLog('Zod 4.x detected correctly', 'success');
+    }
+  }, []);
+
+  // Tool 1: Counter Increment
+  const incrementTool = useWebMCP({
+    name: 'react18_counter_increment',
+    description: 'Increment the counter (React 18 + Zod 4)',
+    inputSchema: {
+      amount: z.number().min(1).max(100).default(1).describe('Amount to increment'),
+    },
+    handler: async (input) => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      globalCounter += input.amount;
+      addLog(`Incremented by ${input.amount}. New value: ${globalCounter}`, 'success');
+      return { counter: globalCounter, incremented: input.amount };
+    },
+    onError: (error) => {
+      addLog(`Error: ${error.message}`, 'error');
+    },
+  });
+
+  // Tool 2: Counter Decrement
+  const decrementTool = useWebMCP({
+    name: 'react18_counter_decrement',
+    description: 'Decrement the counter (React 18 + Zod 4)',
+    inputSchema: {
+      amount: z.number().min(1).max(100).default(1).describe('Amount to decrement'),
+    },
+    handler: async (input) => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      globalCounter -= input.amount;
+      addLog(`Decremented by ${input.amount}. New value: ${globalCounter}`, 'success');
+      return { counter: globalCounter, decremented: input.amount };
+    },
+  });
+
+  // Tool 3: User Validator (comprehensive validation test)
+  const userValidatorTool = useWebMCP({
+    name: 'react18_user_validator',
+    description: 'Validate user data (React 18 + Zod 4)',
+    inputSchema: {
+      username: z.string().min(3).max(20).describe('Username (3-20 chars)'),
+      email: z.string().email().describe('Valid email address'),
+      age: z.number().int().min(18).max(120).describe('Age (18-120)'),
+      tags: z.array(z.string()).optional().describe('Optional tags'),
+    },
+    handler: async ({ username, email, age, tags }) => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      addLog(
+        `Validated: ${username}, ${email}, age=${age}, tags=${tags?.join(',') || 'none'}`,
+        'success'
+      );
+      return { valid: true, username, email, age, tags };
+    },
+    onError: (error) => {
+      addLog(`Validation error: ${error.message}`, 'error');
+    },
+  });
+
+  // Tool 4: Reset Counter
+  const resetTool = useWebMCP({
+    name: 'react18_counter_reset',
+    description: 'Reset the counter to zero',
+    handler: async () => {
+      const oldValue = globalCounter;
+      globalCounter = 0;
+      addLog(`Reset counter from ${oldValue} to 0`, 'success');
+      return { oldValue, newValue: 0 };
+    },
+  });
+
+  const handleIncrement = async () => {
+    try {
+      await incrementTool.execute({ amount: 1 });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleDecrement = async () => {
+    try {
+      await decrementTool.execute({ amount: 1 });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleReset = async () => {
+    try {
+      await resetTool.execute({});
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleValidUser = async () => {
+    try {
+      await userValidatorTool.execute({
+        username: 'testuser',
+        email: 'test@example.com',
+        age: 25,
+        tags: ['react18', 'zod4'],
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleInvalidEmail = async () => {
+    try {
+      await userValidatorTool.execute({
+        username: 'testuser',
+        email: 'not-an-email',
+        age: 25,
+      });
+    } catch (_error) {
+      addLog('Invalid email rejected as expected', 'success');
+    }
+  };
+
+  const handleAgeTooLow = async () => {
+    try {
+      await userValidatorTool.execute({
+        username: 'testuser',
+        email: 'test@example.com',
+        age: 15,
+      });
+    } catch (_error) {
+      addLog('Age too low rejected as expected', 'success');
+    }
+  };
+
+  const clearLogs = () => setLogs([]);
+
+  const isAnyExecuting =
+    incrementTool.state.isExecuting ||
+    decrementTool.state.isExecuting ||
+    resetTool.state.isExecuting ||
+    userValidatorTool.state.isExecuting;
+
+  const totalExecutions =
+    incrementTool.state.executionCount +
+    decrementTool.state.executionCount +
+    resetTool.state.executionCount +
+    userValidatorTool.state.executionCount;
+
+  return (
+    <div className="app-container">
+      <h1>React 18 + Zod 4 Test App</h1>
+      <p className="subtitle">
+        <span className="badge react18">React 18</span>
+        <span className="badge zod4">Zod 4.x</span>
+        Testing <code>@mcp-b/react-webmcp</code> with Zod 4
+      </p>
+
+      {/* Status */}
+      <div style={{ marginBottom: '1.5rem' }}>
+        <span className={`status-badge ${isAnyExecuting ? 'executing' : 'ready'}`}>
+          {isAnyExecuting ? 'Executing' : 'Ready'}
+        </span>
+      </div>
+
+      {/* Zod Version Check */}
+      <div className="section">
+        <h2>Zod Version Check</h2>
+        {zodInfo && (
+          <div style={{ padding: '0.5rem', background: 'white', borderRadius: '6px' }}>
+            <p style={{ color: zodInfo.isZod4 ? '#22543d' : '#742a2a', fontWeight: 'bold' }}>
+              {zodInfo.isZod4
+                ? '✓ Zod 4.x detected (correct)'
+                : zodInfo.hasDef
+                  ? '✗ Zod 3.x detected (wrong)'
+                  : '✗ Wrong Zod version!'}
+            </p>
+            <p style={{ color: '#718096', fontSize: '0.85rem' }}>
+              Has _def: {zodInfo.hasDef.toString()}, Has _zod: {zodInfo.hasZod.toString()}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Counter Section */}
+      <div className="section">
+        <h2>Counter Tools</h2>
+        <div className="counter-display">{globalCounter}</div>
+        <div className="button-group">
+          <button
+            className="primary"
+            onClick={handleIncrement}
+            disabled={incrementTool.state.isExecuting}
+          >
+            {incrementTool.state.isExecuting && <span className="spinner" />}
+            Increment (+1)
+          </button>
+          <button
+            className="primary"
+            onClick={handleDecrement}
+            disabled={decrementTool.state.isExecuting}
+          >
+            {decrementTool.state.isExecuting && <span className="spinner" />}
+            Decrement (-1)
+          </button>
+          <button className="danger" onClick={handleReset} disabled={resetTool.state.isExecuting}>
+            {resetTool.state.isExecuting && <span className="spinner" />}
+            Reset
+          </button>
+        </div>
+      </div>
+
+      {/* Validation Tests Section */}
+      <div className="section">
+        <h2>Validation Tests</h2>
+        <div className="button-group">
+          <button
+            className="secondary"
+            onClick={handleValidUser}
+            disabled={userValidatorTool.state.isExecuting}
+          >
+            {userValidatorTool.state.isExecuting && <span className="spinner" />}
+            Valid User
+          </button>
+          <button className="danger" onClick={handleInvalidEmail}>
+            Test Invalid Email
+          </button>
+          <button className="danger" onClick={handleAgeTooLow}>
+            Test Age Too Low
+          </button>
+        </div>
+      </div>
+
+      {/* Statistics */}
+      <div className="section">
+        <h2>Statistics</h2>
+        <div className="stats">
+          <div className="stat-card">
+            <div className="label">Total Executions</div>
+            <div className="value">{totalExecutions}</div>
+          </div>
+          <div className="stat-card">
+            <div className="label">Registered Tools</div>
+            <div className="value">{clientTools.length}</div>
+          </div>
+          <div className="stat-card">
+            <div className="label">Log Entries</div>
+            <div className="value">{logs.length}</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Registered Tools */}
+      <div className="section">
+        <h2>Registered MCP Tools ({clientTools.length})</h2>
+        <div
+          style={{
+            background: 'white',
+            padding: '1rem',
+            borderRadius: '6px',
+            maxHeight: '150px',
+            overflowY: 'auto',
+          }}
+        >
+          {clientTools.length === 0 ? (
+            <p style={{ color: '#718096', fontStyle: 'italic' }}>Loading tools...</p>
+          ) : (
+            <ul style={{ margin: 0, paddingLeft: '1.5rem' }}>
+              {clientTools.map((tool) => (
+                <li key={tool.name} style={{ marginBottom: '0.25rem' }}>
+                  <strong>{tool.name}</strong> - {tool.description}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* Event Log */}
+      <div className="section">
+        <h2>
+          Event Log
+          <button
+            onClick={clearLogs}
+            style={{
+              marginLeft: 'auto',
+              background: '#e2e8f0',
+              color: '#2d3748',
+              padding: '0.4rem 0.8rem',
+              fontSize: '0.8rem',
+            }}
+          >
+            Clear
+          </button>
+        </h2>
+        <div className="log">
+          {logs.length === 0 ? (
+            <div style={{ color: '#718096', fontStyle: 'italic' }}>No events yet...</div>
+          ) : (
+            logs.map((log) => (
+              <div key={log.id} className={`log-entry ${log.type}`}>
+                {log.message}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/e2e/react18-zod4/src/main.tsx
+++ b/e2e/react18-zod4/src/main.tsx
@@ -1,0 +1,35 @@
+import '@mcp-b/global'; // Initialize navigator.modelContext polyfill
+import type { McpClientProviderProps } from '@mcp-b/react-webmcp';
+import { McpClientProvider } from '@mcp-b/react-webmcp';
+import { TabClientTransport } from '@mcp-b/transports';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { ComponentType } from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+// Expose for testing
+console.log('React 18 + Zod 4 Test App initialized');
+console.log('navigator.modelContext:', navigator.modelContext);
+
+// Create MCP client
+const client = new Client({ name: 'React18Zod4TestClient', version: '1.0.0' });
+
+// Use TabClientTransport to connect to the MCP server
+const transport = new TabClientTransport({
+  targetOrigin: '*',
+  channelId: 'mcp-default',
+});
+const Provider = McpClientProvider as unknown as ComponentType<McpClientProviderProps>;
+const providerClient = client as unknown as McpClientProviderProps['client'];
+const providerTransport = transport as unknown as McpClientProviderProps['transport'];
+
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <Provider client={providerClient} transport={providerTransport}>
+    <App />
+  </Provider>
+);

--- a/e2e/react18-zod4/tsconfig.json
+++ b/e2e/react18-zod4/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/e2e/react18-zod4/vite.config.ts
+++ b/e2e/react18-zod4/vite.config.ts
@@ -1,0 +1,14 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3015,
+    strictPort: true,
+  },
+  preview: {
+    port: 3015,
+    strictPort: true,
+  },
+});

--- a/e2e/tests/validation-matrix.spec.ts
+++ b/e2e/tests/validation-matrix.spec.ts
@@ -3,29 +3,36 @@ import { expect, test } from '@playwright/test';
 /**
  * Validation Matrix E2E Tests
  *
- * Tests validation across all Zod 3/build/framework combinations:
+ * Tests validation across all Zod 3 + Zod 4/build/framework combinations:
  * - vanilla-iife-json: IIFE + JSON Schema (no Zod)
  * - vanilla-iife-zod3: IIFE + Zod 3 CDN
  * - vanilla-esm-zod3: ESM + Zod 3
+ * - vanilla-esm-zod4: ESM + Zod 4
  * - react18-zod3: React 18 + Zod 3
+ * - react18-zod4: React 18 + Zod 4
  * - react-webmcp-test-app: React 19 + Zod 3
+ * - react-webmcp-test-app-zod4: React 19 + Zod 4
  *
- * Note: Zod 4 is NOT supported. Only Zod 3.25+ is supported.
+ * Supports both Zod 3.25+ and Zod 4.
  */
 
 interface TestApp {
   name: string;
   port: number;
-  type: 'json' | 'zod3';
+  type: 'json' | 'zod3' | 'zod4';
   isReact: boolean;
 }
 
 const apps: TestApp[] = [
   { name: 'vanilla-iife-json', port: 3010, type: 'json', isReact: false },
   { name: 'vanilla-iife-zod3', port: 3011, type: 'zod3', isReact: false },
+  { name: 'vanilla-iife-zod4', port: 3012, type: 'zod4', isReact: false },
   { name: 'vanilla-esm-zod3', port: 3013, type: 'zod3', isReact: false },
+  { name: 'vanilla-esm-zod4', port: 3014, type: 'zod4', isReact: false },
   { name: 'react18-zod3', port: 3015, type: 'zod3', isReact: true },
+  { name: 'react18-zod4', port: 3016, type: 'zod4', isReact: true },
   { name: 'react-webmcp-test-app', port: 8888, type: 'zod3', isReact: true },
+  { name: 'react-webmcp-test-app-zod4', port: 8889, type: 'zod4', isReact: true },
 ];
 
 // Test each app in the matrix
@@ -41,25 +48,24 @@ for (const app of apps) {
       // React apps have different UI structure
       test('should load and show ready status', async ({ page }) => {
         // Wait for app to initialize
-        if (app.name === 'react-webmcp-test-app') {
+        if (app.name.startsWith('react-webmcp-test-app')) {
           await page.waitForSelector('[data-testid="app-status"]', { timeout: 10000 });
           const status = page.locator('[data-testid="app-status"]');
           await expect(status).toContainText('Ready');
         } else {
-          // react18-zod3
+          // react18-zod3/react18-zod4
           await page.waitForSelector('.status-badge', { timeout: 10000 });
           const status = page.locator('.status-badge');
           await expect(status).toContainText('Ready');
         }
       });
 
-      // Only react18-zod3 has a Zod version UI section
-      if (app.type === 'zod3' && app.name === 'react18-zod3') {
-        test('should detect correct Zod version (Zod 3)', async ({ page }) => {
-          // react18-zod3 app has a Zod version check section with text "Zod 3.x detected"
+      // react18-zod3/react18-zod4 have a Zod version UI section
+      if (app.name.startsWith('react18-zod')) {
+        test(`should detect correct Zod version (${app.type.toUpperCase()})`, async ({ page }) => {
           await page.waitForSelector('.section h2:has-text("Zod Version")', { timeout: 5000 });
           const zodSection = page.locator('.section:has(h2:has-text("Zod Version"))');
-          await expect(zodSection).toContainText('Zod 3');
+          await expect(zodSection).toContainText(app.type === 'zod4' ? 'Zod 4' : 'Zod 3');
         });
       }
 
@@ -67,7 +73,7 @@ for (const app of apps) {
         // Wait for tools to be registered
         await page.waitForTimeout(1000);
 
-        if (app.name === 'react-webmcp-test-app') {
+        if (app.name.startsWith('react-webmcp-test-app')) {
           // Check for registered tools list
           const toolsList = page.locator('[data-testid="client-tools-list"]');
           await expect(toolsList).toBeVisible({ timeout: 10000 });
@@ -78,7 +84,7 @@ for (const app of apps) {
         }
       });
 
-      if (app.name === 'react18-zod3') {
+      if (app.name.startsWith('react18-zod')) {
         test('should execute realistic Zod validation flows through UI', async ({ page }) => {
           await page.getByRole('button', { name: 'Valid User' }).click();
           await expect(page.locator('.log')).toContainText('Validated: testuser');
@@ -95,7 +101,7 @@ for (const app of apps) {
         });
       }
 
-      if (app.name === 'react-webmcp-test-app') {
+      if (app.name.startsWith('react-webmcp-test-app')) {
         test('should execute real MCP client tool calls and surface validation errors', async ({
           page,
         }) => {
@@ -202,10 +208,10 @@ for (const app of apps) {
         ).toBe(true);
       });
 
-      if (app.type === 'zod3') {
-        test('should detect correct Zod version (Zod 3)', async ({ page }) => {
+      if (app.type === 'zod3' || app.type === 'zod4') {
+        test(`should detect correct Zod version (${app.type.toUpperCase()})`, async ({ page }) => {
           const zodVersion = page.locator('#zod-version');
-          await expect(zodVersion).toContainText('Zod 3');
+          await expect(zodVersion).toContainText(app.type === 'zod4' ? 'Zod 4' : 'Zod 3');
         });
       }
 

--- a/e2e/vanilla-esm-zod4/index.html
+++ b/e2e/vanilla-esm-zod4/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vanilla ESM + Zod 4 Test</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      padding: 2rem;
+      background: #f0f4f8;
+      min-height: 100vh;
+    }
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+      background: white;
+      border-radius: 12px;
+      padding: 2rem;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    }
+    h1 { color: #2d3748; margin-bottom: 0.5rem; }
+    .subtitle { color: #718096; margin-bottom: 2rem; }
+    .badge {
+      display: inline-block;
+      padding: 0.25rem 0.75rem;
+      border-radius: 12px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+    }
+    .badge.zod4 { background: #dbeafe; color: #1e3a8a; }
+    .badge.esm { background: #dbeafe; color: #1e40af; }
+    .section {
+      margin-bottom: 2rem;
+      padding: 1.5rem;
+      background: #f7fafc;
+      border-radius: 8px;
+      border: 1px solid #e2e8f0;
+    }
+    .section h2 { color: #2d3748; margin-bottom: 1rem; font-size: 1.25rem; }
+    #status { padding: 1rem; border-radius: 6px; margin-bottom: 1rem; }
+    #status.success { background: #c6f6d5; color: #22543d; }
+    #status.error { background: #fed7d7; color: #742a2a; }
+    #results {
+      font-family: 'Monaco', 'Menlo', monospace;
+      font-size: 0.85rem;
+      background: #1a202c;
+      color: #a0aec0;
+      padding: 1rem;
+      border-radius: 6px;
+      max-height: 400px;
+      overflow-y: auto;
+    }
+    .result-item { padding: 0.5rem 0; border-bottom: 1px solid #2d3748; }
+    .result-item:last-child { border-bottom: none; }
+    .result-item.success { color: #68d391; }
+    .result-item.error { color: #fc8181; }
+    .result-item.info { color: #63b3ed; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Vanilla ESM + Zod 4 Test</h1>
+    <p class="subtitle">
+      <span class="badge esm">ESM Build</span>
+      <span class="badge zod4">Zod 4.x</span>
+      Testing validation with bundled Zod 4 via Vite
+    </p>
+
+    <div id="status">Initializing...</div>
+
+    <div class="section">
+      <h2>Zod Version Check</h2>
+      <div id="zod-version">Checking...</div>
+    </div>
+
+    <div class="section">
+      <h2>Registered Tools</h2>
+      <div id="tools-list">Loading...</div>
+    </div>
+
+    <div class="section">
+      <h2>Test Results</h2>
+      <div id="results"></div>
+    </div>
+  </div>
+
+  <script type="module" src="/src/main.ts"></script>
+</body>
+</html>

--- a/e2e/vanilla-esm-zod4/package.json
+++ b/e2e/vanilla-esm-zod4/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "vanilla-esm-zod4-test-app",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite --port 3014",
+    "preview": "vite preview --port 3014",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mcp-b/global": "workspace:*",
+    "@mcp-b/webmcp-ts-sdk": "workspace:*",
+    "@mcp-b/webmcp-types": "workspace:*",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/e2e/vanilla-esm-zod4/src/main.ts
+++ b/e2e/vanilla-esm-zod4/src/main.ts
@@ -1,0 +1,251 @@
+import { initializeWebModelContext } from '@mcp-b/global';
+import type { JsonSchemaForInference, ModelContextWithExtensions } from '@mcp-b/webmcp-types';
+import { z } from 'zod';
+
+const statusEl = document.getElementById('status')!;
+const resultsEl = document.getElementById('results')!;
+const toolsListEl = document.getElementById('tools-list')!;
+const zodVersionEl = document.getElementById('zod-version')!;
+
+function log(msg: string, type: 'info' | 'success' | 'error' = 'info') {
+  const div = document.createElement('div');
+  div.className = `result-item ${type}`;
+  div.textContent = `[${new Date().toLocaleTimeString()}] ${msg}`;
+  resultsEl.appendChild(div);
+  resultsEl.scrollTop = resultsEl.scrollHeight;
+}
+
+function getFirstText(result: { content?: Array<{ type?: string; text?: string }> }): string {
+  const textBlock = result.content?.find(
+    (item) => item.type === 'text' && typeof item.text === 'string'
+  );
+  return textBlock?.text ?? '';
+}
+
+// Check Zod version
+const testSchema = z.string();
+const isZod4 = '_zod' in testSchema;
+const isZod3 = '_def' in testSchema && !isZod4;
+zodVersionEl.innerHTML = `
+  <p style="color: ${isZod4 ? '#22543d' : '#742a2a'}; font-weight: bold;">
+    ${isZod4 ? '✓ Zod 4.x detected (correct)' : isZod3 ? '✗ Zod 3.x detected (wrong!)' : '✗ Unknown Zod version'}
+  </p>
+  <p style="color: #718096; font-size: 0.85rem;">
+    Has _def: ${!!(testSchema as any)._def}, Has _zod: ${'_zod' in testSchema}
+  </p>
+`;
+
+if (!isZod4) {
+  statusEl.className = 'error';
+  statusEl.textContent = 'Wrong Zod version! Expected Zod 4.x';
+  log('ERROR: Expected Zod 4.x but got different version', 'error');
+  throw new Error('Wrong Zod version');
+}
+
+// Initialize modelContext
+initializeWebModelContext();
+
+async function runTests() {
+  if (!window.navigator.modelContext) {
+    statusEl.className = 'error';
+    statusEl.textContent = 'modelContext not available';
+    return;
+  }
+
+  statusEl.className = 'success';
+  statusEl.textContent = 'ESM + Zod 4 initialized - Running tests...';
+
+  const mc = window.navigator.modelContext as ModelContextWithExtensions;
+  const registerTool = mc.registerTool as unknown as (tool: unknown) => void;
+
+  try {
+    // Register tool with Zod 4 schemas
+    registerTool({
+      name: 'esm-zod4-validator',
+      description: 'Validate data using ESM + Zod 4',
+      inputSchema: {
+        name: z.string().min(2).max(50).describe('Name (2-50 chars)'),
+        email: z.string().email().describe('Valid email'),
+        score: z.number().min(0).max(100).describe('Score (0-100)'),
+        active: z.boolean().optional().describe('Is active'),
+        tags: z.array(z.string()).optional().describe('Optional tags'),
+      },
+      async execute(args: {
+        name: string;
+        email: string;
+        score: number;
+        active?: boolean;
+        tags?: string[];
+      }) {
+        const { name, email, score, active, tags } = args;
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `ESM Zod4: name=${name}, email=${email}, score=${score}, active=${active ?? 'unset'}, tags=${tags?.join(',') || 'none'}`,
+            },
+          ],
+        };
+      },
+    });
+    log('Tool "esm-zod4-validator" registered successfully', 'success');
+
+    // Update tools list
+    const tools = mc.listTools();
+    toolsListEl.innerHTML = tools
+      .map(
+        (t: { name: string; description?: string }) =>
+          `<div style="padding: 0.5rem; background: white; border-radius: 4px; margin-bottom: 0.5rem;">
+            <strong>${t.name}</strong> - ${t.description || 'No description'}
+          </div>`
+      )
+      .join('');
+
+    // Test 1: Valid input
+    log('Test 1: Valid input...', 'info');
+    const r1 = await mc.callTool({
+      name: 'esm-zod4-validator',
+      arguments: {
+        name: 'John Doe',
+        email: 'john@example.com',
+        score: 85,
+      },
+    });
+    log(
+      `Valid input: ${r1.isError ? 'FAILED' : 'PASSED'} - ${getFirstText(r1 as { content?: Array<{ type?: string; text?: string }> })}`,
+      r1.isError ? 'error' : 'success'
+    );
+
+    // Test 2: Valid with optional fields
+    log('Test 2: Valid input with optional fields...', 'info');
+    const r2 = await mc.callTool({
+      name: 'esm-zod4-validator',
+      arguments: {
+        name: 'Jane Doe',
+        email: 'jane@example.com',
+        score: 92,
+        active: true,
+        tags: ['premium', 'verified'],
+      },
+    });
+    log(
+      `With optionals: ${r2.isError ? 'FAILED' : 'PASSED'} - ${getFirstText(r2 as { content?: Array<{ type?: string; text?: string }> })}`,
+      r2.isError ? 'error' : 'success'
+    );
+
+    // Test 3: Missing required field
+    log('Test 3: Missing required field (email)...', 'info');
+    const r3 = await mc.callTool({
+      name: 'esm-zod4-validator',
+      arguments: {
+        name: 'Test User',
+        score: 50,
+      },
+    });
+    log(
+      `Missing email: ${r3.isError ? 'PASSED (rejected)' : 'FAILED (should reject)'}`,
+      r3.isError ? 'success' : 'error'
+    );
+
+    // Test 4: Invalid type
+    log('Test 4: Invalid type (score as string)...', 'info');
+    const r4 = await mc.callTool({
+      name: 'esm-zod4-validator',
+      arguments: {
+        name: 'Test User',
+        email: 'test@example.com',
+        score: 'high',
+      },
+    });
+    log(
+      `Invalid type: ${r4.isError ? 'PASSED (rejected)' : 'FAILED (should reject)'}`,
+      r4.isError ? 'success' : 'error'
+    );
+
+    // Test 5: Value out of range
+    log('Test 5: Value out of range (score=150)...', 'info');
+    const r5 = await mc.callTool({
+      name: 'esm-zod4-validator',
+      arguments: {
+        name: 'Test User',
+        email: 'test@example.com',
+        score: 150,
+      },
+    });
+    log(
+      `Score too high: ${r5.isError ? 'PASSED (rejected)' : 'FAILED (should reject)'}`,
+      r5.isError ? 'success' : 'error'
+    );
+
+    // Test 6: String too short
+    log('Test 6: String too short (name="A")...', 'info');
+    const r6 = await mc.callTool({
+      name: 'esm-zod4-validator',
+      arguments: {
+        name: 'A',
+        email: 'test@example.com',
+        score: 50,
+      },
+    });
+    log(
+      `Name too short: ${r6.isError ? 'PASSED (rejected)' : 'FAILED (should reject)'}`,
+      r6.isError ? 'success' : 'error'
+    );
+
+    // Test 7: Invalid email
+    log('Test 7: Invalid email format...', 'info');
+    const r7 = await mc.callTool({
+      name: 'esm-zod4-validator',
+      arguments: {
+        name: 'Test User',
+        email: 'not-an-email',
+        score: 50,
+      },
+    });
+    log(
+      `Invalid email: ${r7.isError ? 'PASSED (rejected)' : 'FAILED (should reject)'}`,
+      r7.isError ? 'success' : 'error'
+    );
+
+    // Test 8: Invalid boolean type
+    log('Test 8: Invalid boolean type (active="yes")...', 'info');
+    const r8 = await mc.callTool({
+      name: 'esm-zod4-validator',
+      arguments: {
+        name: 'Test User',
+        email: 'test@example.com',
+        score: 50,
+        active: 'yes',
+      },
+    });
+    log(
+      `Invalid boolean: ${r8.isError ? 'PASSED (rejected)' : 'FAILED (should reject)'}`,
+      r8.isError ? 'success' : 'error'
+    );
+
+    statusEl.textContent = 'All tests completed!';
+    log('All tests completed!', 'success');
+  } catch (error) {
+    log(`Error: ${(error as Error).message}`, 'error');
+    console.error(error);
+  }
+}
+
+// Run tests when page loads
+runTests();
+
+navigator.modelContext.registerTool({
+  name: 'echo',
+  description: 'Echo a message',
+  inputSchema: {
+    type: 'object',
+    properties: { message: { type: 'string' } },
+    required: ['message'],
+    additionalProperties: false,
+    // type saftey on the inputschema
+  } as const satisfies JsonSchemaForInference,
+  async execute(args) {
+    // args is inferred as: { message: string }
+    return { content: [{ type: 'text', text: args.message }] };
+  },
+});

--- a/e2e/vanilla-esm-zod4/tsconfig.json
+++ b/e2e/vanilla-esm-zod4/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/e2e/vanilla-esm-zod4/vite.config.ts
+++ b/e2e/vanilla-esm-zod4/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    port: 3013,
+    strictPort: true,
+  },
+  preview: {
+    port: 3013,
+    strictPort: true,
+  },
+});

--- a/e2e/vanilla-iife-zod4/index.html
+++ b/e2e/vanilla-iife-zod4/index.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vanilla IIFE + Zod 4 CDN Test</title>
+  <script src="/node_modules/@mcp-b/global/dist/index.iife.js"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      padding: 2rem;
+      background: #f0f4f8;
+      min-height: 100vh;
+    }
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+      background: white;
+      border-radius: 12px;
+      padding: 2rem;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    }
+    h1 { color: #2d3748; margin-bottom: 0.5rem; }
+    .subtitle { color: #718096; margin-bottom: 2rem; }
+    .badge {
+      display: inline-block;
+      padding: 0.25rem 0.75rem;
+      border-radius: 12px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+    }
+    .badge.zod4 { background: #dbeafe; color: #1e3a8a; }
+    .badge.iife { background: #e9d5ff; color: #581c87; }
+    .section {
+      margin-bottom: 2rem;
+      padding: 1.5rem;
+      background: #f7fafc;
+      border-radius: 8px;
+      border: 1px solid #e2e8f0;
+    }
+    .section h2 { color: #2d3748; margin-bottom: 1rem; font-size: 1.25rem; }
+    #status { padding: 1rem; border-radius: 6px; margin-bottom: 1rem; }
+    #status.success { background: #c6f6d5; color: #22543d; }
+    #status.error { background: #fed7d7; color: #742a2a; }
+    #results {
+      font-family: 'Monaco', 'Menlo', monospace;
+      font-size: 0.85rem;
+      background: #1a202c;
+      color: #a0aec0;
+      padding: 1rem;
+      border-radius: 6px;
+      max-height: 400px;
+      overflow-y: auto;
+    }
+    .result-item { padding: 0.5rem 0; border-bottom: 1px solid #2d3748; }
+    .result-item:last-child { border-bottom: none; }
+    .result-item.success { color: #68d391; }
+    .result-item.error { color: #fc8181; }
+    .result-item.info { color: #63b3ed; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Vanilla IIFE + Zod 4 CDN Test</h1>
+    <p class="subtitle">
+      <span class="badge iife">IIFE Build</span>
+      <span class="badge zod4">Zod 4.x</span>
+      Testing validation with Zod 4 schemas from CDN
+    </p>
+
+    <div id="status">Loading Zod 4 from CDN...</div>
+
+    <div class="section">
+      <h2>Zod Version Check</h2>
+      <div id="zod-version">Checking...</div>
+    </div>
+
+    <div class="section">
+      <h2>Registered Tools</h2>
+      <div id="tools-list">Loading...</div>
+    </div>
+
+    <div class="section">
+      <h2>Test Results</h2>
+      <div id="results"></div>
+    </div>
+  </div>
+
+  <script type="module">
+    // Load Zod 4 from CDN
+    import { z } from 'https://cdn.jsdelivr.net/npm/zod@4.1.11/+esm';
+    window.z = z;
+
+    const statusEl = document.getElementById('status');
+    const resultsEl = document.getElementById('results');
+    const toolsListEl = document.getElementById('tools-list');
+    const zodVersionEl = document.getElementById('zod-version');
+
+    function log(msg, type = 'info') {
+      const div = document.createElement('div');
+      div.className = `result-item ${type}`;
+      div.textContent = `[${new Date().toLocaleTimeString()}] ${msg}`;
+      resultsEl.appendChild(div);
+      resultsEl.scrollTop = resultsEl.scrollHeight;
+    }
+
+    // Check Zod version
+    const testSchema = z.string();
+    const isZod4 = '_zod' in testSchema;
+    const isZod3 = '_def' in testSchema && !isZod4;
+    zodVersionEl.innerHTML = `
+      <p style="color: ${isZod4 ? '#22543d' : '#742a2a'}; font-weight: bold;">
+        ${isZod4 ? '✓ Zod 4.x detected (correct)' : isZod3 ? '✗ Zod 3.x detected (wrong!)' : '✗ Unknown Zod version'}
+      </p>
+      <p style="color: #718096; font-size: 0.85rem;">
+        Has _def: ${!!testSchema._def}, Has _zod: ${'_zod' in testSchema}
+      </p>
+    `;
+
+    if (!isZod4) {
+      statusEl.className = 'error';
+      statusEl.textContent = 'Wrong Zod version loaded!';
+      log('ERROR: Expected Zod 4.x but got different version', 'error');
+      throw new Error('Wrong Zod version');
+    }
+
+    async function runTests() {
+      if (!window.navigator.modelContext) {
+        statusEl.className = 'error';
+        statusEl.textContent = 'modelContext not available';
+        return;
+      }
+
+      statusEl.className = 'success';
+      statusEl.textContent = 'Zod 4 loaded + modelContext available - Running tests...';
+
+      const mc = window.navigator.modelContext;
+
+      try {
+        // Register tool with Zod 4 schemas
+        mc.registerTool({
+          name: "zod4-user-validator",
+          description: "Validate user data using Zod 4 schemas",
+          inputSchema: {
+            username: z.string().min(3).max(20).describe("Username (3-20 chars)"),
+            email: z.string().email().describe("Valid email address"),
+            age: z.number().int().min(18).max(120).describe("Age (18-120)"),
+            tags: z.array(z.string()).optional().describe("Optional tags")
+          },
+          async execute({ username, email, age, tags }) {
+            return {
+              content: [{
+                type: "text",
+                text: `Zod4 validated: ${username}, ${email}, age=${age}, tags=${tags?.join(',') || 'none'}`
+              }]
+            };
+          }
+        });
+        log('Tool "zod4-user-validator" registered successfully', 'success');
+
+        // Update tools list
+        const tools = await mc.listTools();
+        toolsListEl.innerHTML = tools.map(t =>
+          `<div style="padding: 0.5rem; background: white; border-radius: 4px; margin-bottom: 0.5rem;">
+            <strong>${t.name}</strong> - ${t.description}
+          </div>`
+        ).join('');
+
+        // Test 1: Valid input
+        log('Test 1: Valid input...', 'info');
+        const r1 = await mc.executeTool('zod4-user-validator', {
+          username: "validuser",
+          email: "test@example.com",
+          age: 25
+        });
+        log(`Valid input: ${r1.isError ? 'FAILED' : 'PASSED'} - ${r1.content?.[0]?.text}`, r1.isError ? 'error' : 'success');
+
+        // Test 2: Valid with optional array
+        log('Test 2: Valid input with optional array...', 'info');
+        const r2 = await mc.executeTool('zod4-user-validator', {
+          username: "validuser",
+          email: "test@example.com",
+          age: 30,
+          tags: ["tag1", "tag2"]
+        });
+        log(`With tags: ${r2.isError ? 'FAILED' : 'PASSED'} - ${r2.content?.[0]?.text}`, r2.isError ? 'error' : 'success');
+
+        // Test 3: Missing required field
+        log('Test 3: Missing required field (email)...', 'info');
+        const r3 = await mc.executeTool('zod4-user-validator', {
+          username: "testuser",
+          age: 30
+        });
+        log(`Missing email: ${r3.isError ? 'PASSED (rejected)' : 'FAILED (should reject)'}`, r3.isError ? 'success' : 'error');
+
+        // Test 4: Invalid type (age as string)
+        log('Test 4: Invalid type (age as string)...', 'info');
+        const r4 = await mc.executeTool('zod4-user-validator', {
+          username: "testuser",
+          email: "test@example.com",
+          age: "twenty-five"
+        });
+        log(`Invalid type: ${r4.isError ? 'PASSED (rejected)' : 'FAILED (should reject)'}`, r4.isError ? 'success' : 'error');
+
+        // Test 5: Value out of range (age too low)
+        log('Test 5: Value out of range (age=15)...', 'info');
+        const r5 = await mc.executeTool('zod4-user-validator', {
+          username: "testuser",
+          email: "test@example.com",
+          age: 15
+        });
+        log(`Age too low: ${r5.isError ? 'PASSED (rejected)' : 'FAILED (should reject)'}`, r5.isError ? 'success' : 'error');
+
+        // Test 6: String too short (username)
+        log('Test 6: String too short (username="ab")...', 'info');
+        const r6 = await mc.executeTool('zod4-user-validator', {
+          username: "ab",
+          email: "test@example.com",
+          age: 25
+        });
+        log(`Username too short: ${r6.isError ? 'PASSED (rejected)' : 'FAILED (should reject)'}`, r6.isError ? 'success' : 'error');
+
+        // Test 7: Invalid email format
+        log('Test 7: Invalid email format...', 'info');
+        const r7 = await mc.executeTool('zod4-user-validator', {
+          username: "testuser",
+          email: "not-an-email",
+          age: 25
+        });
+        log(`Invalid email: ${r7.isError ? 'PASSED (rejected)' : 'FAILED (should reject)'}`, r7.isError ? 'success' : 'error');
+
+        // Test 8: Invalid array item type
+        log('Test 8: Invalid array item type (tags with number)...', 'info');
+        const r8 = await mc.executeTool('zod4-user-validator', {
+          username: "testuser",
+          email: "test@example.com",
+          age: 25,
+          tags: ["valid", 123]
+        });
+        log(`Invalid array item: ${r8.isError ? 'PASSED (rejected)' : 'FAILED (should reject)'}`, r8.isError ? 'success' : 'error');
+
+        statusEl.textContent = 'All tests completed!';
+        log('All tests completed!', 'success');
+
+      } catch (error) {
+        log(`Error: ${error.message}`, 'error');
+        console.error(error);
+      }
+    }
+
+    // Run tests when page loads
+    runTests();
+  </script>
+</body>
+</html>

--- a/e2e/vanilla-iife-zod4/package.json
+++ b/e2e/vanilla-iife-zod4/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "vanilla-iife-zod4-test-app",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite --port 3012",
+    "preview": "vite preview --port 3012"
+  },
+  "devDependencies": {
+    "@mcp-b/global": "workspace:*",
+    "vite": "catalog:"
+  }
+}

--- a/e2e/vanilla-iife-zod4/vite.config.ts
+++ b/e2e/vanilla-iife-zod4/vite.config.ts
@@ -1,0 +1,17 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    port: 3011,
+    strictPort: true,
+    fs: {
+      // Allow serving files from node_modules
+      allow: [resolve(__dirname, 'node_modules'), resolve(__dirname, '.')],
+    },
+  },
+  preview: {
+    port: 3011,
+    strictPort: true,
+  },
+});

--- a/packages/global/README.md
+++ b/packages/global/README.md
@@ -509,7 +509,7 @@ navigator.modelContext.provideContext({
 
 ## Zod Version Compatibility
 
-This package supports **Zod 3.25.76+** (3.x only). JSON Schema is also supported if you prefer not to use Zod.
+This package uses the same v4-compatible conversion path as the MCP TypeScript SDK and supports **Zod 3.25+** and **Zod 4**. JSON Schema is also supported if you prefer not to use Zod.
 
 ## Type Exports
 

--- a/packages/react-webmcp/README.md
+++ b/packages/react-webmcp/README.md
@@ -125,7 +125,7 @@ function ToolConsumer() {
 
 ## Zod Version Compatibility
 
-This package supports **Zod 3.25.76+** (3.x only).
+This package internally uses a v4-compatible conversion path and supports projects using **Zod 3.25+** and **Zod 4**.
 
 ## Documentation
 

--- a/packages/react-webmcp/package.json
+++ b/packages/react-webmcp/package.json
@@ -75,7 +75,9 @@
     "@mcp-b/transports": "workspace:*",
     "@mcp-b/webmcp-polyfill": "workspace:*",
     "@mcp-b/webmcp-ts-sdk": "workspace:*",
-    "@mcp-b/webmcp-types": "workspace:*"
+    "@mcp-b/webmcp-types": "workspace:*",
+    "zod": "^3.25 || ^4.0",
+    "zod-to-json-schema": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/react-webmcp/src/types.ts
+++ b/packages/react-webmcp/src/types.ts
@@ -24,22 +24,22 @@ export type { ZodSchemaObject } from './zod-utils.js';
 /**
  * Union of all input schema types supported by react-webmcp:
  * - `ToolInputSchema` (JSON Schema + Standard Schema v1)
- * - `ZodSchemaObject` (Zod v3 `Record<string, z.ZodTypeAny>`)
+ * - `ZodSchemaObject` (Zod v3/v4 `Record<string, z.ZodTypeAny>`)
  */
 export type ReactWebMCPInputSchema = ToolInputSchema | ZodSchemaObject;
 
 /**
  * Union of all output schema types supported by react-webmcp:
  * - `JsonSchemaObject` (MCP output schema)
- * - `ZodSchemaObject` (Zod v3 `Record<string, z.ZodTypeAny>`, converted at runtime)
+ * - `ZodSchemaObject` (Zod v3/v4 `Record<string, z.ZodTypeAny>`, converted at runtime)
  */
 export type ReactWebMCPOutputSchema = JsonSchemaObject | ZodSchemaObject;
 
 /**
- * Infers handler input type from a Standard Schema, Zod v3 schema, or JSON Schema.
+ * Infers handler input type from a Standard Schema, Zod v3/v4 schema, or JSON Schema.
  *
  * - **Standard Schema** (Zod v4, Valibot, ArkType): extracts `~standard.types.input`
- * - **Zod v3** (`Record<string, z.ZodTypeAny>`): uses `z.infer<z.ZodObject<T>>`
+ * - **Zod v3/v4** (`Record<string, z.ZodTypeAny>`): uses `z.infer<z.ZodObject<T>>`
  * - **JSON Schema** (`as const`): uses `InferArgsFromInputSchema` for structural inference
  * - **Fallback**: `Record<string, unknown>`
  *
@@ -52,7 +52,7 @@ export type InferToolInput<T> =
     ? Types extends { readonly input: infer I }
       ? I
       : Record<string, unknown>
-    : // Zod v3 schema object
+    : // Zod v3/v4 schema object
       T extends Record<string, z.ZodTypeAny>
       ? z.infer<z.ZodObject<T>>
       : // JSON Schema
@@ -76,7 +76,7 @@ export type InferOutput<
   TFallback = unknown,
 > = TOutputSchema extends undefined
   ? TFallback
-  : TOutputSchema extends Record<string, z.ZodTypeAny> // Zod v3 schema object
+  : TOutputSchema extends Record<string, z.ZodTypeAny> // Zod v3/v4 schema object
     ? z.infer<z.ZodObject<TOutputSchema>>
     : // JSON Schema object
       TOutputSchema extends JsonSchemaObject

--- a/packages/react-webmcp/src/zod-utils.test.ts
+++ b/packages/react-webmcp/src/zod-utils.test.ts
@@ -1,23 +1,12 @@
-import type { InputSchema } from '@mcp-b/webmcp-types';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-const { zodToJsonSchemaMock } = vi.hoisted(() => ({
-  zodToJsonSchemaMock: vi.fn(),
-}));
-
-vi.mock('zod-to-json-schema', () => ({
-  zodToJsonSchema: zodToJsonSchemaMock,
-}));
+import { describe, expect, it } from 'vitest';
+import { z as z3 } from 'zod/v3';
+import { z as z4 } from 'zod/v4';
 
 import { isZodSchema, zodToJsonSchema } from './zod-utils.js';
 
 describe('zod-utils', () => {
-  beforeEach(() => {
-    zodToJsonSchemaMock.mockReset();
-  });
-
   describe('isZodSchema', () => {
-    it('returns false for non-zod-like values and JSON Schema objects', () => {
+    it('returns false for non-zod values and JSON Schema objects', () => {
       expect(isZodSchema(null)).toBe(false);
       expect(isZodSchema([])).toBe(false);
       expect(isZodSchema({})).toBe(false);
@@ -25,112 +14,57 @@ describe('zod-utils', () => {
       expect(isZodSchema({ username: { type: 'string' } })).toBe(false);
     });
 
-    it('returns true for zod-like schema records', () => {
-      expect(
-        isZodSchema({
-          username: { _def: { typeName: 'ZodString' } },
-          age: { _def: { typeName: 'ZodNumber' } },
-        })
-      ).toBe(true);
-    });
-
-    it('returns true for zod-like schema records with non-zod keys', () => {
-      expect(
-        isZodSchema({
-          type: 'object',
-          username: { _def: { typeName: 'ZodString' } },
-        })
-      ).toBe(true);
+    it('returns true for zod v3 and v4 schema records', () => {
+      expect(isZodSchema({ username: z3.string() })).toBe(true);
+      expect(isZodSchema({ username: z4.string() })).toBe(true);
     });
   });
 
   describe('zodToJsonSchema', () => {
-    it('converts zod-like fields, strips schema metadata, and infers required keys', () => {
-      const schema = {
-        type: 'object',
-        requiredField: { _def: { typeName: 'ZodString' } },
-        optionalField: { _def: { typeName: 'ZodOptional' } },
-        defaultField: { _def: { typeName: 'ZodDefault' } },
-        malformedDefField: { _def: 'not-an-object' },
-      };
-
-      zodToJsonSchemaMock.mockImplementation((value: unknown): InputSchema => {
-        if (value === schema.requiredField) {
-          return {
-            $schema: 'https://json-schema.org/draft/2020-12/schema',
-            type: 'string',
-          };
-        }
-
-        if (value === schema.optionalField) {
-          return {
-            type: 'number',
-            $schema: 'https://json-schema.org/draft/2020-12/schema',
-          };
-        }
-
-        if (value === schema.defaultField) {
-          return {
-            $schema: 'https://json-schema.org/draft/2020-12/schema',
-            type: 'object',
-            properties: {
-              nested: {
-                $schema: 'https://json-schema.org/draft/2020-12/schema',
-                type: 'string',
-              },
-            },
-          };
-        }
-
-        return {
-          type: 'boolean',
-          $schema: 'https://json-schema.org/draft/2020-12/schema',
-        };
+    it('converts zod v3 raw schema shape with required and optional keys', () => {
+      const result = zodToJsonSchema({
+        requiredField: z3.string().min(2),
+        optionalField: z3.number().optional(),
+        defaultField: z3.boolean().default(false),
       });
 
-      const result = zodToJsonSchema(schema as never);
-
-      expect(zodToJsonSchemaMock).toHaveBeenCalledTimes(4);
-      expect(result).toEqual({
-        type: 'object',
-        properties: {
-          requiredField: { type: 'string' },
-          optionalField: { type: 'number' },
-          defaultField: {
-            type: 'object',
-            properties: {
-              nested: { type: 'string' },
-            },
-          },
-          malformedDefField: { type: 'boolean' },
-        },
-        required: ['requiredField', 'malformedDefField'],
-      });
+      expect(result.type).toBe('object');
+      expect(result.properties?.requiredField).toMatchObject({ type: 'string', minLength: 2 });
+      expect(result.properties?.optionalField).toMatchObject({ type: 'number' });
+      expect(result.properties?.defaultField).toMatchObject({ type: 'boolean' });
+      expect(result.required).toEqual(['requiredField']);
     });
 
-    it('omits required when every field is optional or defaulted', () => {
-      const schema = {
-        optionalField: { _def: { typeName: 'ZodOptional' } },
-        defaultField: { _def: { typeName: 'ZodDefault' } },
-      };
-
-      zodToJsonSchemaMock.mockImplementation((value: unknown): InputSchema => {
-        if (value === schema.optionalField) {
-          return { type: 'string' };
-        }
-        return { type: 'number' };
+    it('converts zod v4 raw schema shape into constrained JSON schema', () => {
+      const result = zodToJsonSchema({
+        username: z4.string().min(3),
+        age: z4.number().int().min(18),
       });
 
-      const result = zodToJsonSchema(schema as never);
+      expect(result.type).toBe('object');
+      expect(result.properties?.username).toMatchObject({ type: 'string', minLength: 3 });
+      expect(result.properties?.age).toMatchObject({ type: 'integer', minimum: 18 });
+      expect(result.required).toEqual(['username', 'age']);
+    });
 
-      expect(result).toEqual({
-        type: 'object',
-        properties: {
-          optionalField: { type: 'string' },
-          defaultField: { type: 'number' },
-        },
+    it('omits required when all fields are optional/defaulted', () => {
+      const result = zodToJsonSchema({
+        optionalField: z3.string().optional(),
+        defaultField: z3.number().default(1),
       });
+
       expect(result.required).toBeUndefined();
+    });
+
+    it('throws deterministic error for mixed zod v3/v4 schema shapes', () => {
+      expect(() =>
+        zodToJsonSchema({
+          oldSchema: z3.string(),
+          newSchema: z4.number(),
+        })
+      ).toThrow(
+        'Mixed Zod versions detected in schema shape. Use either all Zod v3 schemas or all Zod v4 schemas.'
+      );
     });
   });
 });

--- a/packages/react-webmcp/src/zod-utils.ts
+++ b/packages/react-webmcp/src/zod-utils.ts
@@ -1,48 +1,31 @@
 import type { InputSchema } from '@mcp-b/webmcp-types';
 import type { z } from 'zod';
-import { zodToJsonSchema as zodToJsonSchemaLib } from 'zod-to-json-schema';
+import { z as zod3 } from 'zod/v3';
+import { z as zod4, toJSONSchema as zod4ToJsonSchema } from 'zod/v4-mini';
+import { zodToJsonSchema as zodToJsonSchemaV3 } from 'zod-to-json-schema';
 
 export type ZodSchemaObject = Record<string, z.ZodTypeAny>;
+
+type ZodVersion = 'v3' | 'v4';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function isZodLikeValue(value: unknown): boolean {
-  // `_def` is present on both zod/v3 and zod v4 schema instances.
-  // Restricting detection to `_def` avoids misclassifying non-Zod Standard Schema values.
-  return isRecord(value) && '_def' in value;
-}
-
-type ZodDefinitionCarrier = {
-  _def: {
-    typeName: unknown;
-  };
-};
-
-function hasZodTypeName(schema: unknown): schema is ZodDefinitionCarrier {
-  if (!isRecord(schema)) {
-    return false;
+function detectZodVersion(value: unknown): ZodVersion | null {
+  if (!isRecord(value)) {
+    return null;
   }
 
-  const definition = schema._def;
-  return isRecord(definition) && 'typeName' in definition;
-}
-
-export function isZodSchema(schema: unknown): schema is ZodSchemaObject {
-  if (!isRecord(schema)) return false;
-  const values = Object.values(schema);
-  if (values.length === 0) return false;
-  return values.some((value) => isZodLikeValue(value));
-}
-
-function isOptionalSchema(schema: unknown): boolean {
-  if (!hasZodTypeName(schema)) {
-    return false;
+  if ('_zod' in value) {
+    return 'v4';
   }
 
-  const { typeName } = schema._def;
-  return typeName === 'ZodOptional' || typeName === 'ZodDefault';
+  if ('_def' in value) {
+    return 'v3';
+  }
+
+  return null;
 }
 
 function stripSchemaMeta(schema: InputSchema): InputSchema {
@@ -58,27 +41,59 @@ function stripSchemaMeta(schema: InputSchema): InputSchema {
   return rest;
 }
 
-export function zodToJsonSchema(schema: ZodSchemaObject): InputSchema {
-  const properties: Record<string, InputSchema> = {};
-  const required: string[] = [];
+function getZodEntries(schema: Record<string, unknown>): Array<[string, z.ZodTypeAny, ZodVersion]> {
+  const entries: Array<[string, z.ZodTypeAny, ZodVersion]> = [];
 
-  for (const [key, rawValue] of Object.entries(schema)) {
-    if (!isZodLikeValue(rawValue)) {
+  for (const [key, value] of Object.entries(schema)) {
+    const version = detectZodVersion(value);
+    if (!version) {
       continue;
     }
+    entries.push([key, value as z.ZodTypeAny, version]);
+  }
 
-    const zodSchema = rawValue as z.ZodTypeAny;
-    const propSchema = zodToJsonSchemaLib(zodSchema, {
+  return entries;
+}
+
+function getSchemaVersion(entries: Array<[string, z.ZodTypeAny, ZodVersion]>): ZodVersion {
+  const versions = new Set(entries.map((entry) => entry[2]));
+  if (versions.size > 1) {
+    throw new Error(
+      'Mixed Zod versions detected in schema shape. Use either all Zod v3 schemas or all Zod v4 schemas.'
+    );
+  }
+
+  const version = versions.values().next().value;
+  if (!version) {
+    throw new Error('No Zod schemas found in provided schema shape.');
+  }
+
+  return version;
+}
+
+export function isZodSchema(schema: unknown): schema is ZodSchemaObject {
+  if (!isRecord(schema)) {
+    return false;
+  }
+
+  return getZodEntries(schema).length > 0;
+}
+
+export function zodToJsonSchema(schema: ZodSchemaObject): InputSchema {
+  const entries = getZodEntries(schema as Record<string, unknown>);
+  const version = getSchemaVersion(entries);
+
+  if (version === 'v3') {
+    const objectSchema = zod3.object(
+      Object.fromEntries(entries.map(([key, value]) => [key, value]))
+    );
+    const jsonSchema = zodToJsonSchemaV3(objectSchema, {
       strictUnions: true,
       $refStrategy: 'none',
     });
-    properties[key] = stripSchemaMeta(propSchema as InputSchema);
-    if (!isOptionalSchema(zodSchema)) {
-      required.push(key);
-    }
+    return stripSchemaMeta(jsonSchema as InputSchema);
   }
 
-  const result: InputSchema = { type: 'object', properties };
-  if (required.length > 0) result.required = required;
-  return result;
+  const objectSchema = zod4.object(Object.fromEntries(entries.map(([key, value]) => [key, value])));
+  return stripSchemaMeta(zod4ToJsonSchema(objectSchema) as InputSchema);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,72 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@cfworker/json-schema':
+      specifier: ^4.1.1
+      version: 4.1.1
+    '@composio/json-schema-to-zod':
+      specifier: ^0.1.19
+      version: 0.1.19
+    '@modelcontextprotocol/sdk':
+      specifier: 1.27.1
+      version: 1.27.1
+    '@types/chrome':
+      specifier: ^0.0.326
+      version: 0.0.326
+    '@types/node':
+      specifier: 22.17.2
+      version: 22.17.2
+    '@types/react':
+      specifier: ^19.2.9
+      version: 19.2.9
+    '@types/react-dom':
+      specifier: ^19.1.2
+      version: 19.2.3
+    '@vitest/browser':
+      specifier: ^4.0.18
+      version: 4.0.18
+    '@vitest/browser-playwright':
+      specifier: ^4.0.18
+      version: 4.0.18
+    '@vitest/coverage-v8':
+      specifier: ^4.0.18
+      version: 4.0.18
+    fast-check:
+      specifier: ^4.0.0
+      version: 4.5.3
+    playwright:
+      specifier: ^1.58.0
+      version: 1.58.0
+    react:
+      specifier: ^19.1.0
+      version: 19.2.3
+    react-dom:
+      specifier: ^19.1.0
+      version: 19.2.3
+    tsdown:
+      specifier: ^0.15.10
+      version: 0.15.10
+    typescript:
+      specifier: ^5.8.3
+      version: 5.9.3
+    vite:
+      specifier: ^7.1.11
+      version: 7.3.1
+    vite-plugin-monkey:
+      specifier: ^6.0.1
+      version: 6.0.1
+    vitest:
+      specifier: ^4.0.18
+      version: 4.0.18
+    zod:
+      specifier: 3.25.76
+      version: 3.25.76
+    zod-to-json-schema:
+      specifier: ^3.24.5
+      version: 3.25.1
+
 overrides:
   ajv@8: '>=8.18.0'
   basic-ftp: '>=5.2.0'
@@ -84,7 +150,7 @@ importers:
         version: link:../../packages/transports
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       react:
         specifier: 'catalog:'
         version: 19.2.3
@@ -94,6 +160,46 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 3.25.76
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.9
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.9)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2))
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  e2e/react-webmcp-test-app-zod4:
+    dependencies:
+      '@mcp-b/global':
+        specifier: workspace:*
+        version: link:../../packages/global
+      '@mcp-b/react-webmcp':
+        specifier: workspace:*
+        version: link:../../packages/react-webmcp
+      '@mcp-b/transports':
+        specifier: workspace:*
+        version: link:../../packages/transports
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.3
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.3(react@19.2.3)
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.5
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -124,7 +230,7 @@ importers:
         version: link:../../packages/transports
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -134,6 +240,46 @@ importers:
       zod:
         specifier: 3.25.76
         version: 3.25.76
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.18
+        version: 18.3.27
+      '@types/react-dom':
+        specifier: ^18.3.5
+        version: 18.3.7(@types/react@18.3.27)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2))
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  e2e/react18-zod4:
+    dependencies:
+      '@mcp-b/global':
+        specifier: workspace:*
+        version: link:../../packages/global
+      '@mcp-b/react-webmcp':
+        specifier: workspace:*
+        version: link:../../packages/react-webmcp
+      '@mcp-b/transports':
+        specifier: workspace:*
+        version: link:../../packages/transports
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.5)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.5
     devDependencies:
       '@types/react':
         specifier: ^18.3.18
@@ -170,7 +316,7 @@ importers:
         version: link:../../packages/webmcp-types
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -204,6 +350,28 @@ importers:
         specifier: 'catalog:'
         version: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
 
+  e2e/vanilla-esm-zod4:
+    dependencies:
+      '@mcp-b/global':
+        specifier: workspace:*
+        version: link:../../packages/global
+      '@mcp-b/webmcp-ts-sdk':
+        specifier: workspace:*
+        version: link:../../packages/webmcp-ts-sdk
+      '@mcp-b/webmcp-types':
+        specifier: workspace:*
+        version: link:../../packages/webmcp-types
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.5
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
+
   e2e/vanilla-iife-json:
     devDependencies:
       '@mcp-b/global':
@@ -214,6 +382,15 @@ importers:
         version: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
 
   e2e/vanilla-iife-zod3:
+    devDependencies:
+      '@mcp-b/global':
+        specifier: workspace:*
+        version: link:../../packages/global
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  e2e/vanilla-iife-zod4:
     devDependencies:
       '@mcp-b/global':
         specifier: workspace:*
@@ -507,7 +684,7 @@ importers:
         version: 0.1.19(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       core-js:
         specifier: 3.48.0
         version: 3.48.0
@@ -726,7 +903,7 @@ importers:
         specifier: ^3.25 || ^4.0
         version: 3.25.76
       zod-to-json-schema:
-        specifier: ^3.25.0
+        specifier: 'catalog:'
         version: 3.25.1(zod@3.25.76)
     devDependencies:
       '@types/node':
@@ -792,7 +969,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       playwright:
         specifier: ^1.54.2
         version: 1.58.0
@@ -900,7 +1077,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       ws:
         specifier: ^8.18.0
         version: 8.19.0
@@ -984,7 +1161,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.5)
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.5)
       '@types/node':
         specifier: 'catalog:'
         version: 22.17.2
@@ -1017,61 +1194,6 @@ importers:
         version: 4.0.18(@types/node@24.9.2)(@vitest/browser-playwright@4.0.18)(happy-dom@20.7.0)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
 
   skills/webmcp-setup: {}
-
-  webmcp-tools/demos/react-flightsearch:
-    dependencies:
-      '@types/react-router-dom':
-        specifier: ^5.3.3
-        version: 5.3.3
-      rc-slider:
-        specifier: ^11.1.8
-        version: 11.1.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react:
-        specifier: ^19.1.1
-        version: 19.2.3
-      react-dom:
-        specifier: ^19.1.1
-        version: 19.2.3(react@19.2.3)
-      react-router-dom:
-        specifier: ^7.13.0
-        version: 7.13.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-    devDependencies:
-      '@eslint/js':
-        specifier: ^9.33.0
-        version: 9.39.2
-      '@mcp-b/webmcp-types':
-        specifier: ^2.0.7
-        version: 2.0.7
-      '@types/react':
-        specifier: ^19.1.10
-        version: 19.2.9
-      '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.2.3(@types/react@19.2.9)
-      '@vitejs/plugin-react-swc':
-        specifier: ^4.0.0
-        version: 4.2.3(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2))
-      eslint:
-        specifier: ^9.33.0
-        version: 9.39.2(jiti@2.6.1)
-      eslint-plugin-react-hooks:
-        specifier: ^5.2.0
-        version: 5.2.0(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react-refresh:
-        specifier: ^0.4.20
-        version: 0.4.26(eslint@9.39.2(jiti@2.6.1))
-      globals:
-        specifier: ^16.3.0
-        version: 16.4.0
-      typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
-      typescript-eslint:
-        specifier: ^8.39.1
-        version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -2682,9 +2804,6 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@jridgewell/trace-mapping@0.3.30':
-    resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
-
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
@@ -2739,11 +2858,18 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mcp-b/webmcp-types@2.0.7':
-    resolution: {integrity: sha512-6ILuJM0F6YxIcyCDsMHvE6byez8eAr9yyfWvxFqzwVrBGbQoadBoWLBThJ/6lWlXMxxnfiRROzzJsB2bcVUcDg==}
-
   '@modelcontextprotocol/sdk@1.26.0':
     resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -3977,83 +4103,8 @@ packages:
       svelte: '>=5.53.5'
       vite: ^6.3.0 || ^7.0.0
 
-  '@swc/core-darwin-arm64@1.15.17':
-    resolution: {integrity: sha512-eB9qdyt4E60323IS0rgV/rd79DJ+YWSyIKi+sT1dlIgR3ns4xlBiunREM3lVH0FKcUbhttiBvdVubT4QoOuZ+w==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@swc/core-darwin-x64@1.15.17':
-    resolution: {integrity: sha512-k1TZARYs8947jJpSioqcPrusz+wEeABF4iiSdwcSyQh2rIUdIEk5FOyaqJASFPJ6dZfx7ZVOyjtDATVAegs2/Q==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@swc/core-linux-arm-gnueabihf@1.15.17':
-    resolution: {integrity: sha512-p6282NQZo5bzx0wphz1ETGjhcRB9CN+/XUAjQwApyoyX9iCloI5IT/RC3vjbflo42g8RPTxUTaItAO0hlLSesQ==}
-    engines: {node: '>=10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@swc/core-linux-arm64-gnu@1.15.17':
-    resolution: {integrity: sha512-TGnDS4ejy8y9jqxXqZCyA+DvFc64nXUHS9rxdyeJ9B9uyIdtKVhBrA2xfghYRS/sSPSyHZ0yu89NxBICvONH+A==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@swc/core-linux-arm64-musl@1.15.17':
-    resolution: {integrity: sha512-D0/6Hj4CkgSTTahtlGxv9IDsLTuvQz30mkZEMDp8TqwYhCL8AomznkibwlQU8HtY4q/dqd1OGRPH+FmNb4BBEA==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@swc/core-linux-x64-gnu@1.15.17':
-    resolution: {integrity: sha512-1s2OFsg6DeRkWU7c+PIfIHZsFCbiZ34akXFHrg7KjpF8zIvpHZNoUUZimoWEwcB6GquXSkAO+1b5KpG5nusTeQ==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@swc/core-linux-x64-musl@1.15.17':
-    resolution: {integrity: sha512-gtxGMGYtRWWmCcgx6xM2Yos43uiE/j8kZwkeL/LNGG9zM0tatd23NsfL9PnQJ45hY7QZ+dx2rM68e4ArgG4kJg==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@swc/core-win32-arm64-msvc@1.15.17':
-    resolution: {integrity: sha512-gxi+/Miytez/O9vJ/QiheIivA3oWZjPp9nJu3VmAfLMWUzcZORMwgaI1ygtDTLjz7CzcwlGMJz/Ab66Y5DfNpg==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@swc/core-win32-ia32-msvc@1.15.17':
-    resolution: {integrity: sha512-KUsRqNbTp7SpNK0T9m4+i8GlngzNjwb69a3ttKA6XJ5r6Pewm+NSYji93pNkawXIivbWY2jhvceGMAyd+4hWaQ==}
-    engines: {node: '>=10'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@swc/core-win32-x64-msvc@1.15.17':
-    resolution: {integrity: sha512-zqtEGE0/rTKvEC5sOtpANLHeWEPjsTD4/rwpUxo6ymztcLI/Z+L9Wi9xQvIGmLTUih1gvNZcAwROqdfRP3oAWQ==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@swc/core@1.15.17':
-    resolution: {integrity: sha512-Mu3eOrYlkdQPl7yqotNckitTr6FZ0yd7mlWIBEzK+EGIyybgMENJHmbS2DeA7BMleJiBElP6ke+Nz93pkKmKJw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.17'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@swc/counter@0.1.3':
-    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
-
-  '@swc/types@0.1.25':
-    resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
 
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
@@ -4204,9 +4255,6 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
-  '@types/history@4.7.11':
-    resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -4246,12 +4294,6 @@ packages:
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
-
-  '@types/react-router-dom@5.3.3':
-    resolution: {integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==}
-
-  '@types/react-router@5.1.20':
-    resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
 
   '@types/react@18.3.27':
     resolution: {integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==}
@@ -4488,12 +4530,6 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0
-
-  '@vitejs/plugin-react-swc@4.2.3':
-    resolution: {integrity: sha512-QIluDil2prhY1gdA3GGwxZzTAmLdi8cQ2CcuMW4PB/Wu4e/1pzqrwhYWVd09LInCRlDUidQjd0B70QWbjWtLxA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      vite: ^4 || ^5 || ^6 || ^7
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -5030,9 +5066,6 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
-  classnames@2.5.1:
-    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
-
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
@@ -5156,10 +5189,6 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
-
-  cookie@1.0.2:
-    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
-    engines: {node: '>=18'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -5591,17 +5620,6 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
-  eslint-plugin-react-hooks@5.2.0:
-    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-
-  eslint-plugin-react-refresh@0.4.26:
-    resolution: {integrity: sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==}
-    peerDependencies:
-      eslint: '>=8.40'
-
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5888,6 +5906,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-slugger@2.0.0:
@@ -6080,9 +6099,6 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
-
-  import-meta-resolve@4.1.0:
-    resolution: {integrity: sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -7403,19 +7419,6 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  rc-slider@11.1.9:
-    resolution: {integrity: sha512-h8IknhzSh3FEM9u8ivkskh+Ef4Yo4JRIY2nj7MrH6GQmrwV6mcpJf5/4KgH5JaVI1H3E52yCdpOlVyGZIeph5A==}
-    engines: {node: '>=8.x'}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
-  rc-util@5.44.4:
-    resolution: {integrity: sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -7458,23 +7461,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  react-router-dom@7.13.1:
-    resolution: {integrity: sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.13.1:
-    resolution: {integrity: sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-    peerDependenciesMeta:
-      react-dom:
         optional: true
 
   react-style-singleton@2.2.3:
@@ -7728,9 +7714,6 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -8266,11 +8249,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
-
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -9264,10 +9242,10 @@ snapshots:
 
   '@babel/generator@7.28.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
   '@babel/generator@7.29.1':
@@ -9280,7 +9258,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
@@ -9336,7 +9314,7 @@ snapshots:
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -9347,7 +9325,7 @@ snapshots:
   '@babel/helpers@7.28.4':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helpers@7.28.6':
     dependencies:
@@ -9389,8 +9367,8 @@ snapshots:
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
 
   '@babel/template@7.28.6':
     dependencies:
@@ -9401,11 +9379,11 @@ snapshots:
   '@babel/traverse@7.28.5':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
+      '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.0
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -9743,7 +9721,7 @@ snapshots:
       '@commitlint/config-validator': 19.8.1
       '@commitlint/types': 19.8.1
       global-directory: 4.0.1
-      import-meta-resolve: 4.1.0
+      import-meta-resolve: 4.2.0
       lodash.mergewith: 4.6.2
       resolve-from: 5.0.0
 
@@ -10422,7 +10400,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
     dependencies:
@@ -10432,11 +10410,6 @@ snapshots:
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
-
-  '@jridgewell/trace-mapping@0.3.30':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
@@ -10493,9 +10466,31 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mcp-b/webmcp-types@2.0.7': {}
+  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.5)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.3)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.12.3
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.5
+      zod-to-json-schema: 3.25.1(zod@4.3.5)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
 
-  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.3)
       ajv: 8.18.0
@@ -10519,7 +10514,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.5)':
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.5)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.3)
       ajv: 8.18.0
@@ -10697,7 +10692,7 @@ snapshots:
 
   '@npmcli/fs@5.0.0':
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   '@npmcli/git@7.0.1':
     dependencies:
@@ -10707,7 +10702,7 @@ snapshots:
       npm-pick-manifest: 11.0.3
       proc-log: 6.1.0
       promise-retry: 2.0.1
-      semver: 7.7.3
+      semver: 7.7.4
       which: 6.0.1
 
   '@npmcli/installed-package-contents@4.0.0':
@@ -10724,7 +10719,7 @@ snapshots:
       hosted-git-info: 9.0.2
       json-parse-even-better-errors: 5.0.0
       proc-log: 6.1.0
-      semver: 7.7.3
+      semver: 7.7.4
       spdx-expression-parse: 4.0.0
 
   '@npmcli/promise-spawn@9.0.1':
@@ -11630,61 +11625,9 @@ snapshots:
       vite: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
       vitefu: 1.1.1(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2))
 
-  '@swc/core-darwin-arm64@1.15.17':
-    optional: true
-
-  '@swc/core-darwin-x64@1.15.17':
-    optional: true
-
-  '@swc/core-linux-arm-gnueabihf@1.15.17':
-    optional: true
-
-  '@swc/core-linux-arm64-gnu@1.15.17':
-    optional: true
-
-  '@swc/core-linux-arm64-musl@1.15.17':
-    optional: true
-
-  '@swc/core-linux-x64-gnu@1.15.17':
-    optional: true
-
-  '@swc/core-linux-x64-musl@1.15.17':
-    optional: true
-
-  '@swc/core-win32-arm64-msvc@1.15.17':
-    optional: true
-
-  '@swc/core-win32-ia32-msvc@1.15.17':
-    optional: true
-
-  '@swc/core-win32-x64-msvc@1.15.17':
-    optional: true
-
-  '@swc/core@1.15.17':
-    dependencies:
-      '@swc/counter': 0.1.3
-      '@swc/types': 0.1.25
-    optionalDependencies:
-      '@swc/core-darwin-arm64': 1.15.17
-      '@swc/core-darwin-x64': 1.15.17
-      '@swc/core-linux-arm-gnueabihf': 1.15.17
-      '@swc/core-linux-arm64-gnu': 1.15.17
-      '@swc/core-linux-arm64-musl': 1.15.17
-      '@swc/core-linux-x64-gnu': 1.15.17
-      '@swc/core-linux-x64-musl': 1.15.17
-      '@swc/core-win32-arm64-msvc': 1.15.17
-      '@swc/core-win32-ia32-msvc': 1.15.17
-      '@swc/core-win32-x64-msvc': 1.15.17
-
-  '@swc/counter@0.1.3': {}
-
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
-
-  '@swc/types@0.1.25':
-    dependencies:
-      '@swc/counter': 0.1.3
 
   '@tailwindcss/node@4.1.18':
     dependencies:
@@ -11825,8 +11768,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/history@4.7.11': {}
-
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -11863,17 +11804,6 @@ snapshots:
 
   '@types/react-dom@19.2.3(@types/react@19.2.9)':
     dependencies:
-      '@types/react': 19.2.9
-
-  '@types/react-router-dom@5.3.3':
-    dependencies:
-      '@types/history': 4.7.11
-      '@types/react': 19.2.9
-      '@types/react-router': 5.1.20
-
-  '@types/react-router@5.1.20':
-    dependencies:
-      '@types/history': 4.7.11
       '@types/react': 19.2.9
 
   '@types/react@18.3.27':
@@ -11930,22 +11860,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
-      '@typescript-eslint/scope-manager': 8.53.1
-      '@typescript-eslint/type-utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.53.1
-      eslint: 9.39.2(jiti@2.6.1)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -11974,18 +11888,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.53.1
-      '@typescript-eslint/types': 8.53.1
-      '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.53.1
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.53.1
@@ -12004,15 +11906,6 @@ snapshots:
       '@typescript-eslint/types': 8.46.2
       debug: 4.4.3
       typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.53.1(typescript@5.8.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.53.1(typescript@5.8.3)
-      '@typescript-eslint/types': 8.53.1
-      debug: 4.4.3
-      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12039,25 +11932,9 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/tsconfig-utils@8.53.1(typescript@5.8.3)':
-    dependencies:
-      typescript: 5.8.3
-
   '@typescript-eslint/tsconfig-utils@8.53.1(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
-
-  '@typescript-eslint/type-utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.53.1
-      '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
-      ts-api-utils: 2.4.0(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/type-utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -12091,21 +11968,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.53.1(typescript@5.8.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.53.1(typescript@5.8.3)
-      '@typescript-eslint/tsconfig-utils': 8.53.1(typescript@5.8.3)
-      '@typescript-eslint/types': 8.53.1
-      '@typescript-eslint/visitor-keys': 8.53.1
-      debug: 4.4.3
-      minimatch: 10.2.4
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/typescript-estree@8.53.1(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.53.1(typescript@5.9.3)
@@ -12118,17 +11980,6 @@ snapshots:
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.53.1
-      '@typescript-eslint/types': 8.53.1
-      '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.8.3)
-      eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12217,14 +12068,6 @@ snapshots:
   '@vitejs/plugin-basic-ssl@2.1.0(vite@7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       vite: 7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
-
-  '@vitejs/plugin-react-swc@4.2.3(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.2
-      '@swc/core': 1.15.17
-      vite: 7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@swc/helpers'
 
   '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -13060,8 +12903,6 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
-  classnames@2.5.1: {}
-
   cli-boxes@3.0.0: {}
 
   cli-cursor@5.0.0:
@@ -13167,8 +13008,6 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
-
-  cookie@1.0.2: {}
 
   cookie@1.1.1: {}
 
@@ -13726,14 +13565,6 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.6.1)):
-    dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
-
-  eslint-plugin-react-refresh@0.4.26(eslint@9.39.2(jiti@2.6.1)):
-    dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -14344,8 +14175,6 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-meta-resolve@4.1.0: {}
-
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
@@ -14545,10 +14374,10 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.3
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -14827,8 +14656,8 @@ snapshots:
 
   magicast@0.5.1:
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
   make-dir@3.1.0:
@@ -15350,7 +15179,7 @@ snapshots:
       make-fetch-happen: 15.0.3
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.3
+      semver: 7.7.4
       tar: 7.5.9
       tinyglobby: 0.2.15
       which: 6.0.1
@@ -15373,7 +15202,7 @@ snapshots:
 
   npm-install-checks@8.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   npm-normalize-package-bin@5.0.0: {}
 
@@ -15381,14 +15210,14 @@ snapshots:
     dependencies:
       hosted-git-info: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.3
+      semver: 7.7.4
       validate-npm-package-name: 6.0.2
 
   npm-package-arg@13.0.2:
     dependencies:
       hosted-git-info: 9.0.2
       proc-log: 6.1.0
-      semver: 7.7.3
+      semver: 7.7.4
       validate-npm-package-name: 7.0.2
 
   npm-packlist@10.0.4:
@@ -15401,7 +15230,7 @@ snapshots:
       npm-install-checks: 8.0.0
       npm-normalize-package-bin: 5.0.0
       npm-package-arg: 13.0.2
-      semver: 7.7.3
+      semver: 7.7.4
 
   npm-registry-fetch@19.1.1:
     dependencies:
@@ -15879,21 +15708,6 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  rc-slider@11.1.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      '@babel/runtime': 7.28.6
-      classnames: 2.5.1
-      rc-util: 5.44.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-
-  rc-util@5.44.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      '@babel/runtime': 7.28.6
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-is: 18.3.1
-
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -15931,20 +15745,6 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.2.9)(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.9
-
-  react-router-dom@7.13.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-router: 7.13.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-
-  react-router@7.13.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.3
-      set-cookie-parser: 2.7.2
-    optionalDependencies:
-      react-dom: 19.2.3(react@19.2.3)
 
   react-style-singleton@2.2.3(@types/react@19.2.9)(react@19.2.3):
     dependencies:
@@ -16330,8 +16130,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  set-cookie-parser@2.7.2: {}
-
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -16360,7 +16158,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.0.0
       detect-libc: 2.1.2
-      semver: 7.7.3
+      semver: 7.7.4
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -16820,10 +16618,6 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-api-utils@2.4.0(typescript@5.8.3):
-    dependencies:
-      typescript: 5.8.3
-
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -16852,7 +16646,7 @@ snapshots:
       hookable: 5.5.3
       rolldown: 1.0.0-beta.44
       rolldown-plugin-dts: 0.17.1(rolldown@1.0.0-beta.44)(typescript@5.9.3)
-      semver: 7.7.3
+      semver: 7.7.4
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
@@ -16964,17 +16758,6 @@ snapshots:
 
   typed-query-selector@2.12.0: {}
 
-  typescript-eslint@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
-      '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
-      eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
   typescript-eslint@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -16985,8 +16768,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  typescript@5.8.3: {}
 
   typescript@5.9.3: {}
 
@@ -17192,7 +16973,7 @@ snapshots:
       acorn-walk: 8.3.4
       cross-spawn: 7.0.6
       htmlparser2: 10.1.0
-      import-meta-resolve: 4.1.0
+      import-meta-resolve: 4.2.0
       magic-string: 0.30.21
       mrmime: 2.0.1
       open: 10.2.0
@@ -17223,7 +17004,7 @@ snapshots:
 
   vite@7.3.0(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -17240,7 +17021,7 @@ snapshots:
 
   vite@7.3.1(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -17585,7 +17366,7 @@ snapshots:
       '@poppinss/colors': 4.1.5
       '@poppinss/dumper': 0.6.4
       '@speed-highlight/core': 1.2.8
-      cookie: 1.0.2
+      cookie: 1.1.1
       youch-core: 0.3.3
 
   zimmerframe@1.1.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,11 +5,15 @@ packages:
   - e2e
   - e2e/test-app
   - e2e/react-webmcp-test-app
+  - e2e/react-webmcp-test-app-zod4
   - e2e/web-standards-showcase
   - e2e/vanilla-iife-json
   - e2e/vanilla-iife-zod3
+  - e2e/vanilla-iife-zod4
   - e2e/vanilla-esm-zod3
+  - e2e/vanilla-esm-zod4
   - e2e/react18-zod3
+  - e2e/react18-zod4
   - examples/frameworks/*
 
 catalog:
@@ -17,7 +21,7 @@ catalog:
   '@cloudflare/vite-plugin': ^1.13.18
   '@composio/json-schema-to-zod': ^0.1.19
   '@hookform/resolvers': ^5.2.2
-  '@modelcontextprotocol/sdk': 1.26.0
+  '@modelcontextprotocol/sdk': 1.27.1
   '@radix-ui/react-collapsible': ^1.1.12
   '@sentry/cloudflare': ^10.22.0
   '@sentry/react': ^10.22.0


### PR DESCRIPTION
### Motivation
- Bring `@mcp-b/react-webmcp` in line with the MCP TS SDK compat pattern so projects using either Zod v3.25+ or Zod v4 can interoperate without runtime errors. 
- Replace brittle v3-only detection/conversion logic with a dual-path compat layer that mirrors upstream MCP behavior and rejects mixed-version raw shapes. 
- Expand the E2E validation matrix to explicitly cover Zod v4 app variants so behavior parity is validated across both major Zod lines.

### Description
- Bumped workspace SDK pin to `@modelcontextprotocol/sdk` `1.27.1` in `pnpm-workspace.yaml` and updated the lockfile references accordingly. 
- Reworked `packages/react-webmcp/src/zod-utils.ts` to implement MCP-style dual-path conversion: runtime detection (`_zod` => v4, `_def` => v3), explicit mixed-version rejection, Zod v3 conversion via `zod-to-json-schema`, and Zod v4 conversion via `zod/v4-mini` `toJSONSchema`. 
- Replaced the mocked zod utility tests with real-version matrix tests in `packages/react-webmcp/src/zod-utils.test.ts` (covers v3 conversion, v4 conversion, optional/default behavior and mixed-version error). 
- Updated `@mcp-b/react-webmcp` package model to include runtime `zod` (`^3.25 || ^4.0`) and `zod-to-json-schema`, kept peer range guidance, and updated type/comments/README to document official v3/v4 support. 
- Added Zod 4 E2E app variants and wiring (new workspaces under `e2e/`: `vanilla-iife-zod4`, `vanilla-esm-zod4`, `react18-zod4`, `react-webmcp-test-app-zod4`) and updated Playwright config + validation matrix tests to run the full Zod3/Zod4 matrix and assert per-app expected Zod version.

### Testing
- `git diff --check` passed after changes and changes were committed successfully. 
- `pnpm --lockfile-only` / workspace lockfile refresh completed (lockfile updated to reflect new SDK/catalog entries). 
- `pnpm --filter @mcp-b/react-webmcp test` attempted but failed in this environment because Playwright browser binaries are not present; test runner surfaced Playwright binary errors (requires `pnpm exec playwright install`) so browser-dependent tests could not complete. 
- `pnpm --filter @mcp-b/react-webmcp typecheck` was attempted and failed in this environment due to workspace module-resolution / ambient `Navigator` typing issues (these are environment/workspace integration constraints rather than logic regressions). 
- `pnpm --filter mcp-e2e-tests test:validation-matrix` was attempted but failed because Playwright Chromium could not be installed here (download blocked by CDN with `403 Domain forbidden`), so the full browser matrix could not be executed in this CI-like environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8883c2128832bad1ac74b31f91616)