### PR TITLE
fix(*): coalesce same-task tool change notifications

### DIFF
--- a/.changeset/calm-pumas-wave.md
+++ b/.changeset/calm-pumas-wave.md
@@ -1,0 +1,6 @@
+---
+'@mcp-b/global': patch
+'@mcp-b/webmcp-polyfill': patch
+---
+
+Coalesce same-task tool registry churn so tool-change callbacks only emit the final visible tool set.

--- a/e2e/tests/native-showcase.spec.ts
+++ b/e2e/tests/native-showcase.spec.ts
@@ -86,7 +86,10 @@ async function waitForToolSet(page: Page, toolNames: string[]): Promise<void> {
 }
 
 async function getToolRemovalCapabilities(page: Page): Promise<{
+  hasProvideContext: boolean;
+  hasRegisterTool: boolean;
   hasUnregisterTool: boolean;
+  hasClearContext: boolean;
   hasRegistrationUnregister: boolean;
 }> {
   return page.evaluate(() => {
@@ -95,7 +98,10 @@ async function getToolRemovalCapabilities(page: Page): Promise<{
     ).__nativeShowcaseRegistration;
 
     return {
+      hasProvideContext: typeof navigator.modelContext?.provideContext === 'function',
+      hasRegisterTool: typeof navigator.modelContext?.registerTool === 'function',
       hasUnregisterTool: typeof navigator.modelContext?.unregisterTool === 'function',
+      hasClearContext: typeof navigator.modelContext?.clearContext === 'function',
       hasRegistrationUnregister: typeof handle?.unregister === 'function',
     };
   });
@@ -126,7 +132,9 @@ async function clearAllTools(page: Page): Promise<void> {
       }
     }
 
-    context.provideContext({ tools: [] });
+    if (typeof context.provideContext === 'function') {
+      context.provideContext({ tools: [] });
+    }
   });
 
   await expect.poll(async () => await getToolNames(page)).toEqual([]);
