### PR TITLE
Guard chrome-devtools MCP package publishing

### DIFF
--- a/packages/chrome-devtools-mcp/package.json
+++ b/packages/chrome-devtools-mcp/package.json
@@ -40,6 +40,7 @@
     "format": "eslint --cache --fix . && prettier --write --cache .",
     "gen": "npm run build && npm run docs:generate && npm run cli:generate && npm run format",
     "prepare": "node --experimental-strip-types scripts/prepare.ts",
+    "prepublishOnly": "npm run prepare && npm run bundle && npm run verify-npm-package",
     "start": "npm run build && node build/src/index.js",
     "start-debug": "DEBUG=mcp:* DEBUG_COLORS=false npm run build && node build/src/index.js",
     "test": "npm run build && node scripts/test.mjs",

--- a/packages/chrome-devtools-mcp/scripts/verify-npm-package.mjs
+++ b/packages/chrome-devtools-mcp/scripts/verify-npm-package.mjs
@@ -4,29 +4,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { execSync } from 'node:child_process';
+import {execSync} from 'node:child_process';
 
-// Checks that the select build files are present using `npm publish --dry-run`.
+// Checks that the selected build files are present using `npm pack --dry-run`.
 function verifyPackageContents() {
   try {
-    const output = execSync('npm publish --dry-run --json --silent', {
-      encoding: 'utf8',
-    });
-    // skip non-JSON output from prepare.
-    const data = JSON.parse(output.substring(output.indexOf('{')));
-    const files = data.files.map((f) => f.path);
+    const output = execSync(
+      'npm pack --dry-run --json --silent --ignore-scripts',
+      {
+        encoding: 'utf8',
+      },
+    );
+    const data = JSON.parse(output.substring(output.indexOf('[')))[0];
+    const files = data.files.map(f => f.path);
     // Check some important files.
-    const requiredPaths = ['build/src/index.js', 'build/src/third_party/index.js'];
+    const requiredPaths = [
+      'build/src/bin/chrome-devtools.js',
+      'build/src/bin/chrome-devtools-mcp.js',
+      'build/src/index.js',
+      'build/src/third_party/index.js',
+    ];
     for (const requiredPath of requiredPaths) {
-      const hasBuildFolder = files.some((path) => path.startsWith(requiredPath));
-      if (!hasBuildFolder) {
-        console.error(`Assertion Failed: "${requiredPath}" not found in tarball.`);
+      if (!files.includes(requiredPath)) {
+        console.error(
+          `Assertion Failed: "${requiredPath}" not found in tarball.`,
+        );
         process.exit(1);
       }
     }
-    console.log(`npm publish --dry-run contained ${JSON.stringify(requiredPaths)}`);
+    console.log(
+      `npm pack --dry-run contained ${JSON.stringify(requiredPaths)}`,
+    );
   } catch (err) {
-    console.error('failed to parse npm publish output', err);
+    console.error('failed to parse npm pack output', err);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- Add a `prepublishOnly` gate for `@mcp-b/chrome-devtools-mcp` that runs `prepare`, `bundle`, and `verify-npm-package` before publish.
- Switch the verifier to `npm pack --dry-run --json --silent --ignore-scripts`, so tarball checks focus on package contents and avoid publish-version conflicts.
- Require the two bin entrypoints plus `build/src/index.js` and `build/src/third_party/index.js` as exact tarball paths.

## Why
The current npm `@mcp-b/chrome-devtools-mcp@3.0.0` tarball contains only `LICENSE`, `README.md`, and `package.json`. The repo root build script also excludes this package, so publish can proceed without a generated `build/src` tree. This guard makes publish stop when bundle generation or tarball contents are incomplete.

Related to #209.

## Validation
- `npm pack @mcp-b/chrome-devtools-mcp@3.0.0 --silent` and tarball inspection: published package contains only metadata files.
- `npm run verify-npm-package`: fails with `Assertion Failed: "build/src/bin/chrome-devtools.js" not found in tarball.` on a tree without build output.
- Temporary four-file build fixture: `npm run verify-npm-package` passes and reports all required paths.
- `./packages/chrome-devtools-mcp/node_modules/.bin/prettier --check packages/chrome-devtools-mcp/package.json packages/chrome-devtools-mcp/scripts/verify-npm-package.mjs`: passes.
- `npm run prepare`: passes.
- `npm run bundle`: currently fails on upstream main TypeScript errors for missing source/generated modules and implicit `any` parameters; the new publish gate surfaces that failure before publish.
