### PR TITLE
fix(react-webmcp): handle transport changes in McpClientProvider

### DIFF
--- a/.changeset/friendly-seals-double.md
+++ b/.changeset/friendly-seals-double.md
@@ -1,5 +1,8 @@
 ---
 '@mcp-b/react-webmcp': patch
+'@mcp-b/webmcp-ts-sdk': patch
 ---
 
 Fix `McpClientProvider` transport switches by closing the previous client connection before reconnecting and ignoring stale tool/resource updates from the old transport.
+
+Make `BrowserMcpServer` preserve `provideContext()` and `clearContext()` semantics when a native WebMCP implementation omits `clearContext()`, as seen in the Chrome Beta native API lane.

--- a/.changeset/friendly-seals-double.md
+++ b/.changeset/friendly-seals-double.md
@@ -1,0 +1,5 @@
+---
+'@mcp-b/react-webmcp': patch
+---
+
+Fix `McpClientProvider` transport switches by closing the previous client connection before reconnecting and ignoring stale tool/resource updates from the old transport.

--- a/packages/react-webmcp/src/client/McpClientProvider.test.tsx
+++ b/packages/react-webmcp/src/client/McpClientProvider.test.tsx
@@ -523,6 +523,24 @@ describe('McpClientProvider', () => {
       });
     }
 
+    function registerLiveResource(server: BrowserMcpServer, uri: string, name: string): void {
+      server.registerResource({
+        uri,
+        name,
+        async read(resourceUri) {
+          return {
+            contents: [
+              {
+                uri: resourceUri.toString(),
+                mimeType: 'text/plain',
+                text: `${name}:content`,
+              },
+            ],
+          };
+        },
+      });
+    }
+
     async function createLiveTransportEndpoint(toolName: string): Promise<{
       server: BrowserMcpServer;
       serverTransport: TabServerTransport;
@@ -716,6 +734,78 @@ describe('McpClientProvider', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(latestTools.current).not.toContain('stale_tab_tool');
+    });
+
+    it('switches transports with the same client without retaining stale resources', async () => {
+      const client = new Client({ name: 'react-webmcp-switch-resource-client', version: '1.0.0' });
+      const firstEndpoint = await createLiveTransportEndpoint('tab_resource_tool');
+      const secondEndpoint = await createLiveTransportEndpoint('iframe_resource_tool');
+
+      registerLiveResource(firstEndpoint.server, 'resource://tab', 'Tab Resource');
+      registerLiveResource(secondEndpoint.server, 'resource://iframe', 'Iframe Resource');
+
+      liveConnections.push({
+        client,
+        clientTransport: firstEndpoint.clientTransport,
+        server: firstEndpoint.server,
+        serverTransport: firstEndpoint.serverTransport,
+      });
+      liveConnections.push({
+        client,
+        clientTransport: secondEndpoint.clientTransport,
+        server: secondEndpoint.server,
+        serverTransport: secondEndpoint.serverTransport,
+      });
+
+      const latestResources: { current: string[] } = { current: [] };
+
+      function ResourceProbe() {
+        const { resources } = useMcpClient();
+
+        useEffect(() => {
+          latestResources.current = resources.map((resource) => resource.uri);
+        }, [resources]);
+
+        return null;
+      }
+
+      const clientProp = client as unknown as McpClientProviderProps['client'];
+      const { rerender } = await render(
+        <McpClientProvider
+          client={clientProp}
+          transport={
+            firstEndpoint.clientTransport as unknown as McpClientProviderProps['transport']
+          }
+        >
+          <ResourceProbe />
+        </McpClientProvider>
+      );
+
+      await vi.waitFor(() => {
+        expect(latestResources.current).toContain('resource://tab');
+      });
+      expect(latestResources.current).not.toContain('resource://iframe');
+
+      rerender(
+        <McpClientProvider
+          client={clientProp}
+          transport={
+            secondEndpoint.clientTransport as unknown as McpClientProviderProps['transport']
+          }
+        >
+          <ResourceProbe />
+        </McpClientProvider>
+      );
+
+      await vi.waitFor(() => {
+        expect(latestResources.current).toContain('resource://iframe');
+      });
+      expect(latestResources.current).not.toContain('resource://tab');
+
+      registerLiveResource(firstEndpoint.server, 'resource://stale-tab', 'Stale Tab Resource');
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(latestResources.current).not.toContain('resource://stale-tab');
     });
   });
 });

