### PR TITLE
fix(transports): default targetOrigin to * and fix relay schema compat

### DIFF
--- a/packages/transports/src/IframeParentTransport.ts
+++ b/packages/transports/src/IframeParentTransport.ts
@@ -4,7 +4,7 @@ export interface IframeParentTransportOptions {
   /** Reference to the iframe element */
   iframe: HTMLIFrameElement;
   /** Expected origin of the iframe (for security) */
-  targetOrigin: string;
+  targetOrigin?: string;
   /** Optional channel name (default: 'mcp-iframe') */
   channelId?: string;
   /** Retry interval for ready handshake in milliseconds (default: 250) */
@@ -49,12 +49,8 @@ export class IframeParentTransport implements Transport {
     if (!options.iframe) {
       throw new Error('iframe element is required');
     }
-    if (!options.targetOrigin) {
-      throw new Error('targetOrigin must be explicitly set for security');
-    }
-
     this._iframe = options.iframe;
-    this._targetOrigin = options.targetOrigin;
+    this._targetOrigin = options.targetOrigin || '*';
     this._channelId = options.channelId || 'mcp-iframe';
     this._checkReadyRetryMs = options.checkReadyRetryMs ?? 250;
 

--- a/packages/transports/src/TabClientTransport.ts
+++ b/packages/transports/src/TabClientTransport.ts
@@ -16,7 +16,7 @@ export interface TabClientTransportOptions {
    * @example 'https://example.com'
    * @example 'http://localhost:3000'
    */
-  targetOrigin: string;
+  targetOrigin?: string;
 
   /**
    * Channel identifier for message routing.
@@ -194,11 +194,7 @@ export class TabClientTransport implements Transport {
    * @throws {Error} If targetOrigin is not specified
    */
   constructor(options: TabClientTransportOptions) {
-    if (!options.targetOrigin) {
-      throw new Error('targetOrigin must be explicitly set for security');
-    }
-
-    this._targetOrigin = options.targetOrigin;
+    this._targetOrigin = options.targetOrigin || '*';
     this._channelId = options.channelId ?? 'mcp-default';
     this._requestTimeout = options.requestTimeout ?? 10000; // Default 10 seconds
 

--- a/packages/transports/src/TabTransport.browser.test.ts
+++ b/packages/transports/src/TabTransport.browser.test.ts
@@ -63,11 +63,9 @@ browserDescribe('Tab transports (browser)', () => {
       await safeClose(clientTransport);
     });
 
-    it('throws if targetOrigin is not provided', () => {
-      expect(() => {
-        // @ts-expect-error testing invalid input
-        new TabClientTransport({});
-      }).toThrow('targetOrigin must be explicitly set for security');
+    it('defaults targetOrigin to * when not provided', () => {
+      const transport = new TabClientTransport({});
+      expect((transport as any)._targetOrigin).toBe('*');
     });
 
     it('rejects sends before start', async () => {

--- a/packages/webmcp-local-relay/src/schemas.test.ts
+++ b/packages/webmcp-local-relay/src/schemas.test.ts
@@ -536,13 +536,28 @@ describe('RelayServerToolsSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects relay/tools without sources', () => {
+  it('accepts relay/tools without sources (defaults to empty)', () => {
     const result = RelayServerToolsSchema.safeParse({
       type: 'relay/tools',
       tools: [],
       toolSourceMap: {},
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.sources).toEqual([]);
+    }
+  });
+
+  it('accepts relay/tools without sources or toolSourceMap (both default)', () => {
+    const result = RelayServerToolsSchema.safeParse({
+      type: 'relay/tools',
+      tools: [],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.sources).toEqual([]);
+      expect(result.data.toolSourceMap).toEqual({});
+    }
   });
 
   it('rejects relay/tools with invalid tool entries', () => {

--- a/packages/webmcp-local-relay/src/schemas.ts
+++ b/packages/webmcp-local-relay/src/schemas.ts
@@ -188,8 +188,8 @@ export type RelayClientToServerMessage = z.infer<typeof RelayClientToServerMessa
 
 const RelayToolsPayloadFields = {
   tools: z.array(NormalizedToolSchema),
-  sources: z.array(RelaySourceInfoSchema),
-  toolSourceMap: z.record(z.string(), z.array(z.string())),
+  sources: z.array(RelaySourceInfoSchema).optional().default([]),
+  toolSourceMap: z.record(z.string(), z.array(z.string())).optional().default({}),
 };
 
 /**


### PR DESCRIPTION
## Summary

- **Transport targetOrigin default**: `TabClientTransport` and `IframeParentTransport` threw `targetOrigin must be explicitly set for security` when omitted. Now defaults to `'*'` so consumers (relay embed, etc.) work without explicit origin config.
- **Relay schema backwards compat**: `RelayServerToolsSchema` required `sources` and `toolSourceMap` fields, but older relay servers (e.g. Claude Desktop extension) don't send them. Zod validation silently rejected the message, causing client-mode relays to see 0 tools. Both fields are now optional with empty defaults.

## Test plan

- [x] `pnpm build` — 20 tasks pass
- [x] `pnpm typecheck` — 28 tasks pass
- [x] `pnpm check` — 408 files, no issues
- [x] `pnpm test:unit` — all pass
- [x] E2E verified: test-app counter tools visible through relay on port 9211, full round-trip (getCounter → incrementCounter → getCounter) works

Generated with [Claude Code](https://claude.com/claude-code)