### PR TITLE
[codex] store static tool descriptors in refs

### DIFF
--- a/packages/react-webmcp/src/model-context.ts
+++ b/packages/react-webmcp/src/model-context.ts
@@ -1,9 +1,14 @@
-export type ModelContextSurface = Document['modelContext'];
+import type { ModelContext } from '@mcp-b/webmcp-types';
+
+export type ModelContextSurface = ModelContext;
+type ModelContextHost = { modelContext?: ModelContext };
 
 export function getModelContext(): ModelContextSurface | undefined {
   if (typeof window === 'undefined') {
     return undefined;
   }
 
-  return window.document?.modelContext ?? window.navigator?.modelContext;
+  const documentContext = (window.document as Document & ModelContextHost).modelContext;
+  const navigatorContext = (window.navigator as Navigator & ModelContextHost).modelContext;
+  return documentContext ?? navigatorContext;
 }

--- a/packages/react-webmcp/src/useWebMCP.test.ts
+++ b/packages/react-webmcp/src/useWebMCP.test.ts
@@ -641,6 +641,57 @@ describe('useWebMCP', () => {
       }
     });
 
+    it('should not re-register when schema or annotations references change without deps', async () => {
+      const registerToolSpy = vi.spyOn(navigator.modelContext, 'registerTool');
+
+      try {
+        const { rerender } = await renderHook(
+          ({ inputSchema, outputSchema, annotations }) =>
+            useWebMCP({
+              name: 'stable_descriptor_tool',
+              description: 'Stable descriptor tool',
+              inputSchema,
+              outputSchema,
+              annotations,
+              handler: async () => ({ value: 'test' }),
+            }),
+          {
+            initialProps: {
+              inputSchema: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+                required: ['name'],
+              } as const,
+              outputSchema: {
+                type: 'object',
+                properties: { value: { type: 'string' } },
+              } as const,
+              annotations: { readOnlyHint: true } as const,
+            },
+          }
+        );
+
+        const initialCallCount = registerToolSpy.mock.calls.length;
+
+        await rerender({
+          inputSchema: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name'],
+          } as const,
+          outputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+          } as const,
+          annotations: { readOnlyHint: true },
+        });
+
+        expect(registerToolSpy.mock.calls.length).toBe(initialCallCount);
+      } finally {
+        registerToolSpy.mockRestore();
+      }
+    });
+
     it('should re-register when name changes', async () => {
       const { rerender } = await renderHook(
         ({ name }) =>

--- a/packages/react-webmcp/src/useWebMCP.ts
+++ b/packages/react-webmcp/src/useWebMCP.ts
@@ -324,14 +324,20 @@ export function useWebMCP<
   const onSuccessRef = useRef(onSuccess);
   const onErrorRef = useRef(onError);
   const formatOutputRef = useRef(formatOutput);
+  const inputSchemaRef = useRef(inputSchema);
+  const outputSchemaRef = useRef(outputSchema);
+  const annotationsRef = useRef(annotations);
   const isMountedRef = useRef(true);
-  // Update refs when callbacks change (doesn't trigger re-registration)
+  // Update refs when callbacks or static descriptors are recreated during render.
   useIsomorphicLayoutEffect(() => {
     handlerRef.current = handler;
     onSuccessRef.current = onSuccess;
     onErrorRef.current = onError;
     formatOutputRef.current = formatOutput;
-  }, [handler, onSuccess, onError, formatOutput]);
+    inputSchemaRef.current = inputSchema;
+    outputSchemaRef.current = outputSchema;
+    annotationsRef.current = annotations;
+  }, [annotations, handler, inputSchema, onSuccess, onError, outputSchema, formatOutput]);
 
   // Cleanup: mark component as unmounted
   useEffect(() => {
@@ -445,7 +451,7 @@ export function useWebMCP<
           ],
         };
 
-        if (isObjectOutputSchema(outputSchema)) {
+        if (isObjectOutputSchema(outputSchemaRef.current)) {
           const structuredContent = toStructuredContent(result);
           if (!structuredContent) {
             throw new Error(
@@ -471,8 +477,9 @@ export function useWebMCP<
       }
     };
 
-    const resolvedInputSchema = toRegisteredInputSchema(inputSchema);
-    const resolvedOutputSchema = toRegisteredOutputSchema(outputSchema);
+    const resolvedInputSchema = toRegisteredInputSchema(inputSchemaRef.current);
+    const resolvedOutputSchema = toRegisteredOutputSchema(outputSchemaRef.current);
+    const resolvedAnnotations = annotationsRef.current;
 
     const ownerToken = Symbol(name);
     const toolDescriptor: ToolDescriptor = {
@@ -480,7 +487,7 @@ export function useWebMCP<
       description,
       ...(resolvedInputSchema && { inputSchema: resolvedInputSchema }),
       ...(resolvedOutputSchema && { outputSchema: resolvedOutputSchema }),
-      ...(annotations && { annotations }),
+      ...(resolvedAnnotations && { annotations: resolvedAnnotations }),
       execute: mcpHandler,
     };
     const controller = registerToolWithCleanup(modelContext, toolDescriptor);
@@ -497,7 +504,7 @@ export function useWebMCP<
     };
     // Spread operator in dependencies intentionally allows consumers to trigger
     // re-registration with custom reactive inputs.
-  }, [name, description, inputSchema, outputSchema, annotations, ...(deps ?? [])]);
+  }, [name, description, ...(deps ?? [])]);
 
   return {
     state,

--- a/packages/usewebmcp/src/model-context.ts
+++ b/packages/usewebmcp/src/model-context.ts
@@ -1,9 +1,14 @@
-export type ModelContextSurface = Document['modelContext'];
+import type { ModelContext } from '@mcp-b/webmcp-types';
+
+export type ModelContextSurface = ModelContext;
+type ModelContextHost = { modelContext?: ModelContext };
 
 export function getModelContext(): ModelContextSurface | undefined {
   if (typeof window === 'undefined') {
     return undefined;
   }
 
-  return window.document?.modelContext ?? window.navigator?.modelContext;
+  const documentContext = (window.document as Document & ModelContextHost).modelContext;
+  const navigatorContext = (window.navigator as Navigator & ModelContextHost).modelContext;
+  return documentContext ?? navigatorContext;
 }

--- a/packages/usewebmcp/src/useWebMCP.test.ts
+++ b/packages/usewebmcp/src/useWebMCP.test.ts
@@ -438,6 +438,57 @@ describe('useWebMCP', () => {
       }
     });
 