--- a/packages/react-webmcp/src/client/McpClientProvider.test.tsx
+++ b/packages/react-webmcp/src/client/McpClientProvider.test.tsx
@@ -1,6 +1,6 @@
 import { TabClientTransport, TabServerTransport } from '@mcp-b/transports';
 import { BrowserMcpServer, Client } from '@mcp-b/webmcp-ts-sdk';
-import type { ReactNode } from 'react';
+import { type ReactNode, useEffect } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, renderHook } from 'vitest-browser-react';
 import {
@@ -11,6 +11,7 @@ import {
 
 // Create mock client and transport
 const mockConnect = vi.fn();
+const mockClose = vi.fn();
 const mockListTools = vi.fn();
 const mockListResources = vi.fn();
 const mockGetServerCapabilities = vi.fn();
@@ -19,6 +20,7 @@ const mockRemoveNotificationHandler = vi.fn();
 
 const createMockClient = () => ({
   connect: mockConnect,
+  close: mockClose,
   listTools: mockListTools,
   listResources: mockListResources,
   getServerCapabilities: mockGetServerCapabilities,
@@ -63,6 +65,7 @@ describe('McpClientProvider', () => {
 
     // Default mocks
     mockConnect.mockResolvedValue(undefined);
+    mockClose.mockResolvedValue(undefined);
     mockGetServerCapabilities.mockReturnValue({
       tools: { listChanged: true },
       resources: { listChanged: true },
@@ -504,6 +507,47 @@ describe('McpClientProvider', () => {
       return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
     }
 
+    function registerLiveTool(server: BrowserMcpServer, name: string): void {
+      server.registerTool({
+        name,
+        description: `Tool ${name}`,
+        inputSchema: {
+          type: 'object',
+          properties: { message: { type: 'string' } },
+        },
+        async execute(args) {
+          return {
+            content: [{ type: 'text', text: `${name}:${String(args.message ?? '')}` }],
+          };
+        },
+      });
+    }
+
+    async function createLiveTransportEndpoint(toolName: string): Promise<{
+      server: BrowserMcpServer;
+      serverTransport: TabServerTransport;
+      clientTransport: TabClientTransport;
+    }> {
+      const channelId = uniqueChannelId(`mcp-client-provider-${toolName}`);
+      const server = new BrowserMcpServer({
+        name: 'react-webmcp-test-server',
+        version: '1.0.0',
+      });
+      const serverTransport = new TabServerTransport({
+        channelId,
+        allowedOrigins: [window.location.origin],
+      });
+      await server.connect(serverTransport);
+      registerLiveTool(server, toolName);
+
+      const clientTransport = new TabClientTransport({
+        targetOrigin: window.location.origin,
+        channelId,
+      });
+
+      return { server, serverTransport, clientTransport };
+    }
+
     async function createLiveProvider(): Promise<{
       server: BrowserMcpServer;
       providerProps: Pick<McpClientProviderProps, 'client' | 'transport'>;
@@ -603,6 +647,75 @@ describe('McpClientProvider', () => {
       await vi.waitFor(() => {
         expect(result.current.tools.some((tool) => tool.name === 'list_changed_tool')).toBe(true);
       });
+    });
+
+    it('switches transports with the same client without retaining stale tools', async () => {
+      const client = new Client({ name: 'react-webmcp-switch-client', version: '1.0.0' });
+      const firstEndpoint = await createLiveTransportEndpoint('tab_tool');
+      const secondEndpoint = await createLiveTransportEndpoint('iframe_tool');
+
+      liveConnections.push({
+        client,
+        clientTransport: firstEndpoint.clientTransport,
+        server: firstEndpoint.server,
+        serverTransport: firstEndpoint.serverTransport,
+      });
+      liveConnections.push({
+        client,
+        clientTransport: secondEndpoint.clientTransport,
+        server: secondEndpoint.server,
+        serverTransport: secondEndpoint.serverTransport,
+      });
+
+      const latestTools: { current: string[] } = { current: [] };
+
+      function ToolProbe() {
+        const { tools } = useMcpClient();
+
+        useEffect(() => {
+          latestTools.current = tools.map((tool) => tool.name);
+        }, [tools]);
+
+        return null;
+      }
+
+      const clientProp = client as unknown as McpClientProviderProps['client'];
+      const { rerender } = await render(
+        <McpClientProvider
+          client={clientProp}
+          transport={
+            firstEndpoint.clientTransport as unknown as McpClientProviderProps['transport']
+          }
+        >
+          <ToolProbe />
+        </McpClientProvider>
+      );
+
+      await vi.waitFor(() => {
+        expect(latestTools.current).toContain('tab_tool');
+      });
+      expect(latestTools.current).not.toContain('iframe_tool');
+
+      rerender(
+        <McpClientProvider
+          client={clientProp}
+          transport={
+            secondEndpoint.clientTransport as unknown as McpClientProviderProps['transport']
+          }
+        >
+          <ToolProbe />
+        </McpClientProvider>
+      );
+
+      await vi.waitFor(() => {
+        expect(latestTools.current).toContain('iframe_tool');
+      });
+      expect(latestTools.current).not.toContain('tab_tool');
+
+      registerLiveTool(firstEndpoint.server, 'stale_tab_tool');
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(latestTools.current).not.toContain('stale_tab_tool');
     });
   });
 });

--- a/packages/react-webmcp/src/client/McpClientProvider.tsx
+++ b/packages/react-webmcp/src/client/McpClientProvider.tsx
@@ -175,6 +175,8 @@ export function McpClientProvider({
   const requestOpts = opts ?? EMPTY_REQUEST_OPTS;
 
   const connectionStateRef = useRef<'disconnected' | 'connecting' | 'connected'>('disconnected');
+  const activeConnectionIdRef = useRef(0);
+  const pendingDisconnectRef = useRef<Promise<void>>(Promise.resolve());
   const toolFlowSequenceRef = useRef(0);
   const logToolFlow = useCallback((event: string, details: Record<string, unknown> = {}) => {
     const sequence = ++toolFlowSequenceRef.current;
@@ -185,62 +187,85 @@ export function McpClientProvider({
     }
   }, []);
 
+  const resetConnectionData = useCallback(() => {
+    setIsConnected(false);
+    setCapabilities(null);
+    setTools([]);
+    setResources([]);
+  }, []);
+
   /**
    * Fetches available resources from the MCP server.
    * Only fetches if the server supports the resources capability.
    */
-  const fetchResourcesInternal = useCallback(async () => {
-    if (!client) return;
+  const fetchResourcesInternal = useCallback(
+    async (connectionId = activeConnectionIdRef.current) => {
+      if (!client) return;
 
-    const serverCapabilities = client.getServerCapabilities();
-    if (!serverCapabilities?.resources) {
-      setResources([]);
-      return;
-    }
+      const serverCapabilities = client.getServerCapabilities();
+      if (!serverCapabilities?.resources) {
+        if (activeConnectionIdRef.current === connectionId) {
+          setResources([]);
+        }
+        return;
+      }
 
-    try {
-      const response = await client.listResources();
-      setResources(response.resources);
-    } catch (e) {
-      console.error('[ReactWebMCP:McpClientProvider]', 'Error fetching resources:', e);
-      throw e;
-    }
-  }, [client]);
+      try {
+        const response = await client.listResources();
+        if (activeConnectionIdRef.current !== connectionId) {
+          return;
+        }
+        setResources(response.resources);
+      } catch (e) {
+        console.error('[ReactWebMCP:McpClientProvider]', 'Error fetching resources:', e);
+        throw e;
+      }
+    },
+    [client]
+  );
 
   /**
    * Fetches available tools from the MCP server.
    * Only fetches if the server supports the tools capability.
    */
-  const fetchToolsInternal = useCallback(async () => {
-    if (!client) return;
+  const fetchToolsInternal = useCallback(
+    async (connectionId = activeConnectionIdRef.current) => {
+      if (!client) return;
 
-    const serverCapabilities = client.getServerCapabilities();
-    if (!serverCapabilities?.tools) {
-      logToolFlow('listTools:capability_missing', {});
-      setTools([]);
-      return;
-    }
+      const serverCapabilities = client.getServerCapabilities();
+      if (!serverCapabilities?.tools) {
+        logToolFlow('listTools:capability_missing', {});
+        if (activeConnectionIdRef.current === connectionId) {
+          setTools([]);
+        }
+        return;
+      }
 
-    const startedAt = Date.now();
-    logToolFlow('listTools:start', {
-      hasToolsCapability: Boolean(serverCapabilities.tools),
-    });
-    try {
-      const response = await client.listTools();
-      setTools(response.tools);
-      logToolFlow('listTools:success', {
-        durationMs: Date.now() - startedAt,
-        toolCount: response.tools.length,
+      const startedAt = Date.now();
+      logToolFlow('listTools:start', {
+        hasToolsCapability: Boolean(serverCapabilities.tools),
       });
-    } catch (e) {
-      logToolFlow('listTools:error', {
-        durationMs: Date.now() - startedAt,
-        errorMessage: e instanceof Error ? e.message : String(e),
-      });
-      console.error('[ReactWebMCP:McpClientProvider]', 'Error fetching tools:', e);
-      throw e;
-    }
-  }, [client, logToolFlow]);
+      try {
+        const response = await client.listTools();
+        if (activeConnectionIdRef.current !== connectionId) {
+          return;
+        }
+        setTools(response.tools);
+        logToolFlow('listTools:success', {
+          durationMs: Date.now() - startedAt,
+          toolCount: response.tools.length,
+        });
+      } catch (e) {
+        logToolFlow('listTools:error', {
+          durationMs: Date.now() - startedAt,
+          errorMessage: e instanceof Error ? e.message : String(e),
+        });
+        console.error('[ReactWebMCP:McpClientProvider]', 'Error fetching tools:', e);
+        throw e;
+      }
+    },
+    [client, logToolFlow]
+  );
 
   /**
    * Establishes connection to the MCP server.
@@ -255,12 +280,28 @@ export function McpClientProvider({
       return;
     }
 
+    const connectionId = ++activeConnectionIdRef.current;
     connectionStateRef.current = 'connecting';
     setIsLoading(true);
     setError(null);
+    resetConnectionData();
+
+    await pendingDisconnectRef.current;
+    if (activeConnectionIdRef.current !== connectionId) {
+      return;
+    }
+
+    let connected = false;
 
     try {
       await client.connect(transport, requestOpts);
+      if (activeConnectionIdRef.current !== connectionId) {
+        pendingDisconnectRef.current = client.close().catch(() => undefined);
+        await pendingDisconnectRef.current;
+        return;
+      }
+
+      connected = true;
       const caps = client.getServerCapabilities();
       setIsConnected(true);
       setCapabilities(caps || null);
@@ -269,26 +310,42 @@ export function McpClientProvider({
         hasToolsListChanged: Boolean(caps?.tools?.listChanged),
       });
 
-      await Promise.all([fetchResourcesInternal(), fetchToolsInternal()]);
+      await Promise.all([fetchResourcesInternal(connectionId), fetchToolsInternal(connectionId)]);
     } catch (e) {
       const err = e instanceof Error ? e : new Error(String(e));
-      connectionStateRef.current = 'disconnected';
-      setError(err);
+      if (activeConnectionIdRef.current === connectionId) {
+        if (!connected) {
+          connectionStateRef.current = 'disconnected';
+          resetConnectionData();
+        }
+        setError(err);
+      }
       throw err;
     } finally {
-      setIsLoading(false);
+      if (activeConnectionIdRef.current === connectionId) {
+        setIsLoading(false);
+      }
     }
-  }, [client, transport, requestOpts, fetchResourcesInternal, fetchToolsInternal, logToolFlow]);
+  }, [
+    client,
+    transport,
+    requestOpts,
+    fetchResourcesInternal,
+    fetchToolsInternal,
+    logToolFlow,
+    resetConnectionData,
+  ]);
 
   useEffect(() => {
     if (!isConnected || !client) {
       return;
     }
 
+    const connectionId = activeConnectionIdRef.current;
     const serverCapabilities = client.getServerCapabilities();
 
     const handleResourcesChanged = () => {
-      fetchResourcesInternal().catch((error) => {
+      fetchResourcesInternal(connectionId).catch((error) => {
         console.error(
           '[ReactWebMCP:McpClientProvider]',
           'Failed to refresh resources after list_changed:',
@@ -299,7 +356,7 @@ export function McpClientProvider({
 
     const handleToolsChanged = () => {
       logToolFlow('notification:tools/list_changed', {});
-      fetchToolsInternal().catch((error) => {
+      fetchToolsInternal(connectionId).catch((error) => {
         console.error(
           '[ReactWebMCP:McpClientProvider]',
           'Failed to refresh tools after list_changed:',
@@ -318,13 +375,15 @@ export function McpClientProvider({
 
     // Re-fetch after setting up handlers to catch any changes that occurred
     // during the gap between initial fetch and handler setup
-    Promise.all([fetchResourcesInternal(), fetchToolsInternal()]).catch((error) => {
-      console.error(
-        '[ReactWebMCP:McpClientProvider]',
-        'Failed to refresh tools/resources after handler registration:',
-        error
-      );
-    });
+    Promise.all([fetchResourcesInternal(connectionId), fetchToolsInternal(connectionId)]).catch(
+      (error) => {
+        console.error(
+          '[ReactWebMCP:McpClientProvider]',
+          'Failed to refresh tools/resources after handler registration:',
+          error
+        );
+      }
+    );
 
     return () => {
       if (serverCapabilities?.resources?.listChanged) {
@@ -346,10 +405,13 @@ export function McpClientProvider({
 
     // Cleanup: mark as disconnected so next mount will reconnect
     return () => {
+      activeConnectionIdRef.current += 1;
       connectionStateRef.current = 'disconnected';
-      setIsConnected(false);
+      pendingDisconnectRef.current = client.close().catch(() => undefined);
+      resetConnectionData();
+      setIsLoading(false);
     };
-  }, [client, transport, reconnect]);
+  }, [client, transport, reconnect, resetConnectionData]);
 
   return (
     <McpClientContext.Provider

--- a/packages/webmcp-ts-sdk/package.json
+++ b/packages/webmcp-ts-sdk/package.json
@@ -61,6 +61,7 @@
     "prepublishOnly": "node ../../scripts/validate-publish.js && pnpm run build",
     "publish:dry": "pnpm publish --access public --dry-run",
     "publish:npm": "pnpm publish --access public",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "version:major": "pnpm version major --no-git-tag-version",
     "version:minor": "pnpm version minor --no-git-tag-version",
@@ -74,7 +75,8 @@
     "@modelcontextprotocol/sdk": "catalog:",
     "@types/node": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "zod": "^3.25 || ^4.0",

--- a/packages/webmcp-ts-sdk/src/browser-server.test.ts
+++ b/packages/webmcp-ts-sdk/src/browser-server.test.ts
@@ -1,0 +1,44 @@
+import type { ModelContextCore, ToolDescriptor } from '@mcp-b/webmcp-types';
+import { describe, expect, it } from 'vitest';
+import { BrowserMcpServer } from './browser-server.js';
+
+function createTool(name: string): ToolDescriptor {
+  return {
+    name,
+    description: `${name} description`,
+    inputSchema: { type: 'object', properties: {} },
+    execute: async () => ({ content: [{ type: 'text', text: name }] }),
+  };
+}
+
+describe('BrowserMcpServer native context fallback', () => {
+  it('replaces and clears mirrored native tools when clearContext is unavailable', () => {
+    const registeredTools = new Set<string>();
+    const unregisteredTools: string[] = [];
+    const native = {
+      registerTool: (tool: ToolDescriptor) => {
+        registeredTools.add(tool.name);
+      },
+      unregisterTool: (name: string) => {
+        unregisteredTools.push(name);
+        registeredTools.delete(name);
+      },
+    } as Partial<ModelContextCore> as ModelContextCore;
+
+    const server = new BrowserMcpServer({ name: 'test-server', version: '1.0.0' }, { native });
+
+    server.provideContext({ tools: [createTool('alpha')] });
+    expect(server.listTools().map((tool) => tool.name)).toEqual(['alpha']);
+    expect([...registeredTools]).toEqual(['alpha']);
+
+    server.provideContext({ tools: [createTool('beta')] });
+    expect(server.listTools().map((tool) => tool.name)).toEqual(['beta']);
+    expect([...registeredTools]).toEqual(['beta']);
+    expect(unregisteredTools).toContain('alpha');
+
+    server.clearContext();
+    expect(server.listTools()).toEqual([]);
+    expect([...registeredTools]).toEqual([]);
+    expect(unregisteredTools).toContain('beta');
+  });
+});

--- a/packages/webmcp-ts-sdk/vitest.config.ts
+++ b/packages/webmcp-ts-sdk/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1063,6 +1063,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@types/node@22.17.2)(@vitest/browser-playwright@4.0.18)(happy-dom@20.7.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.10(@types/node@22.17.2)(typescript@5.9.3))(sass@1.97.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/webmcp-types:
     devDependencies:


### PR DESCRIPTION
## Summary
- add a live regression test that rerenders `McpClientProvider` with the same `Client` and a new transport
- close the previous client connection before reconnecting when `client` or `transport` props change
- ignore stale async tool/resource refreshes from old connections so switched transports cannot repopulate old state

## Problem
`McpClientProvider` attempted to call `client.connect(newTransport)` after a transport prop change without first closing the existing SDK connection. With the same `Client` instance, the SDK rejects that with:

`Already connected to a transport. Call close() before connecting to a new transport, or use a separate Protocol instance per connection.`

That left the provider stuck on stale capabilities/tools/resources from the old transport.

## Behavior
- transport changes now reset connection-scoped state and wait for the previous disconnect before reconnecting
- notification-triggered refreshes and in-flight list fetches are scoped to the active connection only
- stale tool updates from the old transport are ignored after a switch

Closes #150.

## Validation
- `NPM_TOKEN=dummy pnpm install`
- `NPM_TOKEN=dummy pnpm --filter @mcp-b/webmcp-types build`
- `NPM_TOKEN=dummy pnpm --filter @mcp-b/webmcp-polyfill build`
- `NPM_TOKEN=dummy pnpm --filter @mcp-b/webmcp-ts-sdk build`
- `NPM_TOKEN=dummy pnpm --filter @mcp-b/transports build`
- `NPM_TOKEN=dummy pnpm --filter @mcp-b/global build`
- `NPM_TOKEN=dummy pnpm --filter @mcp-b/react-webmcp exec vitest run src/client/McpClientProvider.test.tsx`
- `NPM_TOKEN=dummy pnpm --filter @mcp-b/react-webmcp typecheck`
