### PR TITLE
fix(webmcp-polyfill): validate registerTool names per WebMCP §4.2

### DIFF
--- a/.changeset/polyfill-tool-name-validation.md
+++ b/.changeset/polyfill-tool-name-validation.md
@@ -1,0 +1,5 @@
+---
+'@mcp-b/webmcp-polyfill': patch
+---
+
+Validate `registerTool()` tool names per WebMCP §4.2 and throw `InvalidStateError` for invalid names and descriptions (fixes #224).

--- a/packages/webmcp-polyfill/src/index.test.ts
+++ b/packages/webmcp-polyfill/src/index.test.ts
@@ -19,6 +19,18 @@ function getCompatModelContext(): CompatModelContext {
   return navigator.modelContext as CompatModelContext;
 }
 
+function expectInvalidStateError(register: () => void, message?: string | RegExp): void {
+  try {
+    register();
+    expect.fail('Expected registerTool to throw InvalidStateError');
+  } catch (error) {
+    expect(error).toMatchObject({ name: 'InvalidStateError' });
+    if (message !== undefined) {
+      expect((error as Error).message).toEqual(expect.stringMatching(message));
+    }
+  }
+}
+
 describe('@mcp-b/webmcp-polyfill', () => {
   afterEach(() => {
     cleanupWebMCPPolyfill();
@@ -677,48 +689,146 @@ describe('@mcp-b/webmcp-polyfill', () => {
       ).toThrow('registerTool(tool) requires a tool object');
     });
 
-    it('throws when tool name is empty', () => {
+    it('throws InvalidStateError when tool name is empty', () => {
+      initializeWebMCPPolyfill();
+      expectInvalidStateError(
+        () =>
+          navigator.modelContext.registerTool({
+            name: '',
+            description: 'test',
+            execute: async () => ({ content: [] }),
+          }),
+        'Tool "name" must be a non-empty string'
+      );
+    });
+
+    it('throws InvalidStateError when tool name is not a string', () => {
+      initializeWebMCPPolyfill();
+      expectInvalidStateError(
+        () =>
+          navigator.modelContext.registerTool({
+            name: 42 as unknown as string,
+            description: 'test',
+            execute: async () => ({ content: [] }),
+          }),
+        'Tool "name" must be a non-empty string'
+      );
+    });
+
+    it('throws InvalidStateError when tool description is empty', () => {
+      initializeWebMCPPolyfill();
+      expectInvalidStateError(
+        () =>
+          navigator.modelContext.registerTool({
+            name: 'test',
+            description: '',
+            execute: async () => ({ content: [] }),
+          }),
+        'Tool "description" must be a non-empty string'
+      );
+    });
+
+    it('throws InvalidStateError when tool description is not a string', () => {
+      initializeWebMCPPolyfill();
+      expectInvalidStateError(
+        () =>
+          navigator.modelContext.registerTool({
+            name: 'test',
+            description: 123 as unknown as string,
+            execute: async () => ({ content: [] }),
+          }),
+        'Tool "description" must be a non-empty string'
+      );
+    });
+
+    const invalidToolNameMessage =
+      /Tool "name" must be 1–128 characters and contain only ASCII alphanumeric, underscore, hyphen, or period/;
+
+    it('throws InvalidStateError for tool name with zero-width space', () => {
+      initializeWebMCPPolyfill();
+      expectInvalidStateError(
+        () =>
+          navigator.modelContext.registerTool({
+            name: 'tool\u200Bname',
+            description: 'test',
+            execute: async () => ({ content: [] }),
+          }),
+        invalidToolNameMessage
+      );
+    });
+
+    it('throws InvalidStateError for tool name with cyrillic homoglyph', () => {
+      initializeWebMCPPolyfill();
+      expectInvalidStateError(
+        () =>
+          navigator.modelContext.registerTool({
+            name: 't\u043Eo\u043Bl',
+            description: 'test',
+            execute: async () => ({ content: [] }),
+          }),
+        invalidToolNameMessage
+      );
+    });
+
+    it('throws InvalidStateError for tool name with ASCII space', () => {
+      initializeWebMCPPolyfill();
+      expectInvalidStateError(
+        () =>
+          navigator.modelContext.registerTool({
+            name: 'tool name',
+            description: 'test',
+            execute: async () => ({ content: [] }),
+          }),
+        invalidToolNameMessage
+      );
+    });
+
+    it('throws InvalidStateError for tool name with colon', () => {
+      initializeWebMCPPolyfill();
+      expectInvalidStateError(
+        () =>
+          navigator.modelContext.registerTool({
+            name: 'tool:name',
+            description: 'test',
+            execute: async () => ({ content: [] }),
+          }),
+        invalidToolNameMessage
+      );
+    });
+
+    it('throws InvalidStateError for tool name longer than 128 characters', () => {
+      initializeWebMCPPolyfill();
+      expectInvalidStateError(
+        () =>
+          navigator.modelContext.registerTool({
+            name: 'a'.repeat(129),
+            description: 'test',
+            execute: async () => ({ content: [] }),
+          }),
+        invalidToolNameMessage
+      );
+    });
+
+    it('accepts tool name with underscore, period, and hyphen', () => {
       initializeWebMCPPolyfill();
       expect(() =>
         navigator.modelContext.registerTool({
-          name: '',
+          name: 'a._-b',
           description: 'test',
           execute: async () => ({ content: [] }),
         })
-      ).toThrow('Tool "name" must be a non-empty string');
+      ).not.toThrow();
     });
 
-    it('throws when tool name is not a string', () => {
+    it('accepts tool name with exactly 128 characters', () => {
       initializeWebMCPPolyfill();
       expect(() =>
         navigator.modelContext.registerTool({
-          name: 42 as unknown as string,
+          name: 'a'.repeat(128),
           description: 'test',
           execute: async () => ({ content: [] }),
         })
-      ).toThrow('Tool "name" must be a non-empty string');
-    });
-
-    it('throws when tool description is empty', () => {
-      initializeWebMCPPolyfill();
-      expect(() =>
-        navigator.modelContext.registerTool({
-          name: 'test',
-          description: '',
-          execute: async () => ({ content: [] }),
-        })
-      ).toThrow('Tool "description" must be a non-empty string');
-    });
-
-    it('throws when tool description is not a string', () => {
-      initializeWebMCPPolyfill();
-      expect(() =>
-        navigator.modelContext.registerTool({
-          name: 'test',
-          description: 123 as unknown as string,
-          execute: async () => ({ content: [] }),
-        })
-      ).toThrow('Tool "description" must be a non-empty string');
+      ).not.toThrow();
     });
 
     it('throws when tool execute is not a function', () => {

--- a/packages/webmcp-polyfill/src/index.ts
+++ b/packages/webmcp-polyfill/src/index.ts
@@ -21,6 +21,8 @@ const TOOL_INVOCATION_FAILED_MESSAGE =
 const TOOL_CANCELLED_MESSAGE = 'Tool was cancelled';
 const DEFAULT_INPUT_SCHEMA: InputSchema = { type: 'object', properties: {} };
 const STANDARD_JSON_SCHEMA_TARGETS = ['draft-2020-12', 'draft-07'] as const;
+/** WebMCP §4.2 tool name: ASCII alnum, underscore, hyphen, period; 1–128 code points. */
+const VALID_TOOL_NAME_RE = /^[A-Za-z0-9_\-.]{1,128}$/u;
 
 const POLYFILL_MARKER_PROPERTY = '__isWebMCPPolyfill' as const;
 const STANDARD_VALIDATOR_SYMBOL = Symbol('standardValidator');
@@ -381,6 +383,16 @@ function createUnknownError(message: string): Error {
   }
 }
 
+function createInvalidStateError(message: string): DOMException | Error {
+  try {
+    return new DOMException(message, 'InvalidStateError');
+  } catch {
+    const error = new Error(message);
+    error.name = 'InvalidStateError';
+    return error;
+  }
+}
+
 function parseInputArgsJson(inputArgsJson: string): Record<string, unknown> {
   let parsed: unknown;
 
@@ -634,11 +646,17 @@ function normalizeToolDescriptor(
   }
 
   if (typeof tool.name !== 'string' || tool.name.length === 0) {
-    throw new TypeError('Tool "name" must be a non-empty string');
+    throw createInvalidStateError('Tool "name" must be a non-empty string');
+  }
+
+  if (!VALID_TOOL_NAME_RE.test(tool.name) || Array.from(tool.name).length > 128) {
+    throw createInvalidStateError(
+      'Tool "name" must be 1–128 characters and contain only ASCII alphanumeric, underscore, hyphen, or period'
+    );
   }
 
   if (typeof tool.description !== 'string' || tool.description.length === 0) {
-    throw new TypeError('Tool "description" must be a non-empty string');
+    throw createInvalidStateError('Tool "description" must be a non-empty string');
   }
 
   if (typeof tool.execute !== 'function') {


### PR DESCRIPTION
## Summary

- Validate registerTool tool names per WebMCP §4.2 (ASCII alnum, underscore, hyphen, period; 1–128 code points).
- Throw InvalidStateError for invalid or empty names and descriptions to match native modelContext.
- Add unit tests for invalid codepoints, length limits, and valid edge cases.

Closes #224

## Test plan

- [x] pnpm test in packages/webmcp-polyfill
- [x] pnpm typecheck and pnpm check in packages/webmcp-polyfill
- [ ] CI green on PR