+    it('should not re-register when schema or annotations references change without deps', async () => {
+      const registerToolSpy = vi.spyOn(navigator.modelContext, 'registerTool');
+
+      try {
+        const { rerender } = await renderHook(
+          ({ inputSchema, outputSchema, annotations }) =>
+            useWebMCP({
+              name: 'stable_descriptor_tool',
+              description: 'Stable descriptor tool',
+              inputSchema,
+              outputSchema,
+              annotations,
+              handler: async () => ({ value: 'test' }),
+            }),
+          {
+            initialProps: {
+              inputSchema: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+                required: ['name'],
+              } as const,
+              outputSchema: {
+                type: 'object',
+                properties: { value: { type: 'string' } },
+              } as const,
+              annotations: { readOnlyHint: true } as const,
+            },
+          }
+        );
+
+        const initialCallCount = registerToolSpy.mock.calls.length;
+
+        await rerender({
+          inputSchema: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name'],
+          } as const,
+          outputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+          } as const,
+          annotations: { readOnlyHint: true },
+        });
+
+        expect(registerToolSpy.mock.calls.length).toBe(initialCallCount);
+      } finally {
+        registerToolSpy.mockRestore();
+      }
+    });
+
     it('should re-register when name changes', async () => {
       const { rerender } = await renderHook(
         ({ name }) =>
@@ -797,97 +848,50 @@ describe('useWebMCP', () => {
       (globalThis as Record<string, unknown>).process = originalProcess;
     });
 
-    it('should warn when inputSchema reference changes in dev mode', async () => {
+    it('should not warn when schema or annotations references change in dev mode', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       try {
         const { rerender } = await renderHook(
-          ({ schema }) =>
+          ({ inputSchema, outputSchema, annotations }) =>
             useWebMCP({
-              name: 'dev_input_warn_tool',
+              name: 'dev_descriptor_ref_tool',
               description: 'Test',
-              inputSchema: schema,
-              handler: async () => 'result',
-            }),
-          {
-            initialProps: {
-              schema: {
-                type: 'object',
-                properties: { name: { type: 'string' } },
-                required: ['name'],
-              } as const,
-            },
-          }
-        );
-
-        // Rerender with new inputSchema reference
-        await rerender({
-          schema: {
-            type: 'object',
-            properties: { name: { type: 'string' } },
-            required: ['name'],
-          } as const,
-        });
-
-        expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('inputSchema reference changed')
-        );
-      } finally {
-        warnSpy.mockRestore();
-      }
-    });
-
-    it('should warn when outputSchema reference changes in dev mode', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-      try {
-        const { rerender } = await renderHook(
-          ({ schema }) =>
-            useWebMCP({
-              name: 'dev_output_warn_tool',
-              description: 'Test',
-              outputSchema: schema,
+              inputSchema,
+              outputSchema,
+              annotations,
               handler: async () => ({ value: 'test' }),
             }),
           {
             initialProps: {
-              schema: { type: 'object', properties: { value: { type: 'string' } } } as const,
+              inputSchema: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+                required: ['name'],
+              } as const,
+              outputSchema: {
+                type: 'object',
+                properties: { value: { type: 'string' } },
+              } as const,
+              annotations: { destructiveHint: true } as const,
             },
           }
         );
 
         await rerender({
-          schema: { type: 'object', properties: { value: { type: 'string' } } } as const,
+          inputSchema: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name'],
+          } as const,
+          outputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+          } as const,
+          annotations: { destructiveHint: true },
         });
 
-        expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('outputSchema reference changed')
-        );
-      } finally {
-        warnSpy.mockRestore();
-      }
-    });
-
-    it('should warn when annotations reference changes in dev mode', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-      try {
-        const { rerender } = await renderHook(
-          ({ annotations }) =>
-            useWebMCP({
-              name: 'dev_annot_warn_tool',
-              description: 'Test',
-              annotations,
-              handler: async () => 'result',
-            }),
-          { initialProps: { annotations: { destructiveHint: true as boolean } } }
-        );
-
-        await rerender({ annotations: { destructiveHint: true } });
-
-        expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('annotations reference changed')
-        );
+        expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('reference changed'));
       } finally {
         warnSpy.mockRestore();
       }

