### PR TITLE
ci: exclude agent skills from beta release stack

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,8 +15,7 @@
       "@mcp-b/react-webmcp",
       "usewebmcp",
       "@mcp-b/webmcp-local-relay",
-      "@mcp-b/chrome-devtools-mcp",
-      "agent-skills-ts-sdk"
+      "@mcp-b/chrome-devtools-mcp"
     ]
   ],
   "linked": [],

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -257,6 +257,10 @@ jobs:
             if [ -f "$pkg/package.json" ]; then
               name=$(jq -r '.name' "$pkg/package.json")
               current_version=$(jq -r '.version' "$pkg/package.json")
+              if [ "$name" = "agent-skills-ts-sdk" ]; then
+                echo "Skipping $name; not part of the WebMCP prerelease stack"
+                continue
+              fi
               if [ "$name" != "null" ] && [ "$current_version" != "null" ]; then
                 prerelease_version="${current_version}-${TAG_SUFFIX}.${TIMESTAMP}"
                 jq --arg v "$prerelease_version" '.version = $v' "$pkg/package.json" > "$pkg/package.json.tmp"
@@ -270,7 +274,7 @@ jobs:
 
       - name: Publish prerelease packages
         run: |
-          pnpm publish -r --access public --tag "${{ inputs.tag || 'beta' }}" --no-git-checks
+          pnpm --filter '!agent-skills-ts-sdk' publish -r --access public --tag "${{ inputs.tag || 'beta' }}" --no-git-checks
 
       - name: Install cosign
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v3.8.0


### PR DESCRIPTION
## Summary
- remove `agent-skills-ts-sdk` from the fixed WebMCP changeset release group
- skip `agent-skills-ts-sdk` when creating prerelease versions
- exclude `agent-skills-ts-sdk` from the recursive beta publish command

## Why
The beta trusted-publishing workflow is for the WebMCP package stack. `agent-skills-ts-sdk` has separate npm trust ownership and blocks this workflow with E409/E404 trust errors.

## Test plan
- `node -e "JSON.parse(require('fs').readFileSync('.changeset/config.json','utf8')); console.log('json ok')"`
- `pnpm --filter '!agent-skills-ts-sdk' list --depth -1 --json | jq -r '.[].name' | rg 'agent-skills|@mcp-b/webmcp-types|@mcp-b/global'` confirms the exclusion keeps WebMCP packages and drops agent skills.

Note: full `pnpm check` was not run in the clean worktree because it has no `node_modules`; the local change is confined to release JSON/YAML.