### PR TITLE
Fix smart-dom-reader package exports

### DIFF
--- a/.changeset/smart-dom-reader-package-exports.md
+++ b/.changeset/smart-dom-reader-package-exports.md
@@ -1,0 +1,5 @@
+---
+'@mcp-b/smart-dom-reader': patch
+---
+
+Fix package exports to reference the emitted `.mjs` and `.d.mts` files.

--- a/packages/smart-dom-reader/package.json
+++ b/packages/smart-dom-reader/package.json
@@ -47,18 +47,18 @@
   ],
   "type": "module",
   "sideEffects": true,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "browser": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "browser": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
     },
     "./bundle-string": {
-      "types": "./dist/bundle-string.d.ts",
-      "import": "./dist/bundle-string.js"
+      "types": "./dist/bundle-string.d.mts",
+      "import": "./dist/bundle-string.mjs"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary

Fixes `@mcp-b/smart-dom-reader` package metadata so its exports point to the files emitted by the current build.

The package currently publishes `.mjs` / `.d.mts` files, but `package.json` points to `.js` / `.d.ts` files that are not included in the tarball.

Fixes #232.

## Testing

- `pnpm --filter @mcp-b/smart-dom-reader build`
- `pnpm --filter @mcp-b/extension-tools build`
- `pnpm --filter @mcp-b/extension-tools typecheck`
- Packed `@mcp-b/smart-dom-reader`, installed it into a clean consumer, and verified both exports import successfully