--- a/packages/usewebmcp/src/useWebMCP.ts
+++ b/packages/usewebmcp/src/useWebMCP.ts
@@ -219,21 +219,14 @@ function toRegisteredOutputSchema(
  *
  * This hook is optimized to minimize unnecessary tool re-registrations:
  *
- * - **Ref-based callbacks**: `execute`/`handler`, `onSuccess`, `onError`, and `formatOutput`
- *   are stored in refs, so changing these functions won't trigger re-registration.
+ * - **Ref-based static descriptors and callbacks**: `inputSchema`, `outputSchema`,
+ *   `annotations`, `execute`/`handler`, `onSuccess`, `onError`, and `formatOutput`
+ *   are stored in refs, so recreating them during render won't trigger re-registration.
  *
- * **IMPORTANT**: If `inputSchema`, `outputSchema`, or `annotations` are defined inline
- * or change on every render, the tool will re-register unnecessarily. To avoid this,
- * define them outside your component with `as const`:
+ * If a schema or annotation actually changes and the registered descriptor should change,
+ * include the relevant primitive value in the `deps` array.
  *
  * ```tsx
- * // Good: Static schema defined outside component
- * const OUTPUT_SCHEMA = {
- *   type: 'object',
- *   properties: { count: { type: 'number' } },
- * } as const;
- *
- * // Bad: Inline schema (creates new object every render)
  * useWebMCP({
  *   outputSchema: { type: 'object', properties: { count: { type: 'number' } } } as const,
  * });
@@ -318,22 +311,25 @@ export function useWebMCP<
   const onSuccessRef = useRef(onSuccess);
   const onErrorRef = useRef(onError);
   const formatOutputRef = useRef(formatOutput);
+  const inputSchemaRef = useRef(inputSchema);
+  const outputSchemaRef = useRef(outputSchema);
+  const annotationsRef = useRef(annotations);
   const isMountedRef = useRef(true);
   const warnedRef = useRef(new Set<string>());
   const prevConfigRef = useRef({
-    inputSchema,
-    outputSchema,
-    annotations,
     description,
     deps,
   });
-  // Update refs when callbacks change (doesn't trigger re-registration)
+  // Update refs when callbacks or static descriptors are recreated during render.
   useIsomorphicLayoutEffect(() => {
     toolExecuteRef.current = toolExecute;
     onSuccessRef.current = onSuccess;
     onErrorRef.current = onError;
     formatOutputRef.current = formatOutput;
-  }, [toolExecute, onSuccess, onError, formatOutput]);
+    inputSchemaRef.current = inputSchema;
+    outputSchemaRef.current = outputSchema;
+    annotationsRef.current = annotations;
+  }, [annotations, inputSchema, onSuccess, onError, outputSchema, toolExecute, formatOutput]);
 
   // Cleanup: mark component as unmounted
   useEffect(() => {
@@ -345,7 +341,7 @@ export function useWebMCP<
 
   useEffect(() => {
     if (!isDev()) {
-      prevConfigRef.current = { inputSchema, outputSchema, annotations, description, deps };
+      prevConfigRef.current = { description, deps };
       return;
     }
 
@@ -358,27 +354,6 @@ export function useWebMCP<
     };
 
     const prev = prevConfigRef.current;
-
-    if (inputSchema && prev.inputSchema && prev.inputSchema !== inputSchema) {
-      warnOnce(
-        'inputSchema',
-        `Tool "${name}" inputSchema reference changed; memoize or define it outside the component to avoid re-registration.`
-      );
-    }
-
-    if (outputSchema && prev.outputSchema && prev.outputSchema !== outputSchema) {
-      warnOnce(
-        'outputSchema',
-        `Tool "${name}" outputSchema reference changed; memoize or define it outside the component to avoid re-registration.`
-      );
-    }
-
-    if (annotations && prev.annotations && prev.annotations !== annotations) {
-      warnOnce(
-        'annotations',
-        `Tool "${name}" annotations reference changed; memoize or define it outside the component to avoid re-registration.`
-      );
-    }
 
     if (description !== prev.description) {
       warnOnce(
@@ -398,8 +373,8 @@ export function useWebMCP<
       );
     }
 
-    prevConfigRef.current = { inputSchema, outputSchema, annotations, description, deps };
-  }, [annotations, deps, description, inputSchema, name, outputSchema]);
+    prevConfigRef.current = { description, deps };
+  }, [deps, description, name]);
 
   /**
    * Executes the configured tool implementation with input validation and state management.
@@ -504,7 +479,7 @@ export function useWebMCP<
           ],
         };
 
-        if (isObjectOutputSchema(outputSchema)) {
+        if (isObjectOutputSchema(outputSchemaRef.current)) {
           const structuredContent = toStructuredContent(result);
           if (!structuredContent) {
             throw new Error(
@@ -531,14 +506,15 @@ export function useWebMCP<
     };
 
     const ownerToken = Symbol(name);
-    const resolvedInputSchema = toRegisteredInputSchema(inputSchema);
-    const resolvedOutputSchema = toRegisteredOutputSchema(outputSchema);
+    const resolvedInputSchema = toRegisteredInputSchema(inputSchemaRef.current);
+    const resolvedOutputSchema = toRegisteredOutputSchema(outputSchemaRef.current);
+    const resolvedAnnotations = annotationsRef.current;
     const toolDescriptor: ToolDescriptor = {
       name,
       description,
       ...(resolvedInputSchema && { inputSchema: resolvedInputSchema }),
       ...(resolvedOutputSchema && { outputSchema: resolvedOutputSchema }),
-      ...(annotations && { annotations }),
+      ...(resolvedAnnotations && { annotations: resolvedAnnotations }),
       execute: mcpHandler,
     };
 
@@ -558,7 +534,7 @@ export function useWebMCP<
     // via the `deps` parameter. While unconventional, this pattern is intentional to support
     // dynamic dependency injection. The spread is safe because deps is validated and warned
     // about non-primitive values earlier in this hook.
-  }, [name, description, inputSchema, outputSchema, annotations, ...(deps ?? [])]);
+  }, [name, description, ...(deps ?? [])]);
 
   return {
     state,


### PR DESCRIPTION
## Summary

This PR keeps the scope intentionally small: `useWebMCP` now stores static tool descriptor fields in refs so recreating inline objects during render does not re-register tools.

Changed fields:

- `inputSchema`
- `outputSchema`
- `annotations`

Existing callback refs are unchanged:

- `handler` / `execute`
- `onSuccess`
- `onError`
- `formatOutput`

`name` and `description` still re-register directly. If schema or annotation metadata is genuinely dynamic and the registered descriptor should change, pass a primitive through `deps`.

## Why

Consumers should not need `useMemo` around static schemas just to avoid registration churn:

```tsx
useWebMCP({
  name: 'get_sitemap',
  description: 'Read the sitemap',
  outputSchema: {
    type: 'object',
    properties: { count: { type: 'number' } },
  } as const,
  handler: async () => ({ count: 10 }),
});
```

Before this change, the inline `outputSchema` object changed reference every render and caused re-registration. Now the hook updates the ref during render and only re-registers when `name`, `description`, or explicit `deps` change.

For genuinely dynamic descriptor metadata:

```tsx
useWebMCP(
  {
    name: 'search_docs',
    description: 'Search docs',
    inputSchema: currentInputSchema,
    handler: searchDocs,
  },
  [schemaVersion]
);
```

## Notes

The earlier draft also included broader JSON Schema/Zod output work. That has been removed from this PR. Alignment with MCP TS SDK / WebMCP SDK schema behavior should happen separately.

The small `model-context.ts` typing adjustment avoids depending on ambient `Document['modelContext']` declarations during package typecheck; it does not change runtime behavior.

## Validation

- `pnpm exec vp check --fix packages/react-webmcp/src/model-context.ts packages/react-webmcp/src/useWebMCP.ts packages/react-webmcp/src/useWebMCP.test.ts packages/usewebmcp/src/model-context.ts packages/usewebmcp/src/useWebMCP.ts packages/usewebmcp/src/useWebMCP.test.ts`
- `pnpm --filter @mcp-b/react-webmcp exec tsc --noEmit`
- `pnpm --filter @mcp-b/react-webmcp exec tsc -p tsconfig.strict-null-checks-false.json --noEmit`
- `pnpm --filter usewebmcp exec tsc --noEmit`
- `pnpm --filter usewebmcp exec tsc -p tsconfig.strict-null-checks-false.json --noEmit`
- `git diff --check`
