### PR TITLE
fix(release): allow publish after CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check": "vp check --fix",
     "check:ci": "vp check",
     "check-all": "pnpm -r --filter '!@mcp-b/example-*' --filter '!@mcp-b/chrome-devtools-mcp' run typecheck && vp check",
-    "ci:publish": "pnpm publish -r --access public",
+    "ci:publish": "pnpm publish -r --access public --no-git-checks",
     "clean": "git clean -xdf .cache .vite node_modules",
     "format": "vp fmt --write",
     "format:check": "vp fmt --check",

--- a/packages/react-webmcp/src/zod-utils.test.ts
+++ b/packages/react-webmcp/src/zod-utils.test.ts
@@ -132,5 +132,39 @@ describe('zod-utils', () => {
       });
       expect(result.required).toBeUndefined();
     });
+
+    it('falls back to native Zod v4 JSON Schema conversion when zod-to-json-schema omits type', () => {
+      const schema = {
+        count: {
+          _def: { type: 'number' },
+          toJSONSchema: () => ({
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            type: 'number',
+          }),
+        },
+        maybe: {
+          _def: { type: 'optional' },
+          toJSONSchema: () => ({
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            type: 'string',
+          }),
+        },
+      };
+
+      zodToJsonSchemaMock.mockReturnValue({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+      });
+
+      const result = zodToJsonSchema(schema as never);
+
+      expect(result).toEqual({
+        type: 'object',
+        properties: {
+          count: { type: 'number' },
+          maybe: { type: 'string' },
+        },
+        required: ['count'],
+      });
+    });
   });
 });

--- a/packages/react-webmcp/src/zod-utils.ts
+++ b/packages/react-webmcp/src/zod-utils.ts
@@ -17,7 +17,12 @@ function isZodLikeValue(value: unknown): boolean {
 type ZodDefinitionCarrier = {
   _def: {
     typeName: unknown;
+    type?: unknown;
   };
+};
+
+type ZodJsonSchemaCarrier = {
+  toJSONSchema: () => unknown;
 };
 
 function hasZodTypeName(schema: unknown): schema is ZodDefinitionCarrier {
@@ -38,11 +43,19 @@ export function isZodSchema(schema: unknown): schema is ZodSchemaObject {
 
 function isOptionalSchema(schema: unknown): boolean {
   if (!hasZodTypeName(schema)) {
-    return false;
+    if (!isRecord(schema) || !isRecord(schema._def)) {
+      return false;
+    }
+
+    return schema._def.type === 'optional' || schema._def.type === 'default';
   }
 
   const { typeName } = schema._def;
   return typeName === 'ZodOptional' || typeName === 'ZodDefault';
+}
+
+function hasNativeJsonSchema(schema: unknown): schema is ZodJsonSchemaCarrier {
+  return isRecord(schema) && typeof schema.toJSONSchema === 'function';
 }
 
 function stripSchemaMeta(schema: InputSchema): InputSchema {
@@ -68,10 +81,15 @@ export function zodToJsonSchema(schema: ZodSchemaObject): InputSchema {
     }
 
     const zodSchema = rawValue as z.ZodTypeAny;
-    const propSchema = zodToJsonSchemaLib(zodSchema, {
+    let propSchema: unknown = zodToJsonSchemaLib(zodSchema, {
       strictUnions: true,
       $refStrategy: 'none',
     });
+
+    if (isRecord(propSchema) && !('type' in propSchema) && hasNativeJsonSchema(zodSchema)) {
+      propSchema = zodSchema.toJSONSchema();
+    }
+
     properties[key] = stripSchemaMeta(propSchema as InputSchema);
     if (!isOptionalSchema(zodSchema)) {
       required.push(key);


### PR DESCRIPTION
## Summary
- Add `--no-git-checks` to the root `ci:publish` script used by the Changesets release workflow.
- Fix React WebMCP Zod v4 schema conversion so `outputSchema` is not dropped when `zod-to-json-schema` returns metadata without a `type`.
- Add a regression test for the Zod v4 native `toJSONSchema()` fallback and optional/default detection.

## Why
The post-merge release run for PR #222 failed after a successful build because `pnpm publish -r --access public` rejected generated build output as an unclean working tree:

- Failed run: https://github.com/WebMCP-org/npm-packages/actions/runs/26610715768
- Error: `ERR_PNPM_GIT_UNCLEAN`

The first CI run on this fix branch then exposed a separate main-branch typecheck failure in `@mcp-b/react-webmcp`: the Zod v4 path could drop a zod-like `outputSchema` during registration. This patch fixes that compatibility path instead of weakening the test.

## Validation
- `NPM_TOKEN=dummy vp install`
- `NPM_TOKEN=dummy pnpm build`
- `NPM_TOKEN=dummy pnpm --filter @mcp-b/react-webmcp exec tsc --noEmit`
- `NPM_TOKEN=dummy pnpm --filter @mcp-b/react-webmcp test -- src/zod-utils.test.ts src/useWebMCP.test.ts -t "zod-like outputSchema|native Zod v4"`
- `NPM_TOKEN=dummy pnpm --filter @mcp-b/react-webmcp run typecheck`