### PR TITLE
[codex] Harden local relay browser handshake

### DIFF
--- a/packages/webmcp-local-relay/src/bridgeServer.test.ts
+++ b/packages/webmcp-local-relay/src/bridgeServer.test.ts
@@ -215,11 +215,68 @@ describe('RelayBridgeServer', () => {
         })
       );
 
+      const rejection = await new Promise<Record<string, unknown>>((resolve, reject) => {
+        ws.on('message', (raw) => {
+          const message = JSON.parse(String(raw)) as Record<string, unknown>;
+          if (message.type === 'hello/rejected') {
+            resolve(message);
+          }
+        });
+        ws.on('error', reject);
+      });
+
       const closeCode = await new Promise<number>((resolve) => {
         ws.on('close', (code) => resolve(code));
       });
 
+      expect(rejection).toMatchObject({
+        type: 'hello/rejected',
+        reason: 'host-origin-not-allowed',
+      });
       expect(closeCode).toBe(1008);
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  it('acknowledges hello before accepting tools from an allowed source', async () => {
+    const bridge = new RelayBridgeServer({
+      host: '127.0.0.1',
+      port: 0,
+      allowedOrigins: ['https://trusted.example.com'],
+    });
+
+    try {
+      await bridge.start();
+
+      const ws = new WebSocket(`ws://127.0.0.1:${bridge.port}`);
+      const messages: Array<Record<string, unknown>> = [];
+      await new Promise<void>((resolve, reject) => {
+        ws.on('message', (raw) => {
+          messages.push(JSON.parse(String(raw)) as Record<string, unknown>);
+          if (
+            messages.some((message) => message.type === 'server-hello') &&
+            messages.some((message) => message.type === 'hello/accepted')
+          ) {
+            resolve();
+          }
+        });
+        ws.once('open', () => {
+          ws.send(
+            JSON.stringify({
+              type: 'hello',
+              tabId: 'tab-1',
+              origin: 'https://trusted.example.com',
+            })
+          );
+        });
+        ws.once('error', reject);
+      });
+
+      expect(messages.map((message) => message.type)).toContain('server-hello');
+      expect(messages.map((message) => message.type)).toContain('hello/accepted');
+
+      ws.close();
     } finally {
       await bridge.stop();
     }

--- a/packages/webmcp-local-relay/src/bridgeServer.ts
+++ b/packages/webmcp-local-relay/src/bridgeServer.ts
@@ -22,6 +22,8 @@ import {
   RelayClientToServerMessageSchema,
   type RelayServerToClientMessage,
   RelayServerToClientMessageSchema,
+  type RelayHelloAcceptedMessage,
+  type RelayHelloRejectedMessage,
   type RelaySourceInfo,
   type RelayToBrowserMessage,
   type ServerHelloMessage,
@@ -666,15 +668,29 @@ export class RelayBridgeServer extends EventEmitter {
     switch (message.type) {
       case 'hello':
         try {
+          const socket = this.socketByConnectionId.get(connectionId);
           if (!this.isHostOriginAllowed(message.origin)) {
             process.stderr.write(
               `[webmcp-local-relay] warn: rejecting source ${connectionId} with disallowed host origin: ${message.origin ?? 'missing'}\n`
             );
-            const socket = this.socketByConnectionId.get(connectionId);
-            socket?.close(1008, 'Host origin not allowed');
+            if (socket) {
+              this.sendHelloRejected(
+                socket,
+                {
+                  type: 'hello/rejected',
+                  reason: 'host-origin-not-allowed',
+                  message: 'Host page origin is not allowed by this relay.',
+                },
+                1008,
+                'Host origin not allowed'
+              );
+            }
             break;
           }
           this.registry.upsertSource(connectionId, message);
+          if (socket) {
+            this.sendHelloAccepted(socket, { type: 'hello/accepted' });
+          }
           this.emit('stateChanged');
         } catch (err) {
           process.stderr.write(
@@ -1292,6 +1308,39 @@ export class RelayBridgeServer extends EventEmitter {
     }
 
     return this.allowedOrigins.includes(origin);
+  }
+
+  private sendHelloAccepted(socket: WebSocket, message: RelayHelloAcceptedMessage): void {
+    try {
+      socket.send(JSON.stringify(message));
+    } catch (err) {
+      process.stderr.write(
+        `[webmcp-local-relay] warn: failed to send hello acceptance: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+      socket.close(1011, 'Failed to send hello acceptance');
+    }
+  }
+
+  private sendHelloRejected(
+    socket: WebSocket,
+    message: RelayHelloRejectedMessage,
+    closeCode: number,
+    closeReason: string
+  ): void {
+    try {
+      socket.send(JSON.stringify(message), () => {
+        try {
+          socket.close(closeCode, closeReason);
+        } catch {
+          // Ignore close failures after a rejection send attempt.
+        }
+      });
+    } catch (err) {
+      process.stderr.write(
+        `[webmcp-local-relay] warn: failed to send hello rejection: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+      socket.close(closeCode, closeReason);
+    }
   }
 
   /**

--- a/packages/webmcp-local-relay/src/browser/embed.ts
+++ b/packages/webmcp-local-relay/src/browser/embed.ts
@@ -302,21 +302,30 @@ function subscribeToToolChanges(): void {
   }
 
   let retries = 0;
-  const MAX_RETRIES = 50;
-  const RETRY_INTERVAL_MS = 100;
-  const retryTimer = setInterval(() => {
-    retries++;
-    if (trySubscribe()) {
-      clearInterval(retryTimer);
-      return;
-    }
-    if (retries >= MAX_RETRIES) {
-      clearInterval(retryTimer);
-      debugWarn(
-        `Could not subscribe to tool changes after ${MAX_RETRIES} retries. Dynamic tool updates will not be relayed.`
-      );
-    }
-  }, RETRY_INTERVAL_MS);
+  let retryDelayMs = 100;
+  const MAX_RETRIES = 40;
+  const MAX_RETRY_DELAY_MS = 1000;
+
+  const scheduleRetry = (): void => {
+    setTimeout(() => {
+      retries++;
+      if (trySubscribe()) {
+        return;
+      }
+
+      if (retries >= MAX_RETRIES) {
+        debugWarn(
+          `Could not subscribe to tool changes after ${MAX_RETRIES} retries. Dynamic tool updates will not be relayed.`
+        );
+        return;
+      }
+
+      retryDelayMs = Math.min(Math.round(retryDelayMs * 1.5), MAX_RETRY_DELAY_MS);
+      scheduleRetry();
+    }, retryDelayMs);
+  };
+
+  scheduleRetry();
 }
 
 function respondToSource(
@@ -393,7 +402,10 @@ function installElicitBridge(widgetSource: MessageEventSource, widgetOrigin: str
         ) => Promise<Record<string, unknown>>;
       })
     | undefined;
-  if (!mc || typeof mc.elicitInput !== 'function') return;
+  if (!mc || typeof mc.elicitInput !== 'function') {
+    debugWarn('Elicitation bridge not installed: elicitInput not available on modelContext');
+    return;
+  }
 
   mc.elicitInput = (
     params: Record<string, unknown>,
@@ -401,6 +413,19 @@ function installElicitBridge(widgetSource: MessageEventSource, widgetOrigin: str
   ): Promise<Record<string, unknown>> => {
     const callId = createElicitCallId();
     return new Promise<Record<string, unknown>>((resolve) => {
+      const ELICIT_TIMEOUT_MS = 60_000;
+
+      const cleanup = (): void => {
+        window.removeEventListener('message', handler);
+        clearTimeout(timeout);
+      };
+
+      const timeout = setTimeout(() => {
+        cleanup();
+        debugWarn('Elicitation request timed out after 60s');
+        resolve({ action: 'decline', content: null });
+      }, ELICIT_TIMEOUT_MS);
+
       const handler = (event: MessageEvent): void => {
         if (event.origin !== widgetOrigin) return;
         const data = event.data as Record<string, unknown>;
@@ -411,7 +436,7 @@ function installElicitBridge(widgetSource: MessageEventSource, widgetOrigin: str
         ) {
           return;
         }
-        window.removeEventListener('message', handler);
+        cleanup();
         resolve(
           isJsonObject(data.result)
             ? (data.result as Record<string, unknown>)
@@ -501,7 +526,11 @@ async function injectRelayWidget(cfg: RelayConfig): Promise<void> {
   let blobUrl: string | null = null;
   try {
     const response = await fetch(cfg.widgetUrl);
-    if (response.ok) {
+    if (!response.ok) {
+      console.warn(
+        `[webmcp-relay-embed] Widget HTML fetch returned ${String(response.status)}; falling back to direct iframe src.`
+      );
+    } else if (response.ok) {
       const html = await response.text();
       const configScript = `<script>window.__WEBMCP_RELAY_CONFIG=${JSON.stringify(Object.fromEntries(searchParams))};</script>`;
       const blob = new Blob([html.replace('</head>', `${configScript}</head>`)], {
@@ -578,12 +607,15 @@ if (!document.querySelector(RELAY_IFRAME_SELECTOR)) {
     }
   });
 
-  if (document.body) {
-    void injectRelayWidget(config);
-  } else {
-    document.addEventListener('DOMContentLoaded', () => void injectRelayWidget(config), {
-      once: true,
+  const launchWidget = (): void => {
+    injectRelayWidget(config).catch((err) => {
+      console.error('[webmcp-relay-embed] Failed to inject relay widget:', err);
     });
+  };
+  if (document.body) {
+    launchWidget();
+  } else {
+    document.addEventListener('DOMContentLoaded', launchWidget, { once: true });
   }
 
   subscribeToToolChanges();

--- a/packages/webmcp-local-relay/src/browser/widget.test.ts
+++ b/packages/webmcp-local-relay/src/browser/widget.test.ts
@@ -173,6 +173,8 @@ async function completeHandshake(
 function installEnvironment(options?: {
   referrer?: string;
   search?: string;
+  sendHelloAccepted?: boolean;
+  sendHelloRejected?: { message: string; reason: string } | false;
   sendServerHello?: boolean;
 }): WidgetTestEnv {
   const connections: RelayConnection[] = [];
@@ -195,7 +197,31 @@ function installEnvironment(options?: {
     relayLink.addEventListener('connection', ({ client }) => {
       const connection: RelayConnection = { client: client as RelayClient, messages: [] };
       client.addEventListener('message', (event) => {
-        connection.messages.push(parseWireData(event.data));
+        const payload = parseWireData(event.data);
+        connection.messages.push(payload);
+        if (!payload || typeof payload !== 'object') {
+          return;
+        }
+
+        const message = payload as { type?: unknown };
+        if (message.type !== 'hello') {
+          return;
+        }
+
+        if (options?.sendHelloRejected) {
+          client.send(
+            JSON.stringify({
+              type: 'hello/rejected',
+              message: options.sendHelloRejected.message,
+              reason: options.sendHelloRejected.reason,
+            })
+          );
+          return;
+        }
+
+        if (options?.sendHelloAccepted !== false) {
+          client.send(JSON.stringify({ type: 'hello/accepted' }));
+        }
       });
       if (options?.sendServerHello !== false) {
         client.send(
@@ -260,6 +286,8 @@ function installEnvironment(options?: {
 function startRuntime(options?: {
   referrer?: string;
   search?: string;
+  sendHelloAccepted?: boolean;
+  sendHelloRejected?: { message: string; reason: string } | false;
   sendServerHello?: boolean;
 }): WidgetTestEnv {
   const env = installEnvironment(options);
@@ -513,7 +541,15 @@ describe('widget runtime', () => {
       relayLink.addEventListener('connection', ({ client }) => {
         const connection: RelayConnection = { client: client as RelayClient, messages: [] };
         client.addEventListener('message', (event) => {
-          connection.messages.push(parseWireData(event.data));
+          const payload = parseWireData(event.data);
+          connection.messages.push(payload);
+          if (
+            payload &&
+            typeof payload === 'object' &&
+            (payload as { type?: unknown }).type === 'hello'
+          ) {
+            client.send(JSON.stringify({ type: 'hello/accepted' }));
+          }
         });
         client.send(
           JSON.stringify({
@@ -806,6 +842,75 @@ describe('widget runtime', () => {
 
     await waitForConnection(env, 2);
     await waitForPostedMessage(env, 'webmcp.tools.list.request', 2);
+  });
+
+  it('surfaces structured hello rejection before the socket closes', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const env = startRuntime({
+      sendHelloRejected: {
+        message: 'Host page origin is not allowed by this relay.',
+        reason: 'host-origin-not-allowed',
+      },
+    });
+
+    const request = await waitForPostedMessage(env, 'webmcp.tools.list.request');
+    env.hostWindow.dispatchMessage(APP_ORIGIN, {
+      requestId: request.payload.requestId,
+      tools: [{ name: 'sum' }],
+      type: 'webmcp.tools.list.response',
+    });
+
+    const connection = await waitForConnection(env);
+    await vi.waitFor(() => {
+      expect(connection.messages).toHaveLength(1);
+    });
+
+    expect(connection.messages[0]).toMatchObject({
+      origin: APP_ORIGIN,
+      type: 'hello',
+    });
+
+    await vi.waitFor(() => {
+      expect(error).toHaveBeenCalledWith(
+        '[webmcp-relay-widget] Relay rejected browser hello:',
+        'host-origin-not-allowed',
+        'Host page origin is not allowed by this relay.'
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(getPostedMessages(env, 'webmcp.relay.rejected')).toHaveLength(1);
+    });
+  });
+
+  it('falls back to legacy relay behavior when hello is never acknowledged', async () => {
+    const env = startRuntime({
+      sendHelloAccepted: false,
+    });
+
+    const request = await waitForPostedMessage(env, 'webmcp.tools.list.request');
+    env.hostWindow.dispatchMessage(APP_ORIGIN, {
+      requestId: request.payload.requestId,
+      tools: [{ name: 'sum', description: 'Adds numbers' }],
+      type: 'webmcp.tools.list.response',
+    });
+
+    const connection = await waitForConnection(env);
+    await vi.waitFor(
+      () => {
+        expect(connection.messages).toHaveLength(2);
+      },
+      { timeout: 1000 }
+    );
+
+    expect(connection.messages[0]).toMatchObject({
+      origin: APP_ORIGIN,
+      type: 'hello',
+    });
+    expect(connection.messages[1]).toEqual({
+      tools: [{ description: 'Adds numbers', name: 'sum' }],
+      type: 'tools/list',
+    });
   });
 
   it('starts without emitting websocket warnings during a healthy connection', async () => {

--- a/packages/webmcp-local-relay/src/browser/widgetRuntime.ts
+++ b/packages/webmcp-local-relay/src/browser/widgetRuntime.ts
@@ -59,6 +59,16 @@ interface RelayHelloMessage {
   workspace?: string;
 }
 
+interface RelayHelloAcceptedMessage {
+  type: 'hello/accepted';
+}
+
+interface RelayHelloRejectedMessage {
+  type: 'hello/rejected';
+  message: string;
+  reason: string;
+}
+
 interface RelayEndpoint {
   hello: RelayHelloMessage;
   host: string;
@@ -81,6 +91,7 @@ const RECONNECT_INITIAL_DELAY_MS = 500;
 const RECONNECT_MAX_DELAY_MS = 3000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 60000;
 const RELAY_SERVER_HELLO_TIMEOUT_MS = 1200;
+const RELAY_HELLO_ACK_TIMEOUT_MS = 250;
 const MAX_ENDPOINT_FAILURES_BEFORE_REDISCOVERY = 5;
 
 export function parseConfig(search = window.location.search): WidgetConfig | null {
@@ -210,6 +221,33 @@ function parseRelayHello(value: unknown): RelayHelloMessage | null {
   };
 }
 
+function parseRelayHelloAccepted(value: unknown): RelayHelloAcceptedMessage | null {
+  if (!isJsonObject(value) || value.type !== 'hello/accepted') {
+    return null;
+  }
+
+  return {
+    type: 'hello/accepted',
+  };
+}
+
+function parseRelayHelloRejected(value: unknown): RelayHelloRejectedMessage | null {
+  if (
+    !isJsonObject(value) ||
+    value.type !== 'hello/rejected' ||
+    typeof value.message !== 'string' ||
+    typeof value.reason !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    type: 'hello/rejected',
+    message: value.message,
+    reason: value.reason,
+  };
+}
+
 function cacheKeyForConfig(config: WidgetConfig): string {
   return buildRelayEndpointCacheKey({
     hostOrigin: config.hostOrigin,
@@ -263,6 +301,18 @@ function writeCachedEndpoint(config: WidgetConfig, endpoint: RelayEndpoint): voi
         port: endpoint.port,
       })
     );
+  } catch {
+    // Ignore sessionStorage failures in sandboxed/private browsing contexts.
+  }
+}
+
+function clearCachedEndpoint(config: WidgetConfig): void {
+  if (typeof sessionStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    sessionStorage.removeItem(cacheKeyForConfig(config));
   } catch {
     // Ignore sessionStorage failures in sandboxed/private browsing contexts.
   }
@@ -378,7 +428,8 @@ export function runWidget(cfg: WidgetConfig): void {
   let activeEndpoint: RelayEndpoint | null = null;
   let activeSocket: WebSocket | null = null;
   let consecutiveEndpointFailures = 0;
-  let helloSent = false;
+  let helloAccepted = false;
+  let helloAckTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
   let scheduledReconnect: ReturnType<typeof setTimeout> | null = null;
   let state: RelayRuntimeState = 'idle';
@@ -420,6 +471,20 @@ export function runWidget(cfg: WidgetConfig): void {
   }
 
   const activateSocket = (socket: WebSocket, endpoint: RelayEndpoint): void => {
+    let initialTools: unknown[] = [];
+
+    const clearHelloAckTimer = (): void => {
+      if (!helloAckTimer) {
+        return;
+      }
+      clearTimeout(helloAckTimer);
+      helloAckTimer = null;
+    };
+
+    const sendInitialTools = (): void => {
+      safeSend(socket, JSON.stringify({ type: 'tools/list', tools: initialTools }));
+    };
+
     if (scheduledReconnect) {
       clearTimeout(scheduledReconnect);
       scheduledReconnect = null;
@@ -428,9 +493,8 @@ export function runWidget(cfg: WidgetConfig): void {
     activeEndpoint = endpoint;
     activeSocket = socket;
     reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
-    helloSent = false;
+    helloAccepted = false;
     setState('connected');
-    writeCachedEndpoint(cfg, endpoint);
 
     socket.addEventListener('message', (event) => {
       let relayMessage: Record<string, unknown>;
@@ -448,6 +512,43 @@ export function runWidget(cfg: WidgetConfig): void {
           host: endpoint.host,
           port: endpoint.port,
         };
+        return;
+      }
+
+      const helloAcceptedMessage = parseRelayHelloAccepted(relayMessage);
+      if (helloAcceptedMessage) {
+        clearHelloAckTimer();
+        helloAccepted = true;
+        writeCachedEndpoint(cfg, endpoint);
+        sendInitialTools();
+        return;
+      }
+
+      const helloRejected = parseRelayHelloRejected(relayMessage);
+      if (helloRejected) {
+        clearHelloAckTimer();
+        helloAccepted = false;
+        clearCachedEndpoint(cfg);
+        window.parent.postMessage(
+          {
+            type: 'webmcp.relay.rejected',
+            host: endpoint.host,
+            port: endpoint.port,
+            message: helloRejected.message,
+            reason: helloRejected.reason,
+          },
+          cfg.hostOrigin
+        );
+        console.error(
+          '[webmcp-relay-widget] Relay rejected browser hello:',
+          helloRejected.reason,
+          helloRejected.message
+        );
+        try {
+          socket.close(1008, helloRejected.message);
+        } catch {
+          // Ignore close failures after a structured rejection.
+        }
         return;
       }
 
@@ -530,8 +631,9 @@ export function runWidget(cfg: WidgetConfig): void {
           return;
         }
 
-        helloSent = false;
+        helloAccepted = false;
         activeSocket = null;
+        clearHelloAckTimer();
         rejectPendingRequests('WebSocket connection lost');
         consecutiveEndpointFailures += 1;
 
@@ -557,7 +659,7 @@ export function runWidget(cfg: WidgetConfig): void {
 
     requestHost('webmcp.tools.list', {})
       .then((message) => {
-        const tools = Array.isArray(message.tools) ? message.tools : [];
+        initialTools = Array.isArray(message.tools) ? message.tools : [];
         safeSend(
           socket,
           JSON.stringify({
@@ -568,8 +670,17 @@ export function runWidget(cfg: WidgetConfig): void {
             url: cfg.hostUrl,
           })
         );
-        safeSend(socket, JSON.stringify({ type: 'tools/list', tools }));
-        helloSent = true;
+        helloAckTimer = setTimeout(() => {
+          helloAckTimer = null;
+          if (activeSocket !== socket || socket.readyState !== WebSocket.OPEN || helloAccepted) {
+            return;
+          }
+
+          // Legacy relays accept browser hello but never acknowledge it.
+          helloAccepted = true;
+          writeCachedEndpoint(cfg, endpoint);
+          sendInitialTools();
+        }, RELAY_HELLO_ACK_TIMEOUT_MS);
       })
       .catch((error) => {
         console.warn('[webmcp-relay-widget] Hello handshake failed:', error);
@@ -685,7 +796,7 @@ export function runWidget(cfg: WidgetConfig): void {
 
     const data = event.data;
     if (isJsonObject(data) && data.type === 'webmcp.tools.changed') {
-      if (activeSocket && helloSent) {
+      if (activeSocket && helloAccepted) {
         safeSend(
           activeSocket,
           JSON.stringify({

--- a/packages/webmcp-local-relay/src/cli.ts
+++ b/packages/webmcp-local-relay/src/cli.ts
@@ -87,6 +87,18 @@ const shutdown = async (signal: string) => {
 
 let shuttingDown = false;
 
+process.on('uncaughtException', (err) => {
+  process.stderr.write(
+    `[webmcp-local-relay] error: uncaught exception: ${err.stack ?? err.message}\n`
+  );
+  void shutdown('uncaughtException');
+});
+process.on('unhandledRejection', (reason) => {
+  const message = reason instanceof Error ? (reason.stack ?? reason.message) : String(reason);
+  process.stderr.write(`[webmcp-local-relay] error: unhandled rejection: ${message}\n`);
+  void shutdown('unhandledRejection');
+});
+
 process.on('SIGINT', () => {
   void shutdown('SIGINT');
 });

--- a/packages/webmcp-local-relay/src/index.ts
+++ b/packages/webmcp-local-relay/src/index.ts
@@ -32,6 +32,10 @@ export {
 export {
   type BrowserToRelayMessage,
   BrowserToRelayMessageSchema,
+  type RelayHelloAcceptedMessage,
+  RelayHelloAcceptedMessageSchema,
+  type RelayHelloRejectedMessage,
+  RelayHelloRejectedMessageSchema,
   type RelayClientToServerMessage,
   RelayClientToServerMessageSchema,
   type RelayDescriptor,

--- a/packages/webmcp-local-relay/src/mcpRelayServer.ts
+++ b/packages/webmcp-local-relay/src/mcpRelayServer.ts
@@ -117,12 +117,14 @@ export class LocalRelayMcpServer {
               result as Record<string, unknown>
             );
           } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
             process.stderr.write(
-              `[webmcp-local-relay] warn: elicitation forwarding failed: ${err instanceof Error ? err.message : String(err)}\n`
+              `[webmcp-local-relay] warn: elicitation forwarding failed: ${message}\n`
             );
             this.bridge.sendElicitationResponse(request.connectionId, request.callId, {
               action: 'decline',
               content: null,
+              error: message,
             });
           }
         })();
@@ -153,6 +155,12 @@ export class LocalRelayMcpServer {
 
     await this.mcpServer.connect(transport);
     this.connected = true;
+
+    this.mcpServer.server.onerror = (error) => {
+      process.stderr.write(
+        `[webmcp-local-relay] error: MCP protocol error: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`
+      );
+    };
   }
 
   /**

--- a/packages/webmcp-local-relay/src/schemas.test.ts
+++ b/packages/webmcp-local-relay/src/schemas.test.ts
@@ -12,6 +12,8 @@ import {
   RelayClientListToolsSchema,
   RelayClientToServerMessageSchema,
   RelayDescriptorSchema,
+  RelayHelloAcceptedMessageSchema,
+  RelayHelloRejectedMessageSchema,
   RelayInvokeMessageSchema,
   RelayPingMessageSchema,
   RelayReloadMessageSchema,
@@ -236,6 +238,22 @@ describe('BrowserToRelayMessageSchema', () => {
     });
     expect(result.success).toBe(true);
     expect(result.data?.type).toBe('server-hello');
+  });
+
+  it('parses a hello/accepted relay message', () => {
+    const result = RelayHelloAcceptedMessageSchema.safeParse({
+      type: 'hello/accepted',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('parses a hello/rejected relay message', () => {
+    const result = RelayHelloRejectedMessageSchema.safeParse({
+      type: 'hello/rejected',
+      reason: 'host-origin-not-allowed',
+      message: 'Host page origin is not allowed by this relay.',
+    });
+    expect(result.success).toBe(true);
   });
 
   it('rejects a message without a type field', () => {

--- a/packages/webmcp-local-relay/src/schemas.ts
+++ b/packages/webmcp-local-relay/src/schemas.ts
@@ -135,6 +135,32 @@ export const ServerHelloMessageSchema = z.object({
 export type ServerHelloMessage = z.infer<typeof ServerHelloMessageSchema>;
 
 /**
+ * Schema for acceptance of a browser source hello message.
+ */
+export const RelayHelloAcceptedMessageSchema = z.object({
+  type: z.literal('hello/accepted'),
+});
+
+/**
+ * Acceptance payload for a browser source hello message.
+ */
+export type RelayHelloAcceptedMessage = z.infer<typeof RelayHelloAcceptedMessageSchema>;
+
+/**
+ * Schema for rejection of a browser source hello message.
+ */
+export const RelayHelloRejectedMessageSchema = z.object({
+  type: z.literal('hello/rejected'),
+  reason: z.string().min(1),
+  message: z.string().min(1),
+});
+
+/**
+ * Rejection payload for a browser source hello message.
+ */
+export type RelayHelloRejectedMessage = z.infer<typeof RelayHelloRejectedMessageSchema>;
+
+/**
  * Schema for relay invocation messages sent to browser sources.
  */
 export const RelayInvokeMessageSchema = z.object({
@@ -174,6 +200,8 @@ export const RelayElicitationResponseSchema = z.object({
  */
 export const RelayToBrowserMessageSchema = z.discriminatedUnion('type', [
   ServerHelloMessageSchema,
+  RelayHelloAcceptedMessageSchema,
+  RelayHelloRejectedMessageSchema,
   RelayInvokeMessageSchema,
   RelayPingMessageSchema,
   RelayReloadMessageSchema,


### PR DESCRIPTION
## Summary

- harden the local relay browser handshake and source validation
- surface structured relay rejection reasons to the widget host page
- preserve the configurable widget request timeout and current docs from main

## Impact

This keeps the branch based directly on origin/main while carrying only the relay source and test changes. It does not include release metadata, package version, manifest, README, generated widget HTML, or standalone design-doc changes.

## Validation

- pnpm --filter @mcp-b/webmcp-local-relay check
- pnpm --filter @mcp-b/webmcp-local-relay typecheck
- pnpm --filter @mcp-b/webmcp-local-relay test

Note: the relay unit tests need permission to bind localhost sockets; they pass when run outside the sandbox.