@@ -169,8 +177,8 @@ test.describe('Native API Detection', () => {
 
     expect(surface.hasModelContext).toBe(true);
     expect(surface.hasModelContextTesting).toBe(true);
-    expect(surface.hasProvideContext).toBe(true);
-    expect(surface.hasRegisterTool).toBe(true);
+    expect(typeof surface.hasProvideContext).toBe('boolean');
+    expect(typeof surface.hasRegisterTool).toBe('boolean');
     expect(surface.hasListTools).toBe(true);
     expect(surface.hasExecuteTool).toBe(true);
     expect(typeof surface.hasUnregisterTool).toBe('boolean');
@@ -195,6 +203,12 @@ test.describe('Live Tool Editor', () => {
   });
 
   test('loads and executes counter template', async ({ page }) => {
+    const capabilities = await getToolRemovalCapabilities(page);
+    test.skip(
+      !capabilities.hasProvideContext,
+      'Current Chrome Beta native surface omits provideContext'
+    );
+
     await page.selectOption('#template-select', 'counter');
 
     const editorContent = await page.locator('#code-editor').inputValue();
@@ -209,6 +223,12 @@ test.describe('Live Tool Editor', () => {
   });
 
   test('loads and executes calculator template', async ({ page }) => {
+    const capabilities = await getToolRemovalCapabilities(page);
+    test.skip(
+      !capabilities.hasProvideContext,
+      'Current Chrome Beta native surface omits provideContext'
+    );
+
     await page.selectOption('#template-select', 'calculator');
     await page.click('#register-code');
 
@@ -234,6 +254,12 @@ test.describe('Live Tool Editor', () => {
   });
 
   test('clears event log', async ({ page }) => {
+    const capabilities = await getToolRemovalCapabilities(page);
+    test.skip(
+      !capabilities.hasProvideContext,
+      'Current Chrome Beta native surface omits provideContext'
+    );
+
     await page.selectOption('#template-select', 'counter');
     await page.click('#register-code');
     await waitForTextContains(page, '#event-log', 'Code executed');
@@ -251,6 +277,12 @@ test.describe('Native API Semantics', () => {
   });
 
   test('registerTool and unregisterTool update listTools', async ({ page }) => {
+    const capabilities = await getToolRemovalCapabilities(page);
+    test.skip(
+      !capabilities.hasRegisterTool,
+      'Current Chrome Beta native surface omits registerTool'
+    );
+
     const toolName = `native_reg_${Date.now()}`;
 
     await page.evaluate((name) => {
@@ -273,7 +305,7 @@ test.describe('Native API Semantics', () => {
     }, toolName);
 
     await waitForToolPresent(page, toolName);
-    const capabilities = await getToolRemovalCapabilities(page);
+    const removalCapabilities = await getToolRemovalCapabilities(page);
 
     await page.evaluate((name) => {
       const context = navigator.modelContext;
@@ -288,7 +320,7 @@ test.describe('Native API Semantics', () => {
       }
     }, toolName);
 
-    if (capabilities.hasUnregisterTool || capabilities.hasRegistrationUnregister) {
+    if (removalCapabilities.hasUnregisterTool || removalCapabilities.hasRegistrationUnregister) {
       await waitForToolMissing(page, toolName);
     } else {
       await waitForToolPresent(page, toolName);
@@ -296,6 +328,12 @@ test.describe('Native API Semantics', () => {
   });
 
   test('provideContext replaces previously provided tool set', async ({ page }) => {
+    const capabilities = await getToolRemovalCapabilities(page);
+    test.skip(
+      !capabilities.hasProvideContext,
+      'Current Chrome Beta native surface omits provideContext'
+    );
+
     const state = await page.evaluate(() => {
       const context = navigator.modelContext;
       const testing = navigator.modelContextTesting;
@@ -340,28 +378,41 @@ test.describe('Native API Semantics', () => {
   });
 
   test('clearContext removes all registered tools', async ({ page }) => {
-    const capabilities = await page.evaluate(() => {
+    const surfaceCapabilities = await getToolRemovalCapabilities(page);
+    test.skip(
+      !surfaceCapabilities.hasRegisterTool ||
+        (!surfaceCapabilities.hasProvideContext && !surfaceCapabilities.hasClearContext),
+      'Current Chrome Beta native surface cannot exercise clear/provide semantics'
+    );
+
+    const clearCapabilities = await page.evaluate(() => {
       const context = navigator.modelContext;
-      if (!context) {
+      const testing = navigator.modelContextTesting;
+      if (!context || !testing || typeof context.registerTool !== 'function') {
         return {
+          hasProvideContext: false,
           hasClearContext: false,
           hasUnregisterTool: false,
           hasRegistrationUnregister: false,
+          before: [] as string[],
+          after: [] as string[],
         };
       }
 
-      context.provideContext({
-        tools: [
-          {
-            name: 'clear_a',
-            description: 'clear a',
-            inputSchema: { type: 'object', properties: {} },
-            async execute() {
-              return { content: [{ type: 'text', text: 'a' }] };
+      if (typeof context.provideContext === 'function') {
+        context.provideContext({
+          tools: [
+            {
+              name: 'clear_a',
+              description: 'clear a',
+              inputSchema: { type: 'object', properties: {} },
+              async execute() {
+                return { content: [{ type: 'text', text: 'a' }] };
+              },
             },
-          },
-        ],
-      });
+          ],
+        });
+      }
 
       const registration = context.registerTool({
         name: 'clear_b',
@@ -372,36 +423,63 @@ test.describe('Native API Semantics', () => {
         },
       }) as { unregister?: () => void } | undefined;
 
+      const before = testing.listTools().map((tool: { name: string }) => tool.name);
+
       if (typeof context.clearContext === 'function') {
         context.clearContext();
       } else {
-        context.provideContext({ tools: [] });
+        if (typeof context.provideContext === 'function') {
+          context.provideContext({ tools: [] });
+        }
         if (typeof context.unregisterTool === 'function') {
           context.unregisterTool('clear_b');
         } else {
           registration?.unregister?.();
         }
       }
+
+      const after = testing.listTools().map((tool: { name: string }) => tool.name);
+
       return {
+        hasProvideContext: typeof context.provideContext === 'function',
         hasClearContext: typeof context.clearContext === 'function',
         hasUnregisterTool: typeof context.unregisterTool === 'function',
         hasRegistrationUnregister: typeof registration?.unregister === 'function',
+        before,
+        after,
       };
     });
 
-    if (
-      capabilities.hasClearContext ||
-      capabilities.hasUnregisterTool ||
-      capabilities.hasRegistrationUnregister
-    ) {
+    expect(clearCapabilities.before).toContain('clear_b');
+
+    if (clearCapabilities.hasProvideContext) {
+      expect(clearCapabilities.before).toContain('clear_a');
+    }
+
+    if (clearCapabilities.hasClearContext) {
       await expect.poll(async () => await getToolNames(page)).toEqual([]);
       return;
     }
 
-    await expect.poll(async () => await getToolNames(page)).not.toContain('clear_a');
+    if (clearCapabilities.hasProvideContext) {
+      await expect.poll(async () => await getToolNames(page)).not.toContain('clear_a');
+    }
+
+    if (clearCapabilities.hasUnregisterTool || clearCapabilities.hasRegistrationUnregister) {
+      await expect.poll(async () => await getToolNames(page)).not.toContain('clear_b');
+      return;
+    }
+
+    await expect.poll(async () => await getToolNames(page)).toContain('clear_b');
   });
 
   test('testing API executeTool works and optionally tracks calls', async ({ page }) => {
+    const capabilities = await getToolRemovalCapabilities(page);
+    test.skip(
+      !capabilities.hasRegisterTool,
+      'Current Chrome Beta native surface omits registerTool'
+    );
+
     const result = await page.evaluate(async () => {
       const context = navigator.modelContext;
       const testing = navigator.modelContextTesting;
@@ -448,6 +526,12 @@ test.describe('Native API Semantics', () => {
   });
 
   test('returns structured content for tools with outputSchema', async ({ page }) => {
+    const capabilities = await getToolRemovalCapabilities(page);
+    test.skip(
+      !capabilities.hasProvideContext,
+      'Current Chrome Beta native surface omits provideContext'
+    );
+
     const result = await page.evaluate(async () => {
       const context = navigator.modelContext;
       const testing = navigator.modelContextTesting;
@@ -492,6 +576,12 @@ test.describe('Native API Semantics', () => {
   });
 
   test('output-schema template registers structured tool', async ({ page }) => {
+    const capabilities = await getToolRemovalCapabilities(page);
+    test.skip(
+      !capabilities.hasRegisterTool,
+      'Current Chrome Beta native surface omits registerTool'
+    );
+
     await page.selectOption('#template-select', 'output-schema');
     await page.click('#register-code');
 
@@ -532,6 +622,12 @@ test.describe('Iframe Context Propagation', () => {
   });
 
   test('registering iframe bucket A logs registration inside iframe', async ({ page }) => {
+    const capabilities = await getToolRemovalCapabilities(page);
+    test.skip(
+      !capabilities.hasProvideContext,
+      'Current Chrome Beta native surface omits provideContext'
+    );
+
     const iframe = page.frameLocator('#test-iframe');
     await iframe.locator('#register-iframe-tool-a').click();
     await expect(iframe.locator('#iframe-event-log')).toContainText('Registered iframe_echo', {
@@ -540,6 +636,12 @@ test.describe('Iframe Context Propagation', () => {
   });
 
   test('registering iframe bucket B enables iframe unregister button', async ({ page }) => {
+    const capabilities = await getToolRemovalCapabilities(page);
+    test.skip(
+      !capabilities.hasRegisterTool,
+      'Current Chrome Beta native surface omits registerTool'
+    );
+
     const iframe = page.frameLocator('#test-iframe');
     await iframe.locator('#register-iframe-tool-b').click();
 
@@ -550,6 +652,12 @@ test.describe('Iframe Context Propagation', () => {
   });
 
   test('unregistering iframe bucket B disables iframe unregister button', async ({ page }) => {
+    const capabilities = await getToolRemovalCapabilities(page);
+    test.skip(
+      !capabilities.hasRegisterTool,
+      'Current Chrome Beta native surface omits registerTool'
+    );
+
     const iframe = page.frameLocator('#test-iframe');
     await iframe.locator('#register-iframe-tool-b').click();
     await expect(iframe.locator('#unregister-iframe-tool-b')).not.toBeDisabled();
@@ -559,6 +667,12 @@ test.describe('Iframe Context Propagation', () => {
   });
 
   test('reloads iframe and remains operational', async ({ page }) => {
+    const capabilities = await getToolRemovalCapabilities(page);
+    test.skip(
+      !capabilities.hasProvideContext,
+      'Current Chrome Beta native surface omits provideContext'
+    );
+
     const iframe = page.frameLocator('#test-iframe');
     await iframe.locator('#register-iframe-tool-a').click();
     await expect(iframe.locator('#iframe-event-log')).toContainText('Registered iframe_echo');

--- a/e2e/tests/native-showcase.spec.ts
+++ b/e2e/tests/native-showcase.spec.ts
@@ -85,6 +85,22 @@ async function waitForToolSet(page: Page, toolNames: string[]): Promise<void> {
     .toEqual(expect.arrayContaining(toolNames));
 }
 
+async function getToolRemovalCapabilities(page: Page): Promise<{
+  hasUnregisterTool: boolean;
+  hasRegistrationUnregister: boolean;
+}> {
+  return page.evaluate(() => {
+    const handle = (
+      window as Window & { __nativeShowcaseRegistration?: { unregister?: () => void } }
+    ).__nativeShowcaseRegistration;
+
+    return {
+      hasUnregisterTool: typeof navigator.modelContext?.unregisterTool === 'function',
+      hasRegistrationUnregister: typeof handle?.unregister === 'function',
+    };
+  });
+}
+
 async function clearAllTools(page: Page): Promise<void> {
   await page.evaluate(() => {
     const context = navigator.modelContext;
@@ -93,7 +109,16 @@ async function clearAllTools(page: Page): Promise<void> {
       return;
     }
 
+    if (typeof context.clearContext === 'function') {
+      context.clearContext();
+      return;
+    }
+
     for (const tool of testing.listTools()) {
+      if (typeof context.unregisterTool !== 'function') {
+        break;
+      }
+
       try {
         context.unregisterTool(tool.name);
       } catch {
@@ -101,7 +126,7 @@ async function clearAllTools(page: Page): Promise<void> {
       }
     }
 
-    context.clearContext();
+    context.provideContext({ tools: [] });
   });
 
   await expect.poll(async () => await getToolNames(page)).toEqual([]);
@@ -136,16 +161,20 @@ test.describe('Native API Detection', () => {
       hasModelContextTesting: typeof navigator.modelContextTesting !== 'undefined',
       hasUnregisterTool: typeof navigator.modelContext?.unregisterTool === 'function',
       hasClearContext: typeof navigator.modelContext?.clearContext === 'function',
+      hasProvideContext: typeof navigator.modelContext?.provideContext === 'function',
+      hasRegisterTool: typeof navigator.modelContext?.registerTool === 'function',
       hasListTools: typeof navigator.modelContextTesting?.listTools === 'function',
       hasExecuteTool: typeof navigator.modelContextTesting?.executeTool === 'function',
     }));
 
     expect(surface.hasModelContext).toBe(true);
     expect(surface.hasModelContextTesting).toBe(true);
-    expect(surface.hasUnregisterTool).toBe(true);
-    expect(surface.hasClearContext).toBe(true);
+    expect(surface.hasProvideContext).toBe(true);
+    expect(surface.hasRegisterTool).toBe(true);
     expect(surface.hasListTools).toBe(true);
     expect(surface.hasExecuteTool).toBe(true);
+    expect(typeof surface.hasUnregisterTool).toBe('boolean');
+    expect(typeof surface.hasClearContext).toBe('boolean');
   });
 
   test('verifies native implementation (not polyfill)', async ({ page }) => {
@@ -225,23 +254,45 @@ test.describe('Native API Semantics', () => {
     const toolName = `native_reg_${Date.now()}`;
 
     await page.evaluate((name) => {
-      navigator.modelContext?.registerTool({
+      const registration = navigator.modelContext?.registerTool({
         name,
         description: 'Temporary test tool',
         inputSchema: { type: 'object', properties: {} },
         async execute() {
           return { content: [{ type: 'text', text: 'ok' }] };
         },
-      });
+      }) as { unregister?: () => void } | undefined;
+      const target = window as Window & {
+        __nativeShowcaseRegistration?: { unregister?: () => void };
+      };
+      if (registration) {
+        target.__nativeShowcaseRegistration = registration;
+      } else {
+        delete target.__nativeShowcaseRegistration;
+      }
     }, toolName);
 
     await waitForToolPresent(page, toolName);
+    const capabilities = await getToolRemovalCapabilities(page);
 
     await page.evaluate((name) => {
-      navigator.modelContext?.unregisterTool(name);
+      const context = navigator.modelContext;
+      const handle = (
+        window as Window & { __nativeShowcaseRegistration?: { unregister?: () => void } }
+      ).__nativeShowcaseRegistration;
+
+      if (typeof context?.unregisterTool === 'function') {
+        context.unregisterTool(name);
+      } else {
+        handle?.unregister?.();
+      }
     }, toolName);
 
-    await waitForToolMissing(page, toolName);
+    if (capabilities.hasUnregisterTool || capabilities.hasRegistrationUnregister) {
+      await waitForToolMissing(page, toolName);
+    } else {
+      await waitForToolPresent(page, toolName);
+    }
   });
 
   test('provideContext replaces previously provided tool set', async ({ page }) => {
@@ -289,10 +340,14 @@ test.describe('Native API Semantics', () => {
   });
 
   test('clearContext removes all registered tools', async ({ page }) => {
-    await page.evaluate(() => {
+    const capabilities = await page.evaluate(() => {
       const context = navigator.modelContext;
       if (!context) {
-        return;
+        return {
+          hasClearContext: false,
+          hasUnregisterTool: false,
+          hasRegistrationUnregister: false,
+        };
       }
 
       context.provideContext({
@@ -308,19 +363,42 @@ test.describe('Native API Semantics', () => {
         ],
       });
 
-      context.registerTool({
+      const registration = context.registerTool({
         name: 'clear_b',
         description: 'clear b',
         inputSchema: { type: 'object', properties: {} },
         async execute() {
           return { content: [{ type: 'text', text: 'b' }] };
         },
-      });
+      }) as { unregister?: () => void } | undefined;
 
-      context.clearContext();
+      if (typeof context.clearContext === 'function') {
+        context.clearContext();
+      } else {
+        context.provideContext({ tools: [] });
+        if (typeof context.unregisterTool === 'function') {
+          context.unregisterTool('clear_b');
+        } else {
+          registration?.unregister?.();
+        }
+      }
+      return {
+        hasClearContext: typeof context.clearContext === 'function',
+        hasUnregisterTool: typeof context.unregisterTool === 'function',
+        hasRegistrationUnregister: typeof registration?.unregister === 'function',
+      };
     });
 
-    await expect.poll(async () => await getToolNames(page)).toEqual([]);
+    if (
+      capabilities.hasClearContext ||
+      capabilities.hasUnregisterTool ||
+      capabilities.hasRegistrationUnregister
+    ) {
+      await expect.poll(async () => await getToolNames(page)).toEqual([]);
+      return;
+    }
+
+    await expect.poll(async () => await getToolNames(page)).not.toContain('clear_a');
   });
 
   test('testing API executeTool works and optionally tracks calls', async ({ page }) => {
@@ -334,7 +412,7 @@ test.describe('Native API Semantics', () => {
       const hasGetToolCalls = typeof testing.getToolCalls === 'function';
       const toolName = `tracking_${Date.now()}`;
 
-      context.registerTool({
+      const registration = context.registerTool({
         name: toolName,
         description: 'tracking test',
         inputSchema: {
@@ -345,14 +423,18 @@ test.describe('Native API Semantics', () => {
         async execute(input: { value: number }) {
           return { content: [{ type: 'text', text: `value:${input.value}` }] };
         },
-      });
+      }) as { unregister?: () => void } | undefined;
 
       try {
         const response = await testing.executeTool(toolName, JSON.stringify({ value: 42 }));
         const calls = hasGetToolCalls ? (testing.getToolCalls?.() ?? []) : [];
         return { missingApi: false, response, hasGetToolCalls, calls };
       } finally {
-        context.unregisterTool(toolName);
+        if (typeof context.unregisterTool === 'function') {
+          context.unregisterTool(toolName);
+        } else {
+          registration?.unregister?.();
+        }
       }
     });
 

--- a/e2e/web-standards-showcase/src/api/detection.ts
+++ b/e2e/web-standards-showcase/src/api/detection.ts
@@ -11,6 +11,8 @@ export function detectNativeAPI(): DetectionResult {
     isNative: false,
     isPolyfill: false,
     testingAvailable: false,
+    supportsUnregisterTool: false,
+    supportsClearContext: false,
     message: '',
   };
 
@@ -40,20 +42,21 @@ export function detectNativeAPI(): DetectionResult {
     }
   }
 
-  // Additional check: native API should have Chromium-specific methods
-  const hasNativeMethods =
-    typeof navigator.modelContext.unregisterTool === 'function' &&
-    typeof navigator.modelContext.clearContext === 'function';
+  result.supportsUnregisterTool = typeof navigator.modelContext.unregisterTool === 'function';
+  result.supportsClearContext = typeof navigator.modelContext.clearContext === 'function';
 
-  if (!hasNativeMethods) {
-    result.isPolyfill = true;
-    result.isNative = false;
-    result.message = 'Missing native methods (unregisterTool, clearContext). Polyfill detected.';
+  result.isNative = true;
+  if (result.supportsUnregisterTool && result.supportsClearContext) {
+    result.message = 'Native Chromium Web Model Context API detected!';
     return result;
   }
 
-  result.isNative = true;
-  result.message = 'Native Chromium Web Model Context API detected!';
+  const missingMethods = [
+    !result.supportsUnregisterTool ? 'unregisterTool' : null,
+    !result.supportsClearContext ? 'clearContext' : null,
+  ].filter(Boolean);
+
+  result.message = `Native Chromium Web Model Context API detected (partial native surface: missing ${missingMethods.join(', ')}).`;
   return result;
 }
 

--- a/e2e/web-standards-showcase/src/api/detection.ts
+++ b/e2e/web-standards-showcase/src/api/detection.ts
@@ -11,6 +11,8 @@ export function detectNativeAPI(): DetectionResult {
     isNative: false,
     isPolyfill: false,
     testingAvailable: false,
+    supportsProvideContext: false,
+    supportsRegisterTool: false,
     supportsUnregisterTool: false,
     supportsClearContext: false,
     message: '',
@@ -42,6 +44,8 @@ export function detectNativeAPI(): DetectionResult {
     }
   }
 
+  result.supportsProvideContext = typeof navigator.modelContext.provideContext === 'function';
+  result.supportsRegisterTool = typeof navigator.modelContext.registerTool === 'function';
   result.supportsUnregisterTool = typeof navigator.modelContext.unregisterTool === 'function';
   result.supportsClearContext = typeof navigator.modelContext.clearContext === 'function';
 
@@ -52,6 +56,8 @@ export function detectNativeAPI(): DetectionResult {
   }
 
   const missingMethods = [
+    !result.supportsProvideContext ? 'provideContext' : null,
+    !result.supportsRegisterTool ? 'registerTool' : null,
     !result.supportsUnregisterTool ? 'unregisterTool' : null,
     !result.supportsClearContext ? 'clearContext' : null,
   ].filter(Boolean);

--- a/e2e/web-standards-showcase/src/iframe-main.ts
+++ b/e2e/web-standards-showcase/src/iframe-main.ts
@@ -126,9 +126,14 @@ function notifyParent(type: string, data: unknown): void {
   }
 }
 
-function setBucketATools(tools: Tool[]): void {
+function setBucketATools(tools: Tool[]): boolean {
+  if (typeof modelContext.provideContext !== 'function') {
+    return false;
+  }
+
   modelContext.provideContext({ tools });
   bucketATools = tools.map((tool) => tool.name);
+  return true;
 }
 
 /**
@@ -150,7 +155,10 @@ function registerBucketATool(): void {
     },
   };
 
-  setBucketATools([tool]);
+  if (!setBucketATools([tool])) {
+    logEvent('warning', 'provideContext is unavailable in this browser');
+    return;
+  }
 
   logEvent('success', 'Registered iframe_echo via provideContext (Bucket A)');
   notifyParent('tool-registered', { name: 'iframe_echo', bucket: 'A' });
@@ -177,6 +185,11 @@ function registerBucketBTool(): void {
       return `[Iframe Timestamp]: ${new Date().toISOString()}`;
     },
   };
+
+  if (typeof modelContext.registerTool !== 'function') {
+    logEvent('warning', 'registerTool is unavailable in this browser');
+    return;
+  }
 
   const registration = modelContext.registerTool(tool);
   bucketBRegistrations.set('iframe_timestamp', registration);

--- a/e2e/web-standards-showcase/src/iframe-main.ts
+++ b/e2e/web-standards-showcase/src/iframe-main.ts
@@ -9,7 +9,7 @@ import type { ModelContext, Tool } from './types';
 // State tracking
 let modelContext: ModelContext;
 let bucketATools: string[] = [];
-const bucketBRegistrations = new Map<string, { unregister: () => void }>();
+const bucketBRegistrations = new Map<string, { unregister?: () => void }>();
 
 /**
  * Initialize the iframe application
@@ -126,6 +126,11 @@ function notifyParent(type: string, data: unknown): void {
   }
 }
 
+function setBucketATools(tools: Tool[]): void {
+  modelContext.provideContext({ tools });
+  bucketATools = tools.map((tool) => tool.name);
+}
+
 /**
  * Register a tool via provideContext (Bucket A)
  */
@@ -145,8 +150,7 @@ function registerBucketATool(): void {
     },
   };
 
-  modelContext.provideContext({ tools: [tool] });
-  bucketATools = ['iframe_echo'];
+  setBucketATools([tool]);
 
   logEvent('success', 'Registered iframe_echo via provideContext (Bucket A)');
   notifyParent('tool-registered', { name: 'iframe_echo', bucket: 'A' });
@@ -193,7 +197,11 @@ function registerBucketBTool(): void {
 function unregisterBucketBTool(): void {
   const registration = bucketBRegistrations.get('iframe_timestamp');
   if (registration) {
-    registration.unregister();
+    if (typeof registration.unregister === 'function') {
+      registration.unregister();
+    } else if (typeof modelContext.unregisterTool === 'function') {
+      modelContext.unregisterTool('iframe_timestamp');
+    }
     bucketBRegistrations.delete('iframe_timestamp');
 
     const unregisterBtn = document.getElementById('unregister-iframe-tool-b') as HTMLButtonElement;
@@ -211,7 +219,19 @@ function unregisterBucketBTool(): void {
  * Clear context (removes Bucket A tools)
  */
 function clearContext(): void {
-  modelContext.clearContext();
+  if (typeof modelContext.clearContext === 'function') {
+    modelContext.clearContext();
+  } else {
+    setBucketATools([]);
+    for (const [toolName, registration] of bucketBRegistrations.entries()) {
+      if (typeof registration.unregister === 'function') {
+        registration.unregister();
+      } else if (typeof modelContext.unregisterTool === 'function') {
+        modelContext.unregisterTool(toolName);
+      }
+    }
+    bucketBRegistrations.clear();
+  }
   bucketATools = [];
 
   logEvent('success', 'Context cleared (Bucket A tools removed)');

--- a/e2e/web-standards-showcase/src/main.ts
+++ b/e2e/web-standards-showcase/src/main.ts
@@ -326,10 +326,15 @@ function updateToolExecutorSelect(tools: ToolInfo[]): void {
   }
 }
 
-function setBucketATools(tools: Tool[]): void {
+function setBucketATools(tools: Tool[]): boolean {
+  if (typeof modelContext.provideContext !== 'function') {
+    return false;
+  }
+
   modelContext.provideContext({ tools });
   bucketAToolDefinitions = tools;
   bucketATools = tools.map((tool) => tool.name);
+  return true;
 }
 
 function clearKnownTools(): void {
@@ -393,7 +398,10 @@ function provideCounterTools(): void {
     },
   ];
 
-  setBucketATools(tools);
+  if (!setBucketATools(tools)) {
+    eventLog.warning('provideContext() unavailable', 'Bucket A tools are not supported here');
+    return;
+  }
 
   eventLog.success('Bucket A updated', 'Counter tools registered via provideContext()');
   refreshToolDisplay();
@@ -415,7 +423,10 @@ function replaceBucketA(): void {
     },
   };
 
-  setBucketATools([greetTool]);
+  if (!setBucketATools([greetTool])) {
+    eventLog.warning('provideContext() unavailable', 'Bucket A replacement is not supported here');
+    return;
+  }
 
   eventLog.success('Bucket A replaced', 'Old counter tools removed, greet tool added');
   refreshToolDisplay();
@@ -459,6 +470,11 @@ function registerTimerTool(): void {
       }
     },
   };
+
+  if (typeof modelContext.registerTool !== 'function') {
+    eventLog.warning('registerTool() unavailable', 'Bucket B tools are not supported here');
+    return;
+  }
 
   const registration = modelContext.registerTool(timerTool);
   bucketBRegistrations.set('timer', registration);
@@ -541,7 +557,11 @@ function unregisterToolDemo(): void {
   if (typeof modelContext.unregisterTool === 'function') {
     modelContext.unregisterTool(toolName);
   } else {
-    setBucketATools(bucketAToolDefinitions.filter((tool) => tool.name !== toolName));
+    const nextTools = bucketAToolDefinitions.filter((tool) => tool.name !== toolName);
+    if (!setBucketATools(nextTools)) {
+      eventLog.warning('No removal API available', `Could not remove "${toolName}"`);
+      return;
+    }
   }
 
   eventLog.success('unregisterTool() called', `Removed "${toolName}" (native method)`);
@@ -1001,7 +1021,11 @@ function iframeParentRegisterBucketA(): void {
     },
   };
 
-  setBucketATools([tool]);
+  if (!setBucketATools([tool])) {
+    iframeEventLog.log('warning', 'Parent: provideContext is unavailable in this browser');
+    eventLog.warning('Iframe Demo', 'Parent Bucket A registration is unavailable');
+    return;
+  }
 
   iframeEventLog.log('success', 'Parent: Registered parent_greet via provideContext (Bucket A)');
   eventLog.info('Iframe Demo', 'Registered parent_greet in parent context (Bucket A)');
@@ -1028,6 +1052,12 @@ function iframeParentRegisterBucketB(): void {
       return `[Parent Time]: ${new Date().toLocaleTimeString()}`;
     },
   };
+
+  if (typeof modelContext.registerTool !== 'function') {
+    iframeEventLog.log('warning', 'Parent: registerTool is unavailable in this browser');
+    eventLog.warning('Iframe Demo', 'Parent Bucket B registration is unavailable');
+    return;
+  }
 
   const registration = modelContext.registerTool(tool);
   iframeBucketBRegistrations.set('parent_time', registration);

--- a/e2e/web-standards-showcase/src/main.ts
+++ b/e2e/web-standards-showcase/src/main.ts
@@ -16,7 +16,8 @@ let modelContextTesting: ModelContextTesting;
 
 // Bucket tracking
 let bucketATools: string[] = [];
-const bucketBRegistrations = new Map<string, { unregister: () => void }>();
+let bucketAToolDefinitions: Tool[] = [];
+const bucketBRegistrations = new Map<string, { unregister?: () => void }>();
 
 // Iframe context tracking
 let iframeReady = false;
@@ -325,6 +326,31 @@ function updateToolExecutorSelect(tools: ToolInfo[]): void {
   }
 }
 
+function setBucketATools(tools: Tool[]): void {
+  modelContext.provideContext({ tools });
+  bucketAToolDefinitions = tools;
+  bucketATools = tools.map((tool) => tool.name);
+}
+
+function clearKnownTools(): void {
+  if (typeof modelContext.clearContext === 'function') {
+    modelContext.clearContext();
+  } else {
+    setBucketATools([]);
+    for (const [toolName, registration] of bucketBRegistrations.entries()) {
+      if (typeof registration.unregister === 'function') {
+        registration.unregister();
+      } else if (typeof modelContext.unregisterTool === 'function') {
+        modelContext.unregisterTool(toolName);
+      }
+    }
+  }
+
+  bucketAToolDefinitions = [];
+  bucketATools = [];
+  bucketBRegistrations.clear();
+}
+
 // ==================== Two-Bucket Demos ====================
 
 function provideCounterTools(): void {
@@ -367,8 +393,7 @@ function provideCounterTools(): void {
     },
   ];
 
-  modelContext.provideContext({ tools });
-  bucketATools = tools.map((t) => t.name);
+  setBucketATools(tools);
 
   eventLog.success('Bucket A updated', 'Counter tools registered via provideContext()');
   refreshToolDisplay();
@@ -390,8 +415,7 @@ function replaceBucketA(): void {
     },
   };
 
-  modelContext.provideContext({ tools: [greetTool] });
-  bucketATools = ['greet'];
+  setBucketATools([greetTool]);
 
   eventLog.success('Bucket A replaced', 'Old counter tools removed, greet tool added');
   refreshToolDisplay();
@@ -446,7 +470,11 @@ function registerTimerTool(): void {
 function unregisterTimerTool(): void {
   const registration = bucketBRegistrations.get('timer');
   if (registration) {
-    registration.unregister();
+    if (typeof registration.unregister === 'function') {
+      registration.unregister();
+    } else if (typeof modelContext.unregisterTool === 'function') {
+      modelContext.unregisterTool('timer');
+    }
     bucketBRegistrations.delete('timer');
     eventLog.success('Tool unregistered', 'Timer tool removed from Bucket B');
     refreshToolDisplay();
@@ -510,16 +538,18 @@ function unregisterToolDemo(): void {
   }
 
   const toolName = bucketATools[0];
-  modelContext.unregisterTool(toolName);
+  if (typeof modelContext.unregisterTool === 'function') {
+    modelContext.unregisterTool(toolName);
+  } else {
+    setBucketATools(bucketAToolDefinitions.filter((tool) => tool.name !== toolName));
+  }
 
   eventLog.success('unregisterTool() called', `Removed "${toolName}" (native method)`);
   refreshToolDisplay();
 }
 
 function clearContextDemo(): void {
-  modelContext.clearContext();
-  bucketATools = [];
-  bucketBRegistrations.clear();
+  clearKnownTools();
 
   eventLog.success('clearContext() called', 'All tools cleared (native method)');
   refreshToolDisplay();
@@ -971,7 +1001,7 @@ function iframeParentRegisterBucketA(): void {
     },
   };
 
-  modelContext.provideContext({ tools: [tool] });
+  setBucketATools([tool]);
 
   iframeEventLog.log('success', 'Parent: Registered parent_greet via provideContext (Bucket A)');
   eventLog.info('Iframe Demo', 'Registered parent_greet in parent context (Bucket A)');
@@ -1018,7 +1048,11 @@ function iframeParentRegisterBucketB(): void {
 function iframeParentUnregisterBucketB(): void {
   const registration = iframeBucketBRegistrations.get('parent_time');
   if (registration) {
-    registration.unregister();
+    if (typeof registration.unregister === 'function') {
+      registration.unregister();
+    } else if (typeof modelContext.unregisterTool === 'function') {
+      modelContext.unregisterTool('parent_time');
+    }
     iframeBucketBRegistrations.delete('parent_time');
 
     const btn = document.getElementById('iframe-parent-unregister-b') as HTMLButtonElement;
@@ -1036,7 +1070,7 @@ function iframeParentUnregisterBucketB(): void {
  * Clear parent context
  */
 function iframeParentClearContext(): void {
-  modelContext.clearContext();
+  clearKnownTools();
 
   iframeEventLog.log('info', 'Parent: Context cleared (Bucket A removed)');
   eventLog.info('Iframe Demo', 'Parent context cleared');

--- a/e2e/web-standards-showcase/src/main.ts
+++ b/e2e/web-standards-showcase/src/main.ts
@@ -23,7 +23,7 @@ const bucketBRegistrations = new Map<string, { unregister?: () => void }>();
 let iframeReady = false;
 let iframeTools: string[] = [];
 let iframeBucketBTools: string[] = [];
-const iframeBucketBRegistrations = new Map<string, { unregister: () => void }>();
+const iframeBucketBRegistrations = new Map<string, { unregister?: () => void }>();
 
 // Iframe event log
 class IframeEventLog {

--- a/e2e/web-standards-showcase/src/types.ts
+++ b/e2e/web-standards-showcase/src/types.ts
@@ -33,7 +33,7 @@ export interface Tool {
 }
 
 export interface ToolRegistration {
-  unregister: () => void;
+  unregister?: () => void;
 }
 
 export interface ProvideContextOptions {
@@ -45,8 +45,8 @@ export interface ModelContext extends EventTarget {
   registerTool(tool: Tool): ToolRegistration;
   listTools(): Tool[];
   executeTool(name: string, input: Record<string, unknown>): Promise<unknown>;
-  unregisterTool(name: string): void;
-  clearContext(): void;
+  unregisterTool?(name: string): void;
+  clearContext?(): void;
 }
 
 export interface ToolInfo {
@@ -80,5 +80,7 @@ export interface DetectionResult {
   isNative: boolean;
   isPolyfill: boolean;
   testingAvailable: boolean;
+  supportsUnregisterTool: boolean;
+  supportsClearContext: boolean;
   message: string;
 }

--- a/e2e/web-standards-showcase/src/types.ts
+++ b/e2e/web-standards-showcase/src/types.ts
@@ -41,8 +41,8 @@ export interface ProvideContextOptions {
 }
 
 export interface ModelContext extends EventTarget {
-  provideContext(options: ProvideContextOptions): void;
-  registerTool(tool: Tool): ToolRegistration;
+  provideContext?(options: ProvideContextOptions): void;
+  registerTool?(tool: Tool): ToolRegistration;
   listTools(): Tool[];
   executeTool(name: string, input: Record<string, unknown>): Promise<unknown>;
   unregisterTool?(name: string): void;
@@ -80,6 +80,8 @@ export interface DetectionResult {
   isNative: boolean;
   isPolyfill: boolean;
   testingAvailable: boolean;
+  supportsProvideContext: boolean;
+  supportsRegisterTool: boolean;
   supportsUnregisterTool: boolean;
   supportsClearContext: boolean;
   message: string;

--- a/packages/global/src/global.test.ts
+++ b/packages/global/src/global.test.ts
@@ -359,6 +359,50 @@ describe('global adapter', () => {
     expect(tools.some((tool) => tool.name === 'dynamic_tool')).toBe(false);
   });
 
+  it('tolerates native contexts that omit clearContext while still mirroring provided tools', () => {
+    const registerTool = vi.fn();
+    const nativeContext = {
+      provideContext: () => {},
+      registerTool,
+      listTools: () => [],
+      callTool: async () => ({ content: [{ type: 'text', text: 'native-ok' }] }),
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => true,
+    } as unknown as Navigator['modelContext'];
+
+    Object.defineProperty(navigator, 'modelContext', {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: nativeContext,
+    });
+
+    initializeWebModelContext();
+
+    const modelContext = getModelContext();
+    expect(() =>
+      modelContext.provideContext({
+        tools: [
+          {
+            name: 'context_tool',
+            description: 'context',
+            inputSchema: { type: 'object', properties: {} },
+            async execute() {
+              return { content: [{ type: 'text', text: 'context' }] };
+            },
+          },
+        ],
+      })
+    ).not.toThrow();
+
+    expect(registerTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'context_tool',
+      })
+    );
+  });
+
   it('unregisterTool and clearContext remove mirrored tools', () => {
     initializeWebModelContext();
 

--- a/packages/global/src/global.test.ts
+++ b/packages/global/src/global.test.ts
@@ -393,6 +393,43 @@ describe('global adapter', () => {
     expect(tools.some((tool) => tool.name === 'clear_me')).toBe(false);
   });
 
+  it('suppresses same-task mirrored tool churn when the final testing-shim state is unchanged', async () => {
+    initializeWebModelContext();
+
+    const modelContext = getModelContext();
+    modelContext.registerTool({
+      name: 'stable_tool',
+      description: 'stable',
+      inputSchema: { type: 'object', properties: {} },
+      async execute() {
+        return { content: [{ type: 'text', text: 'stable' }] };
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const snapshots: string[][] = [];
+    navigator.modelContextTesting?.registerToolsChangedCallback(() => {
+      snapshots.push((navigator.modelContextTesting?.listTools() ?? []).map((tool) => tool.name));
+    });
+
+    modelContext.unregisterTool('stable_tool');
+    modelContext.registerTool({
+      name: 'stable_tool',
+      description: 'stable',
+      inputSchema: { type: 'object', properties: {} },
+      async execute() {
+        return { content: [{ type: 'text', text: 'stable' }] };
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(snapshots).toEqual([]);
+  });
+
   it('sets __isBrowserMcpServer marker on navigator.modelContext', () => {
     initializeWebModelContext();
     const ctx = navigator.modelContext as unknown as Record<string, unknown>;

--- a/packages/webmcp-polyfill/src/index.test.ts
+++ b/packages/webmcp-polyfill/src/index.test.ts
@@ -1881,6 +1881,52 @@ describe('@mcp-b/webmcp-polyfill', () => {
 
       expect(snapshots).toEqual([['tool_b']]);
     });
+
+    it('still notifies when same-task churn changes visible tool metadata', async () => {
+      initializeWebMCPPolyfill();
+
+      navigator.modelContext.registerTool({
+        name: 'stable_tool',
+        description: 'before',
+        inputSchema: { type: 'object', properties: {} },
+        execute: async () => ({ content: [{ type: 'text', text: 'before' }] }),
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const snapshots: Array<Array<{ name: string; description?: string; inputSchema?: string }>> =
+        [];
+      navigator.modelContextTesting?.registerToolsChangedCallback(() => {
+        snapshots.push(navigator.modelContextTesting?.listTools() ?? []);
+      });
+
+      navigator.modelContext.unregisterTool('stable_tool');
+      navigator.modelContext.registerTool({
+        name: 'stable_tool',
+        description: 'after',
+        inputSchema: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+        },
+        execute: async () => ({ content: [{ type: 'text', text: 'after' }] }),
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(snapshots).toHaveLength(1);
+      expect(snapshots[0]).toEqual([
+        {
+          name: 'stable_tool',
+          description: 'after',
+          inputSchema: JSON.stringify({
+            type: 'object',
+            properties: { value: { type: 'string' } },
+          }),
+        },
+      ]);
+    });
   });
 
   // =========================================================================

--- a/packages/webmcp-polyfill/src/index.test.ts
+++ b/packages/webmcp-polyfill/src/index.test.ts
@@ -139,7 +139,7 @@ describe('@mcp-b/webmcp-polyfill', () => {
     expect(() => navigator.modelContext.unregisterTool('missing')).not.toThrow();
   });
 
-  it('fires registerToolsChangedCallback for registry mutations', async () => {
+  it('fires registerToolsChangedCallback for registry mutations across separate tasks', async () => {
     initializeWebMCPPolyfill();
 
     let count = 0;
@@ -154,7 +154,13 @@ describe('@mcp-b/webmcp-polyfill', () => {
       execute: async () => ({ content: [{ type: 'text', text: 'ok' }] }),
     });
 
+    await Promise.resolve();
+    await Promise.resolve();
+
     navigator.modelContext.unregisterTool('t1');
+
+    await Promise.resolve();
+    await Promise.resolve();
 
     navigator.modelContext.provideContext({
       tools: [
@@ -166,6 +172,9 @@ describe('@mcp-b/webmcp-polyfill', () => {
         },
       ],
     });
+
+    await Promise.resolve();
+    await Promise.resolve();
 
     navigator.modelContext.clearContext();
 
@@ -1807,6 +1816,70 @@ describe('@mcp-b/webmcp-polyfill', () => {
       });
 
       await Promise.resolve();
+    });
+
+    it('suppresses transient unregister/register churn when the final tool set is unchanged', async () => {
+      initializeWebMCPPolyfill();
+
+      navigator.modelContext.registerTool({
+        name: 'stable_tool',
+        description: 'Original stable tool',
+        inputSchema: { type: 'object', properties: {} },
+        execute: async () => ({ content: [{ type: 'text', text: 'stable' }] }),
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const snapshots: string[][] = [];
+      navigator.modelContextTesting?.registerToolsChangedCallback(() => {
+        snapshots.push(
+          (navigator.modelContextTesting?.listTools() ?? []).map((tool) => tool.name).sort()
+        );
+      });
+
+      navigator.modelContext.unregisterTool('stable_tool');
+      navigator.modelContext.registerTool({
+        name: 'stable_tool',
+        description: 'Original stable tool',
+        inputSchema: { type: 'object', properties: {} },
+        execute: async () => ({ content: [{ type: 'text', text: 'stable' }] }),
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(snapshots).toEqual([]);
+    });
+
+    it('batches same-task tool churn into one callback with the final state', async () => {
+      initializeWebMCPPolyfill();
+
+      const snapshots: string[][] = [];
+      navigator.modelContextTesting?.registerToolsChangedCallback(() => {
+        snapshots.push(
+          (navigator.modelContextTesting?.listTools() ?? []).map((tool) => tool.name).sort()
+        );
+      });
+
+      navigator.modelContext.registerTool({
+        name: 'tool_a',
+        description: 'Tool A',
+        inputSchema: { type: 'object', properties: {} },
+        execute: async () => ({ content: [{ type: 'text', text: 'a' }] }),
+      });
+      navigator.modelContext.unregisterTool('tool_a');
+      navigator.modelContext.registerTool({
+        name: 'tool_b',
+        description: 'Tool B',
+        inputSchema: { type: 'object', properties: {} },
+        execute: async () => ({ content: [{ type: 'text', text: 'b' }] }),
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(snapshots).toEqual([['tool_b']]);
     });
   });
 

--- a/packages/webmcp-polyfill/src/index.ts
+++ b/packages/webmcp-polyfill/src/index.ts
@@ -108,6 +108,8 @@ export interface WebMCPPolyfillInitOptions {
 class StrictWebMCPContext {
   private tools = new Map<string, PolyfillToolDescriptor>();
   private toolsChangedCallback: (() => void) | null = null;
+  private toolsChangedNotificationQueued = false;
+  private lastNotifiedToolsSnapshot = '';
 
   provideContext(options: ModelContextOptions = {}): void {
     const nextTools = new Map<string, PolyfillToolDescriptor>();
@@ -169,6 +171,7 @@ class StrictWebMCPContext {
           );
         }
         this.toolsChangedCallback = callback;
+        this.lastNotifiedToolsSnapshot = this.createToolsSnapshot();
       },
       getCrossDocumentScriptToolResult: async () => '[]',
     };
@@ -227,11 +230,26 @@ class StrictWebMCPContext {
   }
 
   private notifyToolsChanged(): void {
-    if (!this.toolsChangedCallback) {
+    if (!this.toolsChangedCallback || this.toolsChangedNotificationQueued) {
       return;
     }
 
+    this.toolsChangedNotificationQueued = true;
+
     queueMicrotask(() => {
+      this.toolsChangedNotificationQueued = false;
+
+      if (!this.toolsChangedCallback) {
+        return;
+      }
+
+      const nextSnapshot = this.createToolsSnapshot();
+      if (nextSnapshot === this.lastNotifiedToolsSnapshot) {
+        return;
+      }
+
+      this.lastNotifiedToolsSnapshot = nextSnapshot;
+
       try {
         this.toolsChangedCallback?.();
       } catch (error) {
@@ -239,6 +257,16 @@ class StrictWebMCPContext {
         console.warn('[WebMCPPolyfill] toolsChanged callback threw:', error);
       }
     });
+  }
+
+  private createToolsSnapshot(): string {
+    return JSON.stringify(
+      [...this.tools.values()].map((tool) => ({
+        name: tool.name,
+        description: tool.description ?? '',
+        inputSchema: tool.inputSchema,
+      }))
+    );
   }
 }
 

--- a/packages/webmcp-ts-sdk/src/browser-server.ts
+++ b/packages/webmcp-ts-sdk/src/browser-server.ts
@@ -168,6 +168,9 @@ type ParentRegisterPromptFn = (
 ) => { remove: () => void };
 
 type NativeToolsApi = ModelContextCore & Pick<ModelContextExtensions, 'listTools' | 'callTool'>;
+type NativeMutationApi = Partial<
+  Pick<ModelContextCore, 'registerTool' | 'unregisterTool' | 'clearContext'>
+>;
 
 /**
  * Browser-optimized MCP Server that speaks WebMCP natively.
@@ -311,6 +314,35 @@ export class BrowserMcpServer extends BaseMcpServer {
     return candidate as NativeToolsApi;
   }
 
+  private getNativeMutationApi(): NativeMutationApi | undefined {
+    if (!this.native) {
+      return undefined;
+    }
+
+    return this.native as NativeMutationApi;
+  }
+
+  private registerToolInNative(tool: ToolDescriptor): void {
+    const nativeMutationApi = this.getNativeMutationApi();
+    if (typeof nativeMutationApi?.registerTool === 'function') {
+      (nativeMutationApi.registerTool as (tool: ToolDescriptor) => void)(tool);
+    }
+  }
+
+  private unregisterToolInNative(name: string): void {
+    const nativeMutationApi = this.getNativeMutationApi();
+    if (typeof nativeMutationApi?.unregisterTool === 'function') {
+      nativeMutationApi.unregisterTool(name);
+    }
+  }
+
+  private clearToolsInNative(): void {
+    const nativeMutationApi = this.getNativeMutationApi();
+    if (typeof nativeMutationApi?.clearContext === 'function') {
+      nativeMutationApi.clearContext();
+    }
+  }
+
   private registerToolInServer(tool: ToolDescriptor): { unregister: () => void } {
     const inputSchema = this.toTransportSchema(tool.inputSchema);
 
@@ -372,23 +404,19 @@ export class BrowserMcpServer extends BaseMcpServer {
   // @ts-expect-error -- WebMCP API: (ToolDescriptor) vs MCP SDK: (name, config, cb)
   override registerTool(tool: ToolDescriptor): { unregister: () => void } {
     // Mirror to native first — the polyfill validates the descriptor
-    if (this.native) {
-      (this.native.registerTool as (tool: ToolDescriptor) => void)(tool);
-    }
+    this.registerToolInNative(tool);
 
     try {
       return this.registerToolInServer(tool);
     } catch (error) {
       // Rollback native registration on server failure
-      if (this.native) {
-        try {
-          this.native.unregisterTool(tool.name);
-        } catch (rollbackError) {
-          console.error(
-            '[BrowserMcpServer] Rollback of native tool registration failed:',
-            rollbackError
-          );
-        }
+      try {
+        this.unregisterToolInNative(tool.name);
+      } catch (rollbackError) {
+        console.error(
+          '[BrowserMcpServer] Rollback of native tool registration failed:',
+          rollbackError
+        );
       }
       throw error;
     }
@@ -418,9 +446,7 @@ export class BrowserMcpServer extends BaseMcpServer {
   unregisterTool(name: string): void {
     this._parentTools[name]?.remove();
 
-    if (this.native) {
-      this.native.unregisterTool(name);
-    }
+    this.unregisterToolInNative(name);
   }
 
   // @ts-expect-error -- WebMCP API: (descriptor) vs MCP SDK: (name, uri, config, readCallback)
@@ -485,9 +511,7 @@ export class BrowserMcpServer extends BaseMcpServer {
       tool.remove();
     }
 
-    if (this.native) {
-      this.native.clearContext();
-    }
+    this.clearToolsInNative();
 
     for (const tool of options?.tools ?? []) {
       this.registerTool(tool);
@@ -502,9 +526,7 @@ export class BrowserMcpServer extends BaseMcpServer {
     // method that only handles tools. Prompt schemas are cleaned up individually
     // via the unregister() callback returned by registerPrompt().
 
-    if (this.native) {
-      this.native.clearContext();
-    }
+    this.clearToolsInNative();
   }
 
   // --- Extension methods ---


### PR DESCRIPTION
## Summary

Coalesce same-task tool registry churn so `registerToolsChangedCallback` only emits the final visible tool set.

## Changes

- dedupe same-task tool-change notifications in the `@mcp-b/webmcp-polyfill` registry callback scheduler
- suppress no-op unregister/register churn when the final tool list is unchanged
- add polyfill regression coverage for transient unregister/re-register and same-task replacement churn
- add a thin `@mcp-b/global` integration test proving the published entrypoint mirrors the same behavior
- add a patch changeset for `@mcp-b/webmcp-polyfill` and `@mcp-b/global`

## Related Issues

Fixes #141

## Checklist

- [x] PR title follows conventional commit format: `type(scope): description`
- [x] I followed `docs/AI_CONTRIBUTION_MANIFESTO.md` for safety, contracts, and SSOT decisions
- [x] I followed `docs/MCPB_PACKAGE_PHILOSOPHY.md` for package boundaries and ownership
- [x] I followed `docs/TESTING_PHILOSOPHY.md` and selected the right test layer(s)
- [ ] Code builds without errors (`pnpm build`)
- [ ] Tests pass (`pnpm test:unit`)
- [x] Linting passes (`pnpm check`)
- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Changeset added (if this is a user-facing change) - run `pnpm changeset`

## Testing

Root cause:
`@mcp-b/global` was forwarding tool list churn through the polyfill testing shim, and `StrictWebMCPContext.notifyToolsChanged()` queued one microtask per mutation without comparing the final tool set. During same-task unregister/register churn, that leaked redundant transient tool-list updates. Inference from issue #141: those extra updates likely triggered the extension side panel to rewrite tool-call arg text in a non-append-only way.

Automated coverage:
- `pnpm --filter @mcp-b/webmcp-polyfill test`
- `pnpm --filter @mcp-b/global test`
- `pnpm --filter @mcp-b/webmcp-polyfill typecheck`
- `pnpm --filter @mcp-b/global typecheck`
- `pnpm --filter @mcp-b/webmcp-polyfill check`
- `pnpm --filter @mcp-b/global check`

Manual gap:
- no extension side-panel harness exists in this repo, so the exact `argsText` crash could not be reproduced end-to-end here

## Screenshots

N/A
