### PR TITLE
fix(webmcp-local-relay): consolidate relay triage fixes

### DIFF
--- a/.changeset/local-relay-reconnect-payload-sync.md
+++ b/.changeset/local-relay-reconnect-payload-sync.md
@@ -1,0 +1,5 @@
+---
+'@mcp-b/webmcp-local-relay': minor
+---
+
+Reduce local relay reconnection churn, add a reconciler for browser tool-list changes, and expose `--max-payload` with a larger default WebSocket payload limit.

--- a/e2e/web-standards-showcase/public/relay/embed.js
+++ b/e2e/web-standards-showcase/public/relay/embed.js
@@ -1,403 +1,363 @@
-/**
- * Injects a hidden relay widget iframe and bridges widget messages to host tools.
- *
- * Usage:
- * `<script src=".../embed.js" data-relay-host="127.0.0.1" data-relay-port="9333"></script>`
- *
- * @typedef {{ [key: string]: unknown }} JsonObject
- * @typedef {{ name: string; description?: string; inputSchema?: JsonObject }} ToolDescriptor
- * @typedef {{ isError?: boolean; content?: Array<{ type: string; text: string }>; [key: string]: unknown }} ToolInvokeResult
- * @typedef {{ listTools: () => ToolDescriptor[] | Promise<ToolDescriptor[]>; invoke: (name: string, args: JsonObject) => ToolInvokeResult | Promise<ToolInvokeResult> }} ToolBridge
- * @typedef {{ requestId: string; type: string; toolName?: unknown; args?: unknown }} WidgetRequestMessage
- * @typedef {{ relayHost: string; relayPort: string; tabId: string; widgetUrl: string; widgetOrigin: string }} RelayConfig
- */
-(function initializeWebMcpRelayEmbed() {
-  const RELAY_IFRAME_SELECTOR = '[data-webmcp-relay]';
-  const TAB_ID_STORAGE_KEY = '__webmcp_relay_tab_id';
-  const FALLBACK_WIDGET_URL =
-    'https://cdn.jsdelivr.net/npm/@mcp-b/webmcp-local-relay/dist/browser/widget.html';
-
-  /** @type {Window | null} */
-  var widgetWindow = null;
-
-  /**
-   * @returns {HTMLScriptElement | null}
-   */
-  function getCurrentScriptElement() {
+/* eslint-disable */
+(function () {
+  function e(e) {
+    return !!e && typeof e == `object` && !Array.isArray(e);
+  }
+  let t = `[data-webmcp-relay]`,
+    n = `__webmcp_relay_tab_id`,
+    r = null,
+    i;
+  function a() {
     return document.currentScript instanceof HTMLScriptElement ? document.currentScript : null;
   }
-
-  /**
-   * @param {unknown} value
-   * @returns {value is JsonObject}
-   */
-  function isJsonObject(value) {
-    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+  let o = a(),
+    s = o ? o.hasAttribute(`data-debug`) : !1;
+  function c(...e) {
+    s && console.warn(`[webmcp-relay-embed]`, ...e);
   }
-
-  /**
-   * @returns {string}
-   */
-  function createTabId() {
-    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-      return crypto.randomUUID();
-    }
-    return `${String(Date.now())}_${String(Math.random()).slice(2, 10)}`;
+  function l() {
+    return typeof crypto < `u` && typeof crypto.randomUUID == `function`
+      ? crypto.randomUUID()
+      : `${String(Date.now())}_${String(Math.random()).slice(2, 10)}`;
   }
-
-  /**
-   * @returns {string}
-   */
-  function readOrCreateTabId() {
+  function u() {
     try {
-      const storedTabId = sessionStorage.getItem(TAB_ID_STORAGE_KEY);
-      if (storedTabId) {
-        return storedTabId;
-      }
-    } catch (err) {
-      console.warn(
-        '[webmcp-relay-embed] sessionStorage read failed, tab ID will not persist:',
-        err
-      );
+      let e = sessionStorage.getItem(n);
+      if (e) return e;
+    } catch (e) {
+      c(`sessionStorage read failed, tab ID will not persist:`, e);
     }
-
-    const tabId = createTabId();
+    let e = l();
     try {
-      sessionStorage.setItem(TAB_ID_STORAGE_KEY, tabId);
-    } catch (err) {
-      console.warn('[webmcp-relay-embed] sessionStorage write failed:', err);
+      sessionStorage.setItem(n, e);
+    } catch (e) {
+      c(`sessionStorage write failed:`, e);
     }
-
-    return tabId;
+    return e;
   }
-
-  /**
-   * @param {HTMLScriptElement | null} script
-   * @returns {string}
-   */
-  function resolveWidgetUrl(script) {
-    if (script?.src) {
+  function d(e) {
+    if (e?.src)
       try {
-        return new URL('widget.html', script.src).href;
-      } catch (err) {
-        console.warn(
-          '[webmcp-relay-embed] Failed to resolve widget URL from script src, falling back to CDN:',
-          err
-        );
-      }
-    }
-    return FALLBACK_WIDGET_URL;
-  }
-
-  /**
-   * @param {HTMLScriptElement | null} script
-   * @returns {RelayConfig}
-   */
-  function buildRelayConfig(script) {
-    const widgetUrl = resolveWidgetUrl(script);
-    return {
-      relayHost: script?.getAttribute('data-relay-host') || '127.0.0.1',
-      relayPort: script?.getAttribute('data-relay-port') || '9333',
-      tabId: readOrCreateTabId(),
-      widgetUrl,
-      widgetOrigin: new URL(widgetUrl).origin,
-    };
-  }
-
-  /**
-   * @param {unknown} rawSchema
-   * @returns {JsonObject}
-   */
-  function parseTestingSchema(rawSchema) {
-    if (typeof rawSchema !== 'string' || rawSchema.length === 0) {
-      return { type: 'object', properties: {} };
-    }
-    try {
-      const parsed = JSON.parse(rawSchema);
-      return isJsonObject(parsed) ? parsed : { type: 'object', properties: {} };
-    } catch (err) {
-      console.warn(
-        '[webmcp-relay-embed] Failed to parse tool inputSchema, using permissive default:',
-        err
-      );
-      return { type: 'object', properties: {} };
-    }
-  }
-
-  /**
-   * @param {unknown} value
-   * @returns {JsonObject}
-   */
-  function toInvokeArgs(value) {
-    return isJsonObject(value) ? value : {};
-  }
-
-  /**
-   * @returns {ToolBridge | null}
-   */
-  function getToolBridge() {
-    const modelContext = navigator.modelContext;
-    if (
-      modelContext &&
-      typeof modelContext.listTools === 'function' &&
-      typeof modelContext.callTool === 'function'
-    ) {
-      return {
-        listTools() {
-          return modelContext.listTools().map((tool) => ({
-            name: tool.name,
-            description: tool.description,
-            inputSchema: isJsonObject(tool.inputSchema)
-              ? tool.inputSchema
-              : { type: 'object', properties: {} },
-          }));
-        },
-        invoke(name, args) {
-          return modelContext.callTool({ name, arguments: args });
-        },
-      };
-    }
-
-    const testing = navigator.modelContextTesting;
-    if (
-      testing &&
-      typeof testing.listTools === 'function' &&
-      typeof testing.executeTool === 'function'
-    ) {
-      return {
-        listTools() {
-          return testing.listTools().map((tool) => ({
-            name: tool.name,
-            description: tool.description,
-            inputSchema: parseTestingSchema(tool.inputSchema),
-          }));
-        },
-        async invoke(name, args) {
-          const serialized = await testing.executeTool(name, JSON.stringify(args));
-          if (serialized === null) {
-            return {
-              isError: true,
-              content: [{ type: 'text', text: 'Tool execution interrupted by navigation' }],
-            };
-          }
-          const parsed = JSON.parse(serialized);
-          if (!isJsonObject(parsed)) {
-            throw new Error('Testing tool response was not an object');
-          }
-          return parsed;
-        },
-      };
-    }
-
-    return null;
-  }
-
-  var pushScheduled = false;
-
-  /**
-   * Coalesced handler for tool change events.
-   * Uses flag + setTimeout(0) to batch rapid registrations into a single push.
-   */
-  function onToolsChanged() {
-    if (pushScheduled || !widgetWindow) return;
-    pushScheduled = true;
-    setTimeout(function pushToolsChangedToWidget() {
-      pushScheduled = false;
-      if (!widgetWindow) return;
-      var bridge = getToolBridge();
-      var toolsPromise = bridge ? Promise.resolve(bridge.listTools()) : Promise.resolve([]);
-      toolsPromise
-        .then((tools) => {
-          if (!widgetWindow) return;
-          widgetWindow.postMessage(
-            {
-              type: 'webmcp.tools.changed',
-              tools: Array.isArray(tools) ? tools : [],
-            },
-            config.widgetOrigin
-          );
-        })
-        .catch((err) => {
-          console.warn('[webmcp-relay-embed] Failed to push tool changes:', err);
-        });
-    }, 0);
-  }
-
-  /**
-   * Subscribes to tool change events.
-   * Uses the testing API's toolchange event (EventTarget) which is supported
-   * by both native Chromium and the polyfill.
-   */
-  function subscribeToToolChanges() {
-    var testing = navigator.modelContextTesting;
-    if (testing && typeof testing.addEventListener === 'function') {
-      try {
-        testing.addEventListener('toolchange', onToolsChanged);
-        return;
+        return new URL(`widget.html`, e.src).href;
       } catch (e) {
-        console.warn('[webmcp-relay-embed] Failed to subscribe via addEventListener:', e);
+        c(`Failed to resolve widget URL from script src, falling back to CDN:`, e);
       }
-    }
-    console.warn(
-      '[webmcp-relay-embed] Could not subscribe to tool changes. Dynamic tool updates will not be relayed.'
-    );
+    else c(`Script element has no src attribute, falling back to CDN widget URL.`);
+    return `https://cdn.jsdelivr.net/npm/@mcp-b/webmcp-local-relay/dist/browser/widget.html`;
   }
-
-  /**
-   * @param {MessageEventSource | null} source
-   * @param {string} origin
-   * @param {JsonObject} payload
-   */
-  function respondToSource(source, origin, payload) {
-    if (!source || typeof source !== 'object' || !('postMessage' in source)) {
-      return;
-    }
-
-    const postMessage = source.postMessage;
-    if (typeof postMessage !== 'function') {
-      return;
-    }
-
-    postMessage.call(source, payload, origin);
-  }
-
-  /**
-   * @param {unknown} value
-   * @returns {WidgetRequestMessage | null}
-   */
-  function parseWidgetRequest(value) {
-    if (
-      !isJsonObject(value) ||
-      typeof value.requestId !== 'string' ||
-      typeof value.type !== 'string'
-    ) {
-      return null;
-    }
-
+  function f(e) {
+    let t = d(e),
+      n = e?.getAttribute(`data-relay-id`) || void 0,
+      r = e?.getAttribute(`data-relay-workspace`) || void 0,
+      i = e?.getAttribute(`data-request-timeout`) || void 0;
     return {
-      requestId: value.requestId,
-      type: value.type,
-      toolName: value.toolName,
-      args: value.args,
+      autoConnect: e?.getAttribute(`data-auto-connect`) !== `false`,
+      relayHost: e?.getAttribute(`data-relay-host`) || `127.0.0.1`,
+      relayPort: e?.getAttribute(`data-relay-port`) || `9333`,
+      ...(n ? { relayId: n } : {}),
+      ...(r ? { relayWorkspace: r } : {}),
+      ...(i ? { requestTimeout: i } : {}),
+      tabId: u(),
+      widgetUrl: t,
+      widgetOrigin: new URL(t).origin,
     };
   }
-
-  /**
-   * @param {WidgetRequestMessage} request
-   * @param {MessageEvent} event
-   */
-  function handleListRequest(request, event) {
-    const bridge = getToolBridge();
-    const toolsPromise = bridge ? Promise.resolve(bridge.listTools()) : Promise.resolve([]);
-
-    toolsPromise
-      .then((tools) => {
-        respondToSource(event.source, event.origin, {
-          type: 'webmcp.tools.list.response',
-          requestId: request.requestId,
-          tools: Array.isArray(tools) ? tools : [],
+  function p(t) {
+    if (typeof t != `string` || t.length === 0) return { type: `object`, properties: {} };
+    try {
+      let n = JSON.parse(t);
+      return e(n) ? n : { type: `object`, properties: {} };
+    } catch (e) {
+      return (
+        c(`Tool inputSchema is not valid JSON:`, typeof t == `string` ? t.slice(0, 200) : t, e),
+        { type: `object`, properties: {} }
+      );
+    }
+  }
+  function m(t) {
+    return e(t) ? t : (t != null && c(`Tool invocation args must be an object, got`, typeof t), {});
+  }
+  function h(e) {
+    return { name: e.name, description: e.description, inputSchema: e.inputSchema };
+  }
+  function g(e) {
+    return { name: e.name, description: e.description, inputSchema: p(e.inputSchema) };
+  }
+  function _() {
+    let e = navigator.modelContext;
+    if (e && typeof e.listTools == `function` && typeof e.callTool == `function`) return e;
+  }
+  function v() {
+    let t = _();
+    if (t)
+      return {
+        listTools() {
+          return t.listTools().map(h);
+        },
+        invoke(e, n) {
+          return t.callTool({ name: e, arguments: n });
+        },
+      };
+    let n = navigator.modelContextTesting;
+    return n && typeof n.listTools == `function` && typeof n.executeTool == `function`
+      ? {
+          listTools() {
+            return n.listTools().map(g);
+          },
+          async invoke(t, r) {
+            let i = await n.executeTool(t, JSON.stringify(r));
+            if (i === null)
+              return {
+                isError: !0,
+                content: [{ type: `text`, text: `Tool execution interrupted by navigation` }],
+              };
+            let a;
+            try {
+              a = JSON.parse(i);
+            } catch {
+              throw Error(`Testing tool returned invalid JSON: ${String(i).slice(0, 200)}`);
+            }
+            if (!e(a)) throw Error(`Testing tool response was not an object`);
+            return a;
+          },
+        }
+      : (c(`No WebMCP runtime found (navigator.modelContext or navigator.modelContextTesting).`),
+        null);
+  }
+  let y = !1;
+  function b() {
+    y ||
+      !r ||
+      ((y = !0),
+      setTimeout(() => {
+        if (((y = !1), !r)) return;
+        let e = v();
+        (e ? Promise.resolve(e.listTools()) : Promise.resolve([]))
+          .then((e) => {
+            r &&
+              r.postMessage(
+                { type: `webmcp.tools.changed`, tools: Array.isArray(e) ? e : [] },
+                i.widgetOrigin
+              );
+          })
+          .catch((e) => {
+            c(`Failed to push tool changes:`, e);
+          });
+      }, 0));
+  }
+  function x() {
+    let e = _();
+    if (e)
+      try {
+        return (e.addEventListener(`toolchange`, b), !0);
+      } catch (e) {
+        c(`addEventListener threw:`, e);
+      }
+    let t = navigator.modelContextTesting;
+    if (t && typeof t.registerToolsChangedCallback == `function`)
+      try {
+        return (t.registerToolsChangedCallback(b), !0);
+      } catch (e) {
+        c(`Failed to subscribe via registerToolsChangedCallback:`, e);
+      }
+    return !1;
+  }
+  function S() {
+    if (x()) return;
+    let e = 0,
+      t = 100,
+      n = () => {
+        setTimeout(() => {
+          if ((e++, !x())) {
+            if (e >= 40) {
+              c(
+                `Could not subscribe to tool changes after 40 retries. Dynamic tool updates will not be relayed.`
+              );
+              return;
+            }
+            ((t = Math.min(Math.round(t * 1.5), 1e3)), n());
+          }
+        }, t);
+      };
+    n();
+  }
+  function C(e, t, n) {
+    !e || typeof e != `object` || !(`postMessage` in e) || e.postMessage(n, t);
+  }
+  function w(t) {
+    return !e(t) || typeof t.requestId != `string` || typeof t.type != `string`
+      ? null
+      : { requestId: t.requestId, type: t.type, toolName: t.toolName, args: t.args };
+  }
+  function T(e, t) {
+    let n = v();
+    (n ? Promise.resolve(n.listTools()) : Promise.resolve([]))
+      .then((n) => {
+        C(t.source, t.origin, {
+          type: `webmcp.tools.list.response`,
+          requestId: e.requestId,
+          tools: Array.isArray(n) ? n : [],
         });
       })
-      .catch((error) => {
-        console.warn('[webmcp-relay-embed] Failed to list tools:', error);
-        respondToSource(event.source, event.origin, {
-          type: 'webmcp.tools.list.response',
-          requestId: request.requestId,
-          tools: [],
-        });
+      .catch((n) => {
+        (c(`Failed to list tools:`, n),
+          C(t.source, t.origin, {
+            type: `webmcp.tools.list.response`,
+            requestId: e.requestId,
+            tools: [],
+            error: `Failed to list tools: ${n instanceof Error ? n.message : String(n)}`,
+          }));
       });
   }
-
-  /**
-   * @param {WidgetRequestMessage} request
-   * @param {MessageEvent} event
-   */
-  function handleInvokeRequest(request, event) {
-    const bridge = getToolBridge();
-    if (!bridge) {
-      respondToSource(event.source, event.origin, {
-        type: 'webmcp.tools.invoke.error',
-        requestId: request.requestId,
-        error: 'No WebMCP runtime found on this page',
+  let E = !1;
+  function D(t, n) {
+    if (E) return;
+    let r = _();
+    if (!r || typeof r.elicitInput != `function`) {
+      c(`Elicitation bridge not installed: elicitInput not available on modelContext`);
+      return;
+    }
+    ((r.elicitInput = (r, i) => {
+      let a = k();
+      return new Promise((i) => {
+        let o = () => {
+            (window.removeEventListener(`message`, l), clearTimeout(s));
+          },
+          s = setTimeout(() => {
+            (o(),
+              c(`Elicitation request timed out after 60s`),
+              i({ action: `decline`, content: null }));
+          }, 6e4),
+          l = (t) => {
+            if (t.origin !== n) return;
+            let r = t.data;
+            !e(r) ||
+              r.type !== `webmcp.elicitation.response` ||
+              r.callId !== a ||
+              (o(), i(e(r.result) ? r.result : { action: `decline`, content: null }));
+          };
+        (window.addEventListener(`message`, l),
+          t.postMessage({ type: `webmcp.elicitation.request`, callId: a, params: r }, n));
+      });
+    }),
+      (E = !0),
+      c(`Elicitation bridge installed`));
+  }
+  let O = 0;
+  function k() {
+    return ((O += 1), `elicit_${String(Date.now())}_${String(O)}`);
+  }
+  function A(t, n) {
+    let r = v();
+    if (!r) {
+      C(n.source, n.origin, {
+        type: `webmcp.tools.invoke.error`,
+        requestId: t.requestId,
+        error: `No WebMCP runtime found on this page`,
       });
       return;
     }
-
-    Promise.resolve(bridge.invoke(String(request.toolName ?? ''), toInvokeArgs(request.args)))
-      .then((result) => {
-        respondToSource(event.source, event.origin, {
-          type: 'webmcp.tools.invoke.response',
-          requestId: request.requestId,
-          result: isJsonObject(result) ? result : {},
-        });
-      })
-      .catch((error) => {
-        respondToSource(event.source, event.origin, {
-          type: 'webmcp.tools.invoke.error',
-          requestId: request.requestId,
-          error: String(error instanceof Error ? error.message : error),
-        });
-      });
+    (n.source && D(n.source, n.origin),
+      Promise.resolve(r.invoke(String(t.toolName ?? ``), m(t.args)))
+        .then((r) => {
+          C(n.source, n.origin, {
+            type: `webmcp.tools.invoke.response`,
+            requestId: t.requestId,
+            result: e(r) ? r : {},
+          });
+        })
+        .catch((e) => {
+          C(n.source, n.origin, {
+            type: `webmcp.tools.invoke.error`,
+            requestId: t.requestId,
+            error: String(e instanceof Error ? e.message : e),
+          });
+        }));
   }
-
-  /**
-   * @param {RelayConfig} config
-   */
-  function injectRelayWidget(config) {
-    if (document.querySelector(RELAY_IFRAME_SELECTOR)) {
-      return;
+  async function j(e) {
+    if (document.querySelector(t)) return;
+    let n = new URLSearchParams();
+    (n.set(`tabId`, e.tabId), n.set(`hostOrigin`, window.location.origin));
+    let a = new URL(window.location.href);
+    ((a.search = ``),
+      (a.hash = ``),
+      n.set(`hostUrl`, a.href),
+      n.set(`hostTitle`, document.title || ``),
+      n.set(`relayHost`, e.relayHost),
+      n.set(`relayPort`, e.relayPort),
+      n.set(`autoConnect`, e.autoConnect ? `true` : `false`),
+      e.relayId && n.set(`relayId`, e.relayId),
+      e.relayWorkspace && n.set(`relayWorkspace`, e.relayWorkspace),
+      e.requestTimeout && n.set(`requestTimeout`, e.requestTimeout));
+    let o = null;
+    try {
+      let t = await fetch(e.widgetUrl);
+      if (!t.ok)
+        console.warn(
+          `[webmcp-relay-embed] Widget HTML fetch returned ${String(t.status)}; falling back to direct iframe src.`
+        );
+      else if (t.ok) {
+        let e = await t.text(),
+          r = `<script>window.__WEBMCP_RELAY_CONFIG=${JSON.stringify(Object.fromEntries(n))};</script>`,
+          a = new Blob([e.replace(`</head>`, `${r}</head>`)], { type: `text/html` });
+        ((o = URL.createObjectURL(a)), (i.widgetOrigin = window.location.origin));
+      }
+    } catch (e) {
+      c(`Failed to fetch widget HTML for blob URL:`, e);
     }
-
-    const searchParams = new URLSearchParams();
-    searchParams.set('tabId', config.tabId);
-    searchParams.set('hostOrigin', window.location.origin);
-    searchParams.set('hostUrl', window.location.href);
-    searchParams.set('hostTitle', document.title || '');
-    searchParams.set('relayHost', config.relayHost);
-    searchParams.set('relayPort', config.relayPort);
-
-    const iframe = document.createElement('iframe');
-    iframe.src = `${config.widgetUrl}?${searchParams.toString()}`;
-    iframe.style.display = 'none';
-    iframe.setAttribute('aria-hidden', 'true');
-    iframe.setAttribute('data-webmcp-relay', '1');
-    document.body.appendChild(iframe);
-    iframe.addEventListener('load', () => {
-      widgetWindow = iframe.contentWindow;
+    let s = document.createElement(`iframe`);
+    ((s.src = o ?? `${e.widgetUrl}?${n.toString()}`),
+      (s.style.display = `none`),
+      s.setAttribute(`aria-hidden`, `true`),
+      s.setAttribute(`data-webmcp-relay`, `1`),
+      s.setAttribute(`allow`, `loopback-network; local-network; local-network-access`),
+      document.body.appendChild(s),
+      (r = s.contentWindow),
+      s.addEventListener(`load`, () => {
+        ((r = s.contentWindow), o && URL.revokeObjectURL(o));
+      }),
+      s.addEventListener(`error`, () => {
+        (console.error(
+          `[webmcp-relay-embed] Failed to load relay widget iframe from:`,
+          s.src,
+          `-- WebMCP tools will NOT be relayed. Check network connectivity and widget URL.`
+        ),
+          o && URL.revokeObjectURL(o));
+      }));
+  }
+  if (!document.querySelector(t)) {
+    try {
+      i = f(o);
+    } catch (e) {
+      throw (console.error(`[webmcp-relay-embed] Failed to initialize relay configuration:`, e), e);
+    }
+    window.addEventListener(`message`, (t) => {
+      if (t.origin !== i.widgetOrigin || !r || t.source !== r) return;
+      let n = t.data;
+      if (e(n) && n.type === `webmcp.reload`) {
+        window.location.reload();
+        return;
+      }
+      let a = w(t.data);
+      if (a) {
+        if (a.type === `webmcp.tools.list.request`) {
+          T(a, t);
+          return;
+        }
+        a.type === `webmcp.tools.invoke.request` && A(a, t);
+      }
     });
+    let t = () => {
+      j(i).catch((e) => {
+        console.error(`[webmcp-relay-embed] Failed to inject relay widget:`, e);
+      });
+    };
+    (document.body ? t() : document.addEventListener(`DOMContentLoaded`, t, { once: !0 }),
+      S(),
+      document.addEventListener(`visibilitychange`, () => {
+        document.visibilityState === `visible` &&
+          r &&
+          r.postMessage({ type: `webmcp.connect` }, i.widgetOrigin);
+      }));
   }
-
-  if (document.querySelector(RELAY_IFRAME_SELECTOR)) {
-    return;
-  }
-
-  const config = buildRelayConfig(getCurrentScriptElement());
-
-  window.addEventListener('message', (event) => {
-    if (event.origin !== config.widgetOrigin) {
-      return;
-    }
-
-    const request = parseWidgetRequest(event.data);
-    if (!request) {
-      return;
-    }
-
-    if (request.type === 'webmcp.tools.list.request') {
-      handleListRequest(request, event);
-      return;
-    }
-
-    if (request.type === 'webmcp.tools.invoke.request') {
-      handleInvokeRequest(request, event);
-    }
-  });
-
-  if (document.body) {
-    injectRelayWidget(config);
-  } else {
-    document.addEventListener('DOMContentLoaded', () => injectRelayWidget(config), { once: true });
-  }
-
-  subscribeToToolChanges();
 })();

--- a/e2e/web-standards-showcase/public/relay/widget.html
+++ b/e2e/web-standards-showcase/public/relay/widget.html
@@ -6,287 +6,580 @@
   </head>
   <body>
     <script>
-      /**
-       * Relay widget runtime. Runs inside a hidden iframe and proxies tool messages
-       * between the host page (`postMessage`) and the local relay socket.
-       *
-       * @typedef {{ [key: string]: unknown }} JsonObject
-       * @typedef {{ requestId: string; type: string; tools?: unknown; result?: unknown; error?: unknown }} HostMessage
-       * @typedef {{ resolve: (value: HostMessage) => void; reject: (reason: Error) => void; timeoutId: number; responseType: string; errorType: string }} PendingRequest
-       * @typedef {{ hostOrigin: string; hostUrl: string; hostTitle: string; tabId: string; wsUrl: string }} WidgetConfig
-       */
-      (function initializeWebMcpRelayWidget() {
-        'use strict';
-
-        var RECONNECT_INITIAL_DELAY_MS = 500;
-        var RECONNECT_MAX_DELAY_MS = 8000;
-        var REQUEST_TIMEOUT_MS = 10000;
-        var params = new URLSearchParams(window.location.search);
-
-        /**
-         * @returns {string}
-         */
-        function createRequestId() {
-          if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-            return crypto.randomUUID();
-          }
-          return String(Date.now() + Math.random());
+      (function () {
+        let e = new Set([`127.0.0.1`, `localhost`, `::1`, `[::1]`]);
+        function t(e) {
+          return !!e && typeof e == `object` && !Array.isArray(e);
         }
-
-        /**
-         * @param {unknown} value
-         * @returns {value is JsonObject}
-         */
-        function isJsonObject(value) {
-          return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+        function n(t) {
+          return e.has(t);
         }
-
-        /**
-         * @returns {WidgetConfig | null}
-         */
-        function parseConfig() {
-          var hostOrigin = params.get('hostOrigin');
-          if (!hostOrigin) {
-            return null;
-          }
-
-          var hostUrl = params.get('hostUrl') || hostOrigin;
-          var hostTitle = params.get('hostTitle') || '';
-          var tabId = params.get('tabId') || createRequestId();
-          var relayHost = params.get('relayHost') || '127.0.0.1';
-          var relayPort = params.get('relayPort') || '9333';
-
-          return {
-            hostOrigin: hostOrigin,
-            hostUrl: hostUrl,
-            hostTitle: hostTitle,
-            tabId: tabId,
-            wsUrl: 'ws://' + relayHost + ':' + relayPort,
-          };
+        function r() {
+          return typeof crypto < `u` && typeof crypto.randomUUID == `function`
+            ? crypto.randomUUID()
+            : `${String(Date.now())}_${String(Math.random()).slice(2, 10)}`;
         }
-
-        /**
-         * @param {unknown} value
-         * @returns {HostMessage | null}
-         */
-        function parseHostMessage(value) {
-          if (
-            !isJsonObject(value) ||
-            typeof value.requestId !== 'string' ||
-            typeof value.type !== 'string'
-          ) {
-            return null;
-          }
-
-          return {
-            requestId: value.requestId,
-            type: value.type,
-            tools: value.tools,
-            result: value.result,
-            error: value.error,
-          };
+        function i(e) {
+          return String(e).replace(/[\r\n]/g, ``);
         }
-
-        var config = parseConfig();
-        if (!config) {
-          console.warn(
-            '[webmcp-relay-widget] Missing required hostOrigin parameter. Widget will not start.'
-          );
-          return;
-        }
-
-        /** @type {Map<string, PendingRequest>} */
-        var pendingRequests = new Map();
-        var reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
-        /** @type {WebSocket | null} */
-        var activeSocket = null;
-        var helloSent = false;
-
-        window.addEventListener('message', function onHostMessage(event) {
-          if (event.origin !== config.hostOrigin) {
-            return;
-          }
-
-          var data = event.data;
-          if (isJsonObject(data) && data.type === 'webmcp.tools.changed') {
-            if (activeSocket && activeSocket.readyState === WebSocket.OPEN && helloSent) {
-              activeSocket.send(
-                JSON.stringify({
-                  type: 'tools/changed',
-                  tools: Array.isArray(data.tools) ? data.tools : [],
-                })
-              );
-            }
-            return;
-          }
-
-          var message = parseHostMessage(data);
-          if (!message) {
-            return;
-          }
-
-          var pending = pendingRequests.get(message.requestId);
-          if (!pending) {
-            return;
-          }
-
-          if (message.type === pending.responseType) {
-            clearTimeout(pending.timeoutId);
-            pendingRequests.delete(message.requestId);
-            pending.resolve(message);
-            return;
-          }
-
-          if (message.type === pending.errorType) {
-            clearTimeout(pending.timeoutId);
-            pendingRequests.delete(message.requestId);
-            pending.reject(new Error(String(message.error || 'Unknown host error')));
-          }
-        });
-
-        /**
-         * @param {string} baseType
-         * @param {JsonObject} payload
-         * @returns {Promise<HostMessage>}
-         */
-        function requestHost(baseType, payload) {
-          var requestId = createRequestId();
-
-          return new Promise(function createHostRequest(resolve, reject) {
-            var timeoutId = setTimeout(function onTimeout() {
-              pendingRequests.delete(requestId);
-              reject(new Error('Host response timeout: ' + baseType));
-            }, REQUEST_TIMEOUT_MS);
-
-            pendingRequests.set(requestId, {
-              resolve: resolve,
-              reject: reject,
-              timeoutId: timeoutId,
-              responseType: baseType + '.response',
-              errorType: baseType + '.error',
-            });
-
-            window.parent.postMessage(
-              Object.assign({ type: baseType + '.request', requestId: requestId }, payload),
-              config.hostOrigin
-            );
-          });
-        }
-
-        /**
-         * @param {WebSocket} socket
-         */
-        function sendHelloAndTools(socket) {
-          requestHost('webmcp.tools.list', {})
-            .then(function onToolsList(message) {
-              var tools = Array.isArray(message.tools) ? message.tools : [];
-              socket.send(
-                JSON.stringify({
-                  type: 'hello',
-                  tabId: config.tabId,
-                  origin: config.hostOrigin,
-                  url: config.hostUrl,
-                  title: config.hostTitle || document.referrer || 'Unknown page',
-                })
-              );
-              socket.send(JSON.stringify({ type: 'tools/list', tools: tools }));
-              helloSent = true;
-            })
-            .catch(function onHelloError(error) {
-              console.warn('[webmcp-relay-widget] Hello handshake failed:', error);
-              socket.close();
-            });
-        }
-
-        /**
-         * @param {WebSocket} socket
-         * @param {unknown} rawMessage
-         */
-        function handleRelayMessage(socket, rawMessage) {
-          var relayMessage;
+        function a(e, t) {
           try {
-            relayMessage = JSON.parse(String(rawMessage));
-          } catch (parseError) {
-            console.warn('[webmcp-relay-widget] Failed to parse relay message:', parseError);
-            return;
+            e.readyState === WebSocket.OPEN && e.send(t);
+          } catch (e) {
+            console.warn(`[webmcp-relay] Failed to send message:`, e);
           }
-
-          if (!isJsonObject(relayMessage) || typeof relayMessage.type !== 'string') {
-            return;
-          }
-
-          if (relayMessage.type === 'ping') {
-            socket.send(JSON.stringify({ type: 'pong' }));
-            return;
-          }
-
-          if (relayMessage.type !== 'invoke') {
-            return;
-          }
-
-          requestHost('webmcp.tools.invoke', {
-            toolName: relayMessage.toolName,
-            args: isJsonObject(relayMessage.args) ? relayMessage.args : {},
-          })
-            .then(function onInvokeSuccess(hostResponse) {
-              socket.send(
-                JSON.stringify({
-                  type: 'result',
-                  callId: relayMessage.callId,
-                  result: hostResponse.result,
-                })
-              );
-            })
-            .catch(function onInvokeError(error) {
-              socket.send(
-                JSON.stringify({
-                  type: 'result',
-                  callId: relayMessage.callId,
-                  result: {
-                    isError: true,
-                    content: [
-                      {
-                        type: 'text',
-                        text: String(error instanceof Error ? error.message : error),
-                      },
-                    ],
-                  },
-                })
-              );
-            });
         }
-
-        function connect() {
-          var socket = new WebSocket(config.wsUrl);
-          activeSocket = socket;
-
-          socket.addEventListener('open', function onOpen() {
-            reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
-            sendHelloAndTools(socket);
+        function o(e) {
+          return `__webmcp_relay_endpoint:${[e.hostOrigin, e.relayId ?? ``, e.workspace ?? ``].map((e) => encodeURIComponent(e)).join(`:`)}`;
+        }
+        let s = 3e3,
+          c = [1e4, 2e4, 3e4],
+          l = c.length;
+        function u(e = window.location.search) {
+          let t = new URLSearchParams(e),
+            i = globalThis.__WEBMCP_RELAY_CONFIG;
+          function a(e) {
+            return t.get(e) ?? i?.[e] ?? null;
+          }
+          let o = a(`hostOrigin`);
+          if (!o) return null;
+          let s = a(`hostUrl`) || o,
+            c = a(`hostTitle`) || ``,
+            l = a(`tabId`) || r(),
+            u = a(`relayHost`) || `127.0.0.1`,
+            d = a(`relayPort`),
+            f = d && d.length > 0 ? Number.parseInt(d, 10) : 9333,
+            p = a(`autoConnect`) !== `false`,
+            m = a(`relayId`) || void 0,
+            h = a(`relayWorkspace`) || void 0,
+            g = a(`requestTimeout`),
+            _ = g && g.length > 0 ? Number.parseInt(g, 10) : 6e4;
+          return n(u)
+            ? !Number.isInteger(f) || f < 1 || f > 65535
+              ? (console.error(
+                  `[webmcp-relay-widget] relayPort must be an integer between 1 and 65535, got:`,
+                  d
+                ),
+                null)
+              : !Number.isInteger(_) || _ < 1
+                ? (console.error(
+                    `[webmcp-relay-widget] requestTimeout must be a positive integer (ms), got:`,
+                    g
+                  ),
+                  null)
+                : {
+                    autoConnect: p,
+                    hostOrigin: o,
+                    hostTitle: c,
+                    hostUrl: s,
+                    relayHostHint: u,
+                    relayPortHint: f,
+                    ...(m ? { relayId: m } : {}),
+                    ...(h ? { relayWorkspace: h } : {}),
+                    requestTimeoutMs: _,
+                    tabId: l,
+                  }
+            : (console.error(`[webmcp-relay-widget] relayHost must be a loopback address, got:`, u),
+              null);
+        }
+        function d(e) {
+          return !t(e) || typeof e.requestId != `string` || typeof e.type != `string`
+            ? null
+            : {
+                requestId: e.requestId,
+                type: e.type,
+                tools: e.tools,
+                result: e.result,
+                error: e.error,
+              };
+        }
+        function f() {
+          let e = u();
+          if (!e) {
+            console.warn(
+              `[webmcp-relay-widget] Missing required hostOrigin parameter. Widget will not start.`
+            );
+            return;
+          }
+          S(e);
+        }
+        function p(e) {
+          return !t(e) ||
+            e.type !== `server-hello` ||
+            e.service !== `webmcp-local-relay` ||
+            e.version !== 1 ||
+            typeof e.host != `string` ||
+            typeof e.instanceId != `string` ||
+            typeof e.port != `number`
+            ? null
+            : {
+                type: `server-hello`,
+                service: `webmcp-local-relay`,
+                version: 1,
+                host: e.host,
+                instanceId: e.instanceId,
+                port: e.port,
+                ...(typeof e.label == `string` ? { label: e.label } : {}),
+                ...(typeof e.relayId == `string` ? { relayId: e.relayId } : {}),
+                ...(typeof e.workspace == `string` ? { workspace: e.workspace } : {}),
+              };
+        }
+        function m(e) {
+          return !t(e) || e.type !== `hello/accepted` ? null : { type: `hello/accepted` };
+        }
+        function h(e) {
+          return !t(e) ||
+            e.type !== `hello/rejected` ||
+            typeof e.message != `string` ||
+            typeof e.reason != `string`
+            ? null
+            : { type: `hello/rejected`, message: e.message, reason: e.reason };
+        }
+        function g(e) {
+          return o({
+            hostOrigin: e.hostOrigin,
+            ...(e.relayId ? { relayId: e.relayId } : {}),
+            ...(e.relayWorkspace ? { workspace: e.relayWorkspace } : {}),
           });
-
-          socket.addEventListener('message', function onMessage(event) {
-            handleRelayMessage(socket, event.data);
-          });
-
-          socket.addEventListener('close', function onClose() {
-            helloSent = false;
-            activeSocket = null;
-            setTimeout(connect, reconnectDelayMs);
-            reconnectDelayMs = Math.min(reconnectDelayMs * 1.5, RECONNECT_MAX_DELAY_MS);
-          });
-
-          socket.addEventListener('error', function onError(event) {
-            console.warn('[webmcp-relay-widget] WebSocket error:', event);
+        }
+        function _(e) {
+          if (typeof sessionStorage > `u`) return null;
+          try {
+            let t = sessionStorage.getItem(g(e));
+            if (!t) return null;
+            let n = JSON.parse(t);
+            return typeof n.host != `string` ||
+              n.host.length === 0 ||
+              typeof n.port != `number` ||
+              !Number.isInteger(n.port) ||
+              n.port < 1 ||
+              n.port > 65535
+              ? null
+              : { host: n.host, port: n.port };
+          } catch {
+            return null;
+          }
+        }
+        function v(e, t) {
+          if (!(typeof sessionStorage > `u`))
             try {
-              socket.close();
-            } catch (closeErr) {
-              console.warn('[webmcp-relay-widget] Error closing socket after error:', closeErr);
-            }
+              sessionStorage.setItem(g(e), JSON.stringify({ host: t.host, port: t.port }));
+            } catch {}
+        }
+        function y(e) {
+          if (!(typeof sessionStorage > `u`))
+            try {
+              sessionStorage.removeItem(g(e));
+            } catch {}
+        }
+        function b(e) {
+          let t = _(e),
+            n = new Set(),
+            r = [],
+            i = (e, t) => {
+              if (!Number.isInteger(t) || t < 1 || t > 65535) return;
+              let i = `${e}:${String(t)}`;
+              n.has(i) || (n.add(i), r.push({ host: e, port: t }));
+            };
+          (e.relayPortHint !== void 0 && i(e.relayHostHint, e.relayPortHint),
+            t && i(t.host, t.port));
+          for (let e of [`127.0.0.1`, `[::1]`]) for (let t = 9333; t <= 9348; t += 1) i(e, t);
+          return r;
+        }
+        async function x(e) {
+          let t = `ws://${e.host}:${String(e.port)}`;
+          return new Promise((n) => {
+            let r = !1,
+              i = new WebSocket(t, [`webmcp-discovery.v1`, `webmcp.v1`]),
+              a = (e) => {
+                if (!r) {
+                  if (
+                    ((r = !0),
+                    clearTimeout(l),
+                    i.removeEventListener(`close`, s),
+                    i.removeEventListener(`error`, o),
+                    i.removeEventListener(`message`, c),
+                    e === null)
+                  )
+                    try {
+                      i.close();
+                    } catch {}
+                  n(e);
+                }
+              },
+              o = () => {
+                a(null);
+              },
+              s = () => {
+                a(null);
+              },
+              c = (t) => {
+                let n;
+                try {
+                  n = JSON.parse(String(t.data));
+                } catch {
+                  return;
+                }
+                let r = p(n);
+                r && a({ endpoint: { hello: r, host: e.host, port: e.port }, socket: i });
+              },
+              l = setTimeout(() => {
+                a(null);
+              }, 1200);
+            (i.addEventListener(`close`, s, { once: !0 }),
+              i.addEventListener(`error`, o, { once: !0 }),
+              i.addEventListener(`message`, c));
           });
         }
-
-        connect();
+        function S(e) {
+          let n = new Map(),
+            o = null,
+            u = null,
+            f = 0,
+            g = !1,
+            S = null,
+            C = 500,
+            w = null,
+            T = `idle`,
+            E = 0,
+            D = null,
+            O = (e) => {
+              for (let [t, r] of n) (clearTimeout(r.timeoutId), n.delete(t), r.reject(Error(e)));
+            },
+            k = (e) => {
+              T = e;
+            };
+          function A(t, i) {
+            let a = r();
+            return new Promise((r, o) => {
+              let s = setTimeout(() => {
+                (n.delete(a), o(Error(`Host response timeout: ${t}`)));
+              }, e.requestTimeoutMs);
+              (n.set(a, {
+                resolve: r,
+                reject: o,
+                timeoutId: s,
+                responseType: `${t}.response`,
+                errorType: `${t}.error`,
+              }),
+                window.parent.postMessage(
+                  { type: `${t}.request`, requestId: a, ...i },
+                  e.hostOrigin
+                ));
+            });
+          }
+          let j = (n, r) => {
+              let s = [],
+                c = () => {
+                  S && (clearTimeout(S), (S = null));
+                },
+                l = () => {
+                  a(n, JSON.stringify({ type: `tools/list`, tools: s }));
+                };
+              (w && (clearTimeout(w), (w = null)),
+                (o = r),
+                (u = n),
+                (C = 500),
+                (E = 0),
+                (g = !1),
+                k(`connected`),
+                n.addEventListener(`message`, (s) => {
+                  let u;
+                  try {
+                    u = JSON.parse(String(s.data));
+                  } catch (e) {
+                    console.warn(`[webmcp-relay-widget] Failed to parse relay message:`, e);
+                    return;
+                  }
+                  let d = p(u);
+                  if (d) {
+                    o = { hello: d, host: r.host, port: r.port };
+                    return;
+                  }
+                  if (m(u)) {
+                    (c(), (g = !0), v(e, r), l());
+                    return;
+                  }
+                  let f = h(u);
+                  if (f) {
+                    (c(),
+                      (g = !1),
+                      y(e),
+                      window.parent.postMessage(
+                        {
+                          type: `webmcp.relay.rejected`,
+                          host: r.host,
+                          port: r.port,
+                          message: f.message,
+                          reason: f.reason,
+                        },
+                        e.hostOrigin
+                      ),
+                      console.error(
+                        `[webmcp-relay-widget] Relay rejected browser hello:`,
+                        f.reason,
+                        f.message
+                      ));
+                    try {
+                      n.close(1008, f.message);
+                    } catch {}
+                    return;
+                  }
+                  if (!(!t(u) || typeof u.type != `string`)) {
+                    if (u.type === `ping`) {
+                      a(n, JSON.stringify({ type: `pong` }));
+                      return;
+                    }
+                    if (u.type === `reload`) {
+                      window.parent.postMessage({ type: `webmcp.reload` }, e.hostOrigin);
+                      return;
+                    }
+                    if (u.type === `elicitation-response`) {
+                      window.parent.postMessage(
+                        {
+                          type: `webmcp.elicitation.response`,
+                          callId: u.callId,
+                          result: t(u.result) ? u.result : { action: `decline`, content: null },
+                        },
+                        e.hostOrigin
+                      );
+                      return;
+                    }
+                    if (u.type !== `invoke`) {
+                      console.debug(
+                        `[webmcp-relay-widget] Ignoring unrecognized message type:`,
+                        i(u.type)
+                      );
+                      return;
+                    }
+                    A(`webmcp.tools.invoke`, {
+                      toolName: u.toolName,
+                      args: t(u.args) ? u.args : {},
+                    })
+                      .then((e) => {
+                        a(
+                          n,
+                          JSON.stringify({ type: `result`, callId: u.callId, result: e.result })
+                        );
+                      })
+                      .catch((e) => {
+                        a(
+                          n,
+                          JSON.stringify({
+                            type: `result`,
+                            callId: u.callId,
+                            result: {
+                              isError: !0,
+                              content: [
+                                { type: `text`, text: String(e instanceof Error ? e.message : e) },
+                              ],
+                            },
+                          })
+                        );
+                      });
+                  }
+                }),
+                n.addEventListener(
+                  `close`,
+                  () => {
+                    if (u === n) {
+                      if (
+                        ((g = !1),
+                        (u = null),
+                        c(),
+                        O(`WebSocket connection lost`),
+                        (f += 1),
+                        f >= 5)
+                      ) {
+                        ((f = 0), F());
+                        return;
+                      }
+                      P();
+                    }
+                  },
+                  { once: !0 }
+                ),
+                n.addEventListener(`error`, (e) => {
+                  console.warn(`[webmcp-relay-widget] WebSocket error:`, e);
+                  try {
+                    n.close();
+                  } catch (e) {
+                    console.warn(`[webmcp-relay-widget] Error closing socket after error:`, e);
+                  }
+                }),
+                A(`webmcp.tools.list`, {})
+                  .then((t) => {
+                    ((s = Array.isArray(t.tools) ? t.tools : []),
+                      a(
+                        n,
+                        JSON.stringify({
+                          type: `hello`,
+                          tabId: e.tabId,
+                          origin: e.hostOrigin,
+                          title: e.hostTitle || document.referrer || `Unknown page`,
+                          url: e.hostUrl,
+                        })
+                      ),
+                      (S = setTimeout(() => {
+                        ((S = null),
+                          !(u !== n || n.readyState !== WebSocket.OPEN || g) &&
+                            ((g = !0), v(e, r), l()));
+                      }, 250)));
+                  })
+                  .catch((e) => {
+                    console.warn(`[webmcp-relay-widget] Hello handshake failed:`, e);
+                    try {
+                      n.close();
+                    } catch {}
+                  }));
+            },
+            M = async (t) => {
+              let n = await x({ host: t.host, port: t.port });
+              if (!n) return !1;
+              let r = n.endpoint;
+              return (e.relayId && r.hello.relayId !== e.relayId) ||
+                (e.relayWorkspace && r.hello.workspace !== e.relayWorkspace)
+                ? (n.socket.close(), !1)
+                : (j(n.socket, r), !0);
+            },
+            N = async () => {
+              k(`discovering`);
+              for (let t of b(e)) if (await M(t)) return ((f = 0), !0);
+              return !1;
+            },
+            P = () => {
+              if (!o || w) return;
+              k(`retry-same-endpoint`);
+              let e = { host: o.host, port: o.port },
+                t = Math.min(s, Math.round(C * (0.85 + Math.random() * 0.3)));
+              ((C = Math.min(Math.round(C * 1.5), s)),
+                (w = setTimeout(() => {
+                  ((w = null),
+                    M(e).then((e) => {
+                      if (e) {
+                        f = 0;
+                        return;
+                      }
+                      if (f >= 5) {
+                        ((f = 0), F());
+                        return;
+                      }
+                      P();
+                    }));
+                }, t)));
+            },
+            F = () => {
+              if (w) return;
+              if (E >= l) {
+                R();
+                return;
+              }
+              k(`rediscover`);
+              let e = c[E];
+              w = setTimeout(() => {
+                ((w = null),
+                  N().then((e) => {
+                    e || ((E += 1), F());
+                  }));
+              }, e);
+            },
+            I = () => {
+              document.visibilityState === `visible` && T === `dormant` && B();
+            },
+            L = () => {
+              (document.removeEventListener(`visibilitychange`, I),
+                D !== null && (clearInterval(D), (D = null)));
+            },
+            R = () => {
+              T !== `dormant` &&
+                (k(`dormant`),
+                w && (clearTimeout(w), (w = null)),
+                document.addEventListener(`visibilitychange`, I),
+                (D = setInterval(() => {
+                  z();
+                }, 12e4)));
+            },
+            z = async () => {
+              if (T !== `dormant`) return;
+              let t = new Set(),
+                n = [],
+                r = (e, r) => {
+                  let i = `${e}:${String(r)}`;
+                  t.has(i) || (t.add(i), n.push({ host: e, port: r }));
+                };
+              e.relayPortHint !== void 0 && r(e.relayHostHint, e.relayPortHint);
+              let i = _(e);
+              if ((i && r(i.host, i.port), n.length !== 0)) {
+                (k(`discovering`), L());
+                for (let e of n)
+                  if (await M(e)) {
+                    E = 0;
+                    return;
+                  }
+                R();
+              }
+            },
+            B = () => {
+              (L(),
+                (C = 500),
+                (E = 0),
+                N().then((e) => {
+                  e || R();
+                }));
+            };
+          (window.addEventListener(`message`, (r) => {
+            if (r.origin !== e.hostOrigin) return;
+            let i = r.data;
+            if (t(i) && i.type === `webmcp.tools.changed`) {
+              u &&
+                g &&
+                a(
+                  u,
+                  JSON.stringify({
+                    type: `tools/changed`,
+                    tools: Array.isArray(i.tools) ? i.tools : [],
+                  })
+                );
+              return;
+            }
+            if (t(i) && i.type === `webmcp.connect`) {
+              T === `dormant` ? B() : !u && T !== `discovering` && N();
+              return;
+            }
+            if (t(i) && i.type === `webmcp.elicitation.request`) {
+              u &&
+                u.readyState === WebSocket.OPEN &&
+                a(
+                  u,
+                  JSON.stringify({
+                    type: `elicitation-request`,
+                    callId: i.callId,
+                    params: t(i.params) ? i.params : {},
+                  })
+                );
+              return;
+            }
+            let o = d(i);
+            if (!o) return;
+            let s = n.get(o.requestId);
+            if (s) {
+              if (o.type === s.responseType) {
+                (clearTimeout(s.timeoutId), n.delete(o.requestId), s.resolve(o));
+                return;
+              }
+              o.type === s.errorType &&
+                (clearTimeout(s.timeoutId),
+                n.delete(o.requestId),
+                s.reject(Error(String(o.error || `Unknown host error`))));
+            }
+          }),
+            e.autoConnect
+              ? N().then((e) => {
+                  e || F();
+                })
+              : k(`idle`));
+        }
+        f();
       })();
     </script>
   </body>

--- a/packages/webmcp-local-relay/example/embed.js
+++ b/packages/webmcp-local-relay/example/embed.js
@@ -1,461 +1,357 @@
-/**
- * Injects a hidden relay widget iframe and bridges widget messages to host tools.
- *
- * Usage:
- * `<script src=".../embed.js" data-relay-host="127.0.0.1" data-relay-port="9333"></script>`
- *
- * @typedef {{ [key: string]: unknown }} JsonObject
- * @typedef {{ name: string; description?: string; inputSchema?: JsonObject }} ToolDescriptor
- * @typedef {{ isError?: boolean; content?: Array<{ type: string; text: string }>; [key: string]: unknown }} ToolInvokeResult
- * @typedef {{ listTools: () => ToolDescriptor[] | Promise<ToolDescriptor[]>; invoke: (name: string, args: JsonObject) => ToolInvokeResult | Promise<ToolInvokeResult> }} ToolBridge
- * @typedef {{ requestId: string; type: string; toolName?: unknown; args?: unknown }} WidgetRequestMessage
- * @typedef {{ relayHost: string; relayPort: string; tabId: string; widgetUrl: string; widgetOrigin: string }} RelayConfig
- */
-(() => {
-  const RELAY_IFRAME_SELECTOR = '[data-webmcp-relay]';
-  const TAB_ID_STORAGE_KEY = '__webmcp_relay_tab_id';
-  const FALLBACK_WIDGET_URL =
-    'https://cdn.jsdelivr.net/npm/@mcp-b/webmcp-local-relay/dist/browser/widget.html';
-
-  /** @type {Window | null} */
-  let widgetWindow = null;
-
-  /** @returns {HTMLScriptElement | null} */
-  function getCurrentScriptElement() {
+/* eslint-disable */
+(function () {
+  function e(e) {
+    return !!e && typeof e == `object` && !Array.isArray(e);
+  }
+  let t = `[data-webmcp-relay]`,
+    n = `__webmcp_relay_tab_id`,
+    r = null,
+    i;
+  function a() {
     return document.currentScript instanceof HTMLScriptElement ? document.currentScript : null;
   }
-
-  /**
-   * @param {unknown} value
-   * @returns {value is JsonObject}
-   */
-  function isJsonObject(value) {
-    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+  let o = a(),
+    s = o ? o.hasAttribute(`data-debug`) : !1;
+  function c(...e) {
+    s && console.warn(`[webmcp-relay-embed]`, ...e);
   }
-
-  /** @returns {string} */
-  function createTabId() {
-    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-      return crypto.randomUUID();
-    }
-    return `${String(Date.now())}_${String(Math.random()).slice(2, 10)}`;
+  function l() {
+    return typeof crypto < `u` && typeof crypto.randomUUID == `function`
+      ? crypto.randomUUID()
+      : `${String(Date.now())}_${String(Math.random()).slice(2, 10)}`;
   }
-
-  /** @returns {string} */
-  function readOrCreateTabId() {
+  function u() {
     try {
-      const storedTabId = sessionStorage.getItem(TAB_ID_STORAGE_KEY);
-      if (storedTabId) {
-        return storedTabId;
-      }
-    } catch (err) {
-      console.warn(
-        '[webmcp-relay-embed] sessionStorage read failed, tab ID will not persist:',
-        err
-      );
+      let e = sessionStorage.getItem(n);
+      if (e) return e;
+    } catch (e) {
+      c(`sessionStorage read failed, tab ID will not persist:`, e);
     }
-
-    const tabId = createTabId();
+    let e = l();
     try {
-      sessionStorage.setItem(TAB_ID_STORAGE_KEY, tabId);
-    } catch (err) {
-      console.warn('[webmcp-relay-embed] sessionStorage write failed:', err);
+      sessionStorage.setItem(n, e);
+    } catch (e) {
+      c(`sessionStorage write failed:`, e);
     }
-
-    return tabId;
+    return e;
   }
-
-  /**
-   * @param {HTMLScriptElement | null} script
-   * @returns {string}
-   */
-  function resolveWidgetUrl(script) {
-    if (script?.src) {
+  function d(e) {
+    if (e?.src)
       try {
-        return new URL('widget.html', script.src).href;
-      } catch (err) {
-        console.warn(
-          '[webmcp-relay-embed] Failed to resolve widget URL from script src, falling back to CDN:',
-          err
-        );
+        return new URL(`widget.html`, e.src).href;
+      } catch (e) {
+        c(`Failed to resolve widget URL from script src, falling back to CDN:`, e);
       }
-    } else {
-      console.warn(
-        '[webmcp-relay-embed] Script element has no src attribute, falling back to CDN widget URL'
-      );
-    }
-    return FALLBACK_WIDGET_URL;
+    else c(`Script element has no src attribute, falling back to CDN widget URL.`);
+    return `https://cdn.jsdelivr.net/npm/@mcp-b/webmcp-local-relay/dist/browser/widget.html`;
   }
-
-  /**
-   * @param {HTMLScriptElement | null} script
-   * @returns {RelayConfig}
-   */
-  function buildRelayConfig(script) {
-    const widgetUrl = resolveWidgetUrl(script);
+  function f(e) {
+    let t = d(e),
+      n = e?.getAttribute(`data-relay-id`) || void 0,
+      r = e?.getAttribute(`data-relay-workspace`) || void 0,
+      i = e?.getAttribute(`data-request-timeout`) || void 0;
     return {
-      relayHost: script?.getAttribute('data-relay-host') || '127.0.0.1',
-      relayPort: script?.getAttribute('data-relay-port') || '9333',
-      tabId: readOrCreateTabId(),
-      widgetUrl,
-      widgetOrigin: new URL(widgetUrl).origin,
+      autoConnect: e?.getAttribute(`data-auto-connect`) !== `false`,
+      relayHost: e?.getAttribute(`data-relay-host`) || `127.0.0.1`,
+      relayPort: e?.getAttribute(`data-relay-port`) || `9333`,
+      ...(n ? { relayId: n } : {}),
+      ...(r ? { relayWorkspace: r } : {}),
+      ...(i ? { requestTimeout: i } : {}),
+      tabId: u(),
+      widgetUrl: t,
+      widgetOrigin: new URL(t).origin,
     };
   }
-
-  /**
-   * @param {unknown} rawSchema
-   * @returns {JsonObject}
-   */
-  function parseTestingSchema(rawSchema) {
-    if (typeof rawSchema !== 'string' || rawSchema.length === 0) {
-      return { type: 'object', properties: {} };
-    }
+  function p(t) {
+    if (typeof t != `string` || t.length === 0) return { type: `object`, properties: {} };
     try {
-      const parsed = JSON.parse(rawSchema);
-      return isJsonObject(parsed) ? parsed : { type: 'object', properties: {} };
-    } catch (err) {
-      console.warn(
-        '[webmcp-relay-embed] Failed to parse tool inputSchema, using permissive default:',
-        err
-      );
-      return { type: 'object', properties: {} };
-    }
-  }
-
-  /**
-   * @param {unknown} value
-   * @returns {JsonObject}
-   */
-  function toInvokeArgs(value) {
-    if (isJsonObject(value)) return value;
-    if (value !== undefined && value !== null) {
-      console.warn(
-        '[webmcp-relay-embed] Tool invocation args was not an object, defaulting to {}:',
-        typeof value
+      let n = JSON.parse(t);
+      return e(n) ? n : { type: `object`, properties: {} };
+    } catch (e) {
+      return (
+        c(`Tool inputSchema is not valid JSON:`, typeof t == `string` ? t.slice(0, 200) : t, e),
+        { type: `object`, properties: {} }
       );
     }
-    return {};
   }
-
-  /** @returns {ToolBridge | null} */
-  function getToolBridge() {
-    const modelContext = navigator.modelContext;
-    if (
-      modelContext &&
-      typeof modelContext.listTools === 'function' &&
-      typeof modelContext.callTool === 'function'
-    ) {
+  function m(t) {
+    return e(t) ? t : (t != null && c(`Tool invocation args must be an object, got`, typeof t), {});
+  }
+  function h(e) {
+    return { name: e.name, description: e.description, inputSchema: e.inputSchema };
+  }
+  function g(e) {
+    return { name: e.name, description: e.description, inputSchema: p(e.inputSchema) };
+  }
+  function _() {
+    let e = navigator.modelContext;
+    if (e && typeof e.listTools == `function` && typeof e.callTool == `function`) return e;
+  }
+  function v() {
+    let t = _();
+    if (t)
       return {
         listTools() {
-          return modelContext.listTools().map((tool) => ({
-            name: tool.name,
-            description: tool.description,
-            inputSchema: isJsonObject(tool.inputSchema)
-              ? tool.inputSchema
-              : { type: 'object', properties: {} },
-          }));
+          return t.listTools().map(h);
         },
-        invoke(name, args) {
-          return modelContext.callTool({ name, arguments: args });
+        invoke(e, n) {
+          return t.callTool({ name: e, arguments: n });
         },
       };
-    }
-
-    const testing = navigator.modelContextTesting;
-    if (
-      testing &&
-      typeof testing.listTools === 'function' &&
-      typeof testing.executeTool === 'function'
-    ) {
-      return {
-        listTools() {
-          return testing.listTools().map((tool) => ({
-            name: tool.name,
-            description: tool.description,
-            inputSchema: parseTestingSchema(tool.inputSchema),
-          }));
-        },
-        async invoke(name, args) {
-          const serialized = await testing.executeTool(name, JSON.stringify(args));
-          if (serialized === null) {
-            return {
-              isError: true,
-              content: [{ type: 'text', text: 'Tool execution interrupted by navigation' }],
-            };
-          }
-          let parsed;
-          try {
-            parsed = JSON.parse(serialized);
-          } catch {
-            throw new Error(
-              `Testing tool returned invalid JSON: ${String(serialized).slice(0, 200)}`
-            );
-          }
-          if (!isJsonObject(parsed)) {
-            throw new Error('Testing tool response was not an object');
-          }
-          return parsed;
-        },
-      };
-    }
-
-    return null;
+    let n = navigator.modelContextTesting;
+    return n && typeof n.listTools == `function` && typeof n.executeTool == `function`
+      ? {
+          listTools() {
+            return n.listTools().map(g);
+          },
+          async invoke(t, r) {
+            let i = await n.executeTool(t, JSON.stringify(r));
+            if (i === null)
+              return {
+                isError: !0,
+                content: [{ type: `text`, text: `Tool execution interrupted by navigation` }],
+              };
+            let a;
+            try {
+              a = JSON.parse(i);
+            } catch {
+              throw Error(`Testing tool returned invalid JSON: ${String(i).slice(0, 200)}`);
+            }
+            if (!e(a)) throw Error(`Testing tool response was not an object`);
+            return a;
+          },
+        }
+      : (c(`No WebMCP runtime found (navigator.modelContext or navigator.modelContextTesting).`),
+        null);
   }
-
-  let pushScheduled = false;
-
-  /**
-   * Coalesced handler for tool change events.
-   * Uses flag + setTimeout(0) to batch rapid registrations into a single push.
-   */
-  function onToolsChanged() {
-    if (pushScheduled || !widgetWindow) return;
-    pushScheduled = true;
-    setTimeout(() => {
-      pushScheduled = false;
-      if (!widgetWindow) return;
-      const bridge = getToolBridge();
-      const toolsPromise = bridge ? Promise.resolve(bridge.listTools()) : Promise.resolve([]);
-      toolsPromise
-        .then((tools) => {
-          if (!widgetWindow) return;
-          widgetWindow.postMessage(
-            {
-              type: 'webmcp.tools.changed',
-              tools: Array.isArray(tools) ? tools : [],
-            },
-            config.widgetOrigin
-          );
+  let y = !1;
+  function b() {
+    y ||
+      !r ||
+      ((y = !0),
+      setTimeout(() => {
+        if (((y = !1), !r)) return;
+        let e = v();
+        (e ? Promise.resolve(e.listTools()) : Promise.resolve([]))
+          .then((e) => {
+            r &&
+              r.postMessage(
+                { type: `webmcp.tools.changed`, tools: Array.isArray(e) ? e : [] },
+                i.widgetOrigin
+              );
+          })
+          .catch((e) => {
+            c(`Failed to push tool changes:`, e);
+          });
+      }, 0));
+  }
+  function x() {
+    let e = _();
+    if (e)
+      try {
+        return (e.addEventListener(`toolchange`, b), !0);
+      } catch (e) {
+        c(`addEventListener threw:`, e);
+      }
+    let t = navigator.modelContextTesting;
+    if (t && typeof t.registerToolsChangedCallback == `function`)
+      try {
+        return (t.registerToolsChangedCallback(b), !0);
+      } catch (e) {
+        c(`Failed to subscribe via registerToolsChangedCallback:`, e);
+      }
+    return !1;
+  }
+  function S() {
+    if (x()) return;
+    let e = 0,
+      t = 100,
+      n = () => {
+        setTimeout(() => {
+          if ((e++, !x())) {
+            if (e >= 40) {
+              c(
+                `Could not subscribe to tool changes after 40 retries. Dynamic tool updates will not be relayed.`
+              );
+              return;
+            }
+            ((t = Math.min(Math.round(t * 1.5), 1e3)), n());
+          }
+        }, t);
+      };
+    n();
+  }
+  function C(e, t, n) {
+    !e || typeof e != `object` || !(`postMessage` in e) || e.postMessage(n, t);
+  }
+  function w(t) {
+    return !e(t) || typeof t.requestId != `string` || typeof t.type != `string`
+      ? null
+      : { requestId: t.requestId, type: t.type, toolName: t.toolName, args: t.args };
+  }
+  function T(e, t) {
+    let n = v();
+    (n ? Promise.resolve(n.listTools()) : Promise.resolve([]))
+      .then((n) => {
+        C(t.source, t.origin, {
+          type: `webmcp.tools.list.response`,
+          requestId: e.requestId,
+          tools: Array.isArray(n) ? n : [],
+        });
+      })
+      .catch((n) => {
+        (c(`Failed to list tools:`, n),
+          C(t.source, t.origin, {
+            type: `webmcp.tools.list.response`,
+            requestId: e.requestId,
+            tools: [],
+            error: `Failed to list tools: ${n instanceof Error ? n.message : String(n)}`,
+          }));
+      });
+  }
+  let E = !1;
+  function D(t, n) {
+    if (E) return;
+    let r = _();
+    if (!r || typeof r.elicitInput != `function`) {
+      c(`Elicitation bridge not installed: elicitInput not available on modelContext`);
+      return;
+    }
+    ((r.elicitInput = (r, i) => {
+      let a = k();
+      return new Promise((i) => {
+        let o = () => {
+            (window.removeEventListener(`message`, l), clearTimeout(s));
+          },
+          s = setTimeout(() => {
+            (o(),
+              c(`Elicitation request timed out after 60s`),
+              i({ action: `decline`, content: null }));
+          }, 6e4),
+          l = (t) => {
+            if (t.origin !== n) return;
+            let r = t.data;
+            !e(r) ||
+              r.type !== `webmcp.elicitation.response` ||
+              r.callId !== a ||
+              (o(), i(e(r.result) ? r.result : { action: `decline`, content: null }));
+          };
+        (window.addEventListener(`message`, l),
+          t.postMessage({ type: `webmcp.elicitation.request`, callId: a, params: r }, n));
+      });
+    }),
+      (E = !0),
+      c(`Elicitation bridge installed`));
+  }
+  let O = 0;
+  function k() {
+    return ((O += 1), `elicit_${String(Date.now())}_${String(O)}`);
+  }
+  function A(t, n) {
+    let r = v();
+    if (!r) {
+      C(n.source, n.origin, {
+        type: `webmcp.tools.invoke.error`,
+        requestId: t.requestId,
+        error: `No WebMCP runtime found on this page`,
+      });
+      return;
+    }
+    (n.source && D(n.source, n.origin),
+      Promise.resolve(r.invoke(String(t.toolName ?? ``), m(t.args)))
+        .then((r) => {
+          C(n.source, n.origin, {
+            type: `webmcp.tools.invoke.response`,
+            requestId: t.requestId,
+            result: e(r) ? r : {},
+          });
         })
-        .catch((err) => {
-          console.warn('[webmcp-relay-embed] Failed to push tool changes:', err);
-        });
-    }, 0);
+        .catch((e) => {
+          C(n.source, n.origin, {
+            type: `webmcp.tools.invoke.error`,
+            requestId: t.requestId,
+            error: String(e instanceof Error ? e.message : e),
+          });
+        }));
   }
-
-  /**
-   * Subscribes to tool change events.
-   * Uses the testing API's toolchange event (EventTarget) which is supported
-   * by both native Chromium and the polyfill.
-   */
-  function subscribeToToolChanges() {
-    const testing = navigator.modelContextTesting;
-    if (testing && typeof testing.addEventListener === 'function') {
-      try {
-        testing.addEventListener('toolchange', onToolsChanged);
-        return;
-      } catch (error) {
-        console.warn('[webmcp-relay-embed] Failed to subscribe via addEventListener:', error);
-      }
-    }
-    console.warn(
-      '[webmcp-relay-embed] Could not subscribe to tool changes. Dynamic tool updates will not be relayed.'
-    );
-  }
-
-  /**
-   * @param {MessageEventSource | null} source
-   * @param {string} origin
-   * @param {JsonObject} payload
-   */
-  function respondToSource(source, origin, payload) {
-    if (!source || typeof source !== 'object' || !('postMessage' in source)) {
-      return;
-    }
-
-    const { postMessage } = source;
-    if (typeof postMessage !== 'function') {
-      return;
-    }
-
-    postMessage.call(source, payload, origin);
-  }
-
-  /**
-   * @param {unknown} value
-   * @returns {WidgetRequestMessage | null}
-   */
-  function parseWidgetRequest(value) {
-    if (
-      !isJsonObject(value) ||
-      typeof value.requestId !== 'string' ||
-      typeof value.type !== 'string'
-    ) {
-      return null;
-    }
-
-    return {
-      requestId: value.requestId,
-      type: value.type,
-      toolName: value.toolName,
-      args: value.args,
-    };
-  }
-
-  /**
-   * @param {WidgetRequestMessage} request
-   * @param {MessageEvent} event
-   */
-  function handleListRequest(request, event) {
-    const bridge = getToolBridge();
-    const toolsPromise = bridge ? Promise.resolve(bridge.listTools()) : Promise.resolve([]);
-
-    toolsPromise
-      .then((tools) => {
-        respondToSource(event.source, event.origin, {
-          type: 'webmcp.tools.list.response',
-          requestId: request.requestId,
-          tools: Array.isArray(tools) ? tools : [],
-        });
-      })
-      .catch((error) => {
-        console.warn('[webmcp-relay-embed] Failed to list tools:', error);
-        respondToSource(event.source, event.origin, {
-          type: 'webmcp.tools.list.response',
-          requestId: request.requestId,
-          tools: [],
-          error: `Failed to list tools: ${error instanceof Error ? error.message : String(error)}`,
-        });
-      });
-  }
-
-  /**
-   * @param {WidgetRequestMessage} request
-   * @param {MessageEvent} event
-   */
-  function handleInvokeRequest(request, event) {
-    const bridge = getToolBridge();
-    if (!bridge) {
-      respondToSource(event.source, event.origin, {
-        type: 'webmcp.tools.invoke.error',
-        requestId: request.requestId,
-        error: 'No WebMCP runtime found on this page',
-      });
-      return;
-    }
-
-    Promise.resolve(bridge.invoke(String(request.toolName ?? ''), toInvokeArgs(request.args)))
-      .then((result) => {
-        respondToSource(event.source, event.origin, {
-          type: 'webmcp.tools.invoke.response',
-          requestId: request.requestId,
-          result: isJsonObject(result) ? result : {},
-        });
-      })
-      .catch((error) => {
-        respondToSource(event.source, event.origin, {
-          type: 'webmcp.tools.invoke.error',
-          requestId: request.requestId,
-          error: String(error instanceof Error ? error.message : error),
-        });
-      });
-  }
-
-  /** @param {RelayConfig} cfg */
-  async function injectRelayWidget(cfg) {
-    if (document.querySelector(RELAY_IFRAME_SELECTOR)) {
-      return;
-    }
-
-    const searchParams = new URLSearchParams();
-    searchParams.set('tabId', cfg.tabId);
-    searchParams.set('hostOrigin', window.location.origin);
-    const cleanUrl = new URL(window.location.href);
-    cleanUrl.search = '';
-    cleanUrl.hash = '';
-    searchParams.set('hostUrl', cleanUrl.href);
-    searchParams.set('hostTitle', document.title || '');
-    searchParams.set('relayHost', cfg.relayHost);
-    searchParams.set('relayPort', cfg.relayPort);
-
-    // Try fetch + blob URL to work around CDNs serving .html as text/plain.
-    /** @type {string | null} */
-    let blobUrl = null;
+  async function j(e) {
+    if (document.querySelector(t)) return;
+    let n = new URLSearchParams();
+    (n.set(`tabId`, e.tabId), n.set(`hostOrigin`, window.location.origin));
+    let a = new URL(window.location.href);
+    ((a.search = ``),
+      (a.hash = ``),
+      n.set(`hostUrl`, a.href),
+      n.set(`hostTitle`, document.title || ``),
+      n.set(`relayHost`, e.relayHost),
+      n.set(`relayPort`, e.relayPort),
+      n.set(`autoConnect`, e.autoConnect ? `true` : `false`),
+      e.relayId && n.set(`relayId`, e.relayId),
+      e.relayWorkspace && n.set(`relayWorkspace`, e.relayWorkspace),
+      e.requestTimeout && n.set(`requestTimeout`, e.requestTimeout));
+    let o = null;
     try {
-      const response = await fetch(cfg.widgetUrl);
-      if (response.ok) {
-        const html = await response.text();
-        const configScript =
-          '<script>window.__WEBMCP_RELAY_CONFIG=' +
-          JSON.stringify(Object.fromEntries(searchParams)) +
-          ';</script>';
-        const blob = new Blob([html.replace('</head>', configScript + '</head>')], {
-          type: 'text/html',
-        });
-        blobUrl = URL.createObjectURL(blob);
-        config.widgetOrigin = window.location.origin;
+      let t = await fetch(e.widgetUrl);
+      if (!t.ok)
+        console.warn(
+          `[webmcp-relay-embed] Widget HTML fetch returned ${String(t.status)}; falling back to direct iframe src.`
+        );
+      else if (t.ok) {
+        let e = await t.text(),
+          r = `<script>window.__WEBMCP_RELAY_CONFIG=${JSON.stringify(Object.fromEntries(n))};</script>`,
+          a = new Blob([e.replace(`</head>`, `${r}</head>`)], { type: `text/html` });
+        ((o = URL.createObjectURL(a)), (i.widgetOrigin = window.location.origin));
       }
-    } catch (err) {
-      console.warn('[webmcp-relay-embed] Failed to fetch widget HTML for blob URL:', err);
+    } catch (e) {
+      c(`Failed to fetch widget HTML for blob URL:`, e);
     }
-
-    const iframe = document.createElement('iframe');
-    // Fallback: direct iframe src (works when widget.html is served as text/html).
-    iframe.src = blobUrl ?? cfg.widgetUrl + '?' + searchParams.toString();
-    iframe.style.display = 'none';
-    iframe.setAttribute('aria-hidden', 'true');
-    iframe.setAttribute('data-webmcp-relay', '1');
-    document.body.appendChild(iframe);
-    widgetWindow = iframe.contentWindow;
-    iframe.addEventListener('load', () => {
-      widgetWindow = iframe.contentWindow;
-      if (blobUrl) {
-        URL.revokeObjectURL(blobUrl);
+    let s = document.createElement(`iframe`);
+    ((s.src = o ?? `${e.widgetUrl}?${n.toString()}`),
+      (s.style.display = `none`),
+      s.setAttribute(`aria-hidden`, `true`),
+      s.setAttribute(`data-webmcp-relay`, `1`),
+      s.setAttribute(`allow`, `loopback-network; local-network; local-network-access`),
+      document.body.appendChild(s),
+      (r = s.contentWindow),
+      s.addEventListener(`load`, () => {
+        ((r = s.contentWindow), o && URL.revokeObjectURL(o));
+      }),
+      s.addEventListener(`error`, () => {
+        (console.error(
+          `[webmcp-relay-embed] Failed to load relay widget iframe from:`,
+          s.src,
+          `-- WebMCP tools will NOT be relayed. Check network connectivity and widget URL.`
+        ),
+          o && URL.revokeObjectURL(o));
+      }));
+  }
+  if (!document.querySelector(t)) {
+    try {
+      i = f(o);
+    } catch (e) {
+      throw (console.error(`[webmcp-relay-embed] Failed to initialize relay configuration:`, e), e);
+    }
+    window.addEventListener(`message`, (t) => {
+      if (t.origin !== i.widgetOrigin || !r || t.source !== r) return;
+      let n = t.data;
+      if (e(n) && n.type === `webmcp.reload`) {
+        window.location.reload();
+        return;
+      }
+      let a = w(t.data);
+      if (a) {
+        if (a.type === `webmcp.tools.list.request`) {
+          T(a, t);
+          return;
+        }
+        a.type === `webmcp.tools.invoke.request` && A(a, t);
       }
     });
-    iframe.addEventListener('error', () => {
-      console.error('[webmcp-relay-embed] Failed to load relay widget iframe from:', iframe.src);
-      if (blobUrl) {
-        URL.revokeObjectURL(blobUrl);
-      }
-    });
+    let t = () => {
+      j(i).catch((e) => {
+        console.error(`[webmcp-relay-embed] Failed to inject relay widget:`, e);
+      });
+    };
+    (document.body ? t() : document.addEventListener(`DOMContentLoaded`, t, { once: !0 }), S());
   }
-
-  if (document.querySelector(RELAY_IFRAME_SELECTOR)) {
-    return;
-  }
-
-  let config;
-  try {
-    config = buildRelayConfig(getCurrentScriptElement());
-  } catch (err) {
-    console.error('[webmcp-relay-embed] Failed to initialize relay configuration:', err);
-    return;
-  }
-
-  window.addEventListener('message', (event) => {
-    if (event.origin !== config.widgetOrigin) {
-      return;
-    }
-
-    const data = event.data;
-    if (isJsonObject(data) && data.type === 'webmcp.reload') {
-      window.location.reload();
-      return;
-    }
-
-    const request = parseWidgetRequest(event.data);
-    if (!request) {
-      return;
-    }
-
-    if (request.type === 'webmcp.tools.list.request') {
-      handleListRequest(request, event);
-      return;
-    }
-
-    if (request.type === 'webmcp.tools.invoke.request') {
-      handleInvokeRequest(request, event);
-    }
-  });
-
-  if (document.body) {
-    void injectRelayWidget(config);
-  } else {
-    document.addEventListener('DOMContentLoaded', () => void injectRelayWidget(config), {
-      once: true,
-    });
-  }
-
-  subscribeToToolChanges();
 })();

--- a/packages/webmcp-local-relay/example/widget.html
+++ b/packages/webmcp-local-relay/example/widget.html
@@ -6,338 +6,583 @@
   </head>
   <body>
     <script>
-      /**
-       * Relay widget runtime. Runs inside a hidden iframe and proxies tool messages
-       * between the host page (`postMessage`) and the local relay socket.
-       *
-       * Security: The iframe boundary provides origin isolation. All postMessage
-       * exchanges validate `event.origin` against the host page's origin to prevent
-       * cross-origin message injection.
-       *
-       * @typedef {{ [key: string]: unknown }} JsonObject
-       * @typedef {{ requestId: string; type: string; tools?: unknown; result?: unknown; error?: unknown }} HostMessage
-       * @typedef {{ resolve: (value: HostMessage) => void; reject: (reason: Error) => void; timeoutId: number; responseType: string; errorType: string }} PendingRequest
-       * @typedef {{ hostOrigin: string; hostUrl: string; hostTitle: string; tabId: string; wsUrl: string }} WidgetConfig
-       */
-      (() => {
-        'use strict';
-
-        const RECONNECT_INITIAL_DELAY_MS = 500;
-        const RECONNECT_MAX_DELAY_MS = 8000;
-        const REQUEST_TIMEOUT_MS = 10000;
-        const params = new URLSearchParams(window.location.search);
-
-        /** @returns {string} */
-        function createRequestId() {
-          if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-            return crypto.randomUUID();
-          }
-          return String(Date.now() + Math.random());
+      (function () {
+        let e = new Set([`127.0.0.1`, `localhost`, `::1`, `[::1]`]);
+        function t(e) {
+          return !!e && typeof e == `object` && !Array.isArray(e);
         }
-
-        /**
-         * @param {unknown} value
-         * @returns {value is JsonObject}
-         */
-        function isJsonObject(value) {
-          return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+        function n(t) {
+          return e.has(t);
         }
-
-        /**
-         * @param {string} host
-         * @returns {boolean}
-         */
-        function isLoopback(host) {
-          return host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '[::1]';
+        function r() {
+          return typeof crypto < `u` && typeof crypto.randomUUID == `function`
+            ? crypto.randomUUID()
+            : `${String(Date.now())}_${String(Math.random()).slice(2, 10)}`;
         }
-
-        /** @returns {WidgetConfig | null} */
-        function parseConfig() {
-          const hostOrigin = params.get('hostOrigin');
-          if (!hostOrigin) {
-            return null;
-          }
-
-          const hostUrl = params.get('hostUrl') || hostOrigin;
-          const hostTitle = params.get('hostTitle') || '';
-          const tabId = params.get('tabId') || createRequestId();
-          const relayHost = params.get('relayHost') || '127.0.0.1';
-          const relayPort = params.get('relayPort') || '9333';
-
-          if (!isLoopback(relayHost)) {
-            console.error(
-              '[webmcp-relay-widget] relayHost must be a loopback address, got:',
-              relayHost
-            );
-            return null;
-          }
-
-          return { hostOrigin, hostUrl, hostTitle, tabId, wsUrl: `ws://${relayHost}:${relayPort}` };
+        function i(e) {
+          return String(e).replace(/[\r\n]/g, ``);
         }
-
-        /**
-         * @param {unknown} value
-         * @returns {HostMessage | null}
-         */
-        function parseHostMessage(value) {
-          if (
-            !isJsonObject(value) ||
-            typeof value.requestId !== 'string' ||
-            typeof value.type !== 'string'
-          ) {
-            return null;
-          }
-          return {
-            requestId: value.requestId,
-            type: value.type,
-            tools: value.tools,
-            result: value.result,
-            error: value.error,
-          };
-        }
-
-        /**
-         * Sends data through a WebSocket, catching errors from closed/closing states.
-         * @param {WebSocket} ws
-         * @param {string} data
-         */
-        function safeSend(ws, data) {
+        function a(e, t) {
           try {
-            if (ws.readyState === WebSocket.OPEN) {
-              ws.send(data);
-            }
-          } catch (err) {
-            console.warn('[webmcp-relay-widget] Failed to send message:', err);
+            e.readyState === WebSocket.OPEN && e.send(t);
+          } catch (e) {
+            console.warn(`[webmcp-relay] Failed to send message:`, e);
           }
         }
-
-        const config = parseConfig();
-        if (!config) {
-          console.warn(
-            '[webmcp-relay-widget] Missing required hostOrigin parameter. Widget will not start.'
-          );
-          return;
+        function o(e) {
+          return `__webmcp_relay_endpoint:${[e.hostOrigin, e.relayId ?? ``, e.workspace ?? ``].map((e) => encodeURIComponent(e)).join(`:`)}`;
         }
-
-        /** @type {Map<string, PendingRequest>} */
-        const pendingRequests = new Map();
-        let reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
-        let reconnectAttempts = 0;
-        /** @type {WebSocket | null} */
-        let activeSocket = null;
-        let helloSent = false;
-
-        window.addEventListener('message', (event) => {
-          if (event.origin !== config.hostOrigin) {
-            return;
+        let s = 3e3,
+          c = [1e4, 2e4, 3e4],
+          l = c.length;
+        function u(e = window.location.search) {
+          let t = new URLSearchParams(e),
+            i = globalThis.__WEBMCP_RELAY_CONFIG;
+          function a(e) {
+            return t.get(e) ?? i?.[e] ?? null;
           }
-
-          const data = event.data;
-          if (isJsonObject(data) && data.type === 'webmcp.tools.changed') {
-            if (activeSocket && helloSent) {
-              safeSend(
-                activeSocket,
-                JSON.stringify({
-                  type: 'tools/changed',
-                  tools: Array.isArray(data.tools) ? data.tools : [],
-                })
-              );
-            }
-            return;
-          }
-
-          const message = parseHostMessage(data);
-          if (!message) {
-            return;
-          }
-
-          const pending = pendingRequests.get(message.requestId);
-          if (!pending) {
-            return;
-          }
-
-          if (message.type === pending.responseType) {
-            clearTimeout(pending.timeoutId);
-            pendingRequests.delete(message.requestId);
-            pending.resolve(message);
-            return;
-          }
-
-          if (message.type === pending.errorType) {
-            clearTimeout(pending.timeoutId);
-            pendingRequests.delete(message.requestId);
-            pending.reject(new Error(String(message.error || 'Unknown host error')));
-          }
-        });
-
-        /**
-         * @param {string} baseType
-         * @param {JsonObject} payload
-         * @returns {Promise<HostMessage>}
-         */
-        function requestHost(baseType, payload) {
-          const requestId = createRequestId();
-
-          return new Promise((resolve, reject) => {
-            const timeoutId = setTimeout(() => {
-              pendingRequests.delete(requestId);
-              reject(new Error(`Host response timeout: ${baseType}`));
-            }, REQUEST_TIMEOUT_MS);
-
-            pendingRequests.set(requestId, {
-              resolve,
-              reject,
-              timeoutId,
-              responseType: `${baseType}.response`,
-              errorType: `${baseType}.error`,
-            });
-
-            window.parent.postMessage(
-              { type: `${baseType}.request`, requestId, ...payload },
-              config.hostOrigin
+          let o = a(`hostOrigin`);
+          if (!o) return null;
+          let s = a(`hostUrl`) || o,
+            c = a(`hostTitle`) || ``,
+            l = a(`tabId`) || r(),
+            u = a(`relayHost`) || `127.0.0.1`,
+            d = a(`relayPort`),
+            f = d && d.length > 0 ? Number.parseInt(d, 10) : 9333,
+            p = a(`autoConnect`) !== `false`,
+            m = a(`relayId`) || void 0,
+            h = a(`relayWorkspace`) || void 0,
+            g = a(`requestTimeout`),
+            _ = g && g.length > 0 ? Number.parseInt(g, 10) : 6e4;
+          return n(u)
+            ? !Number.isInteger(f) || f < 1 || f > 65535
+              ? (console.error(
+                  `[webmcp-relay-widget] relayPort must be an integer between 1 and 65535, got:`,
+                  d
+                ),
+                null)
+              : !Number.isInteger(_) || _ < 1
+                ? (console.error(
+                    `[webmcp-relay-widget] requestTimeout must be a positive integer (ms), got:`,
+                    g
+                  ),
+                  null)
+                : {
+                    autoConnect: p,
+                    hostOrigin: o,
+                    hostTitle: c,
+                    hostUrl: s,
+                    relayHostHint: u,
+                    relayPortHint: f,
+                    ...(m ? { relayId: m } : {}),
+                    ...(h ? { relayWorkspace: h } : {}),
+                    requestTimeoutMs: _,
+                    tabId: l,
+                  }
+            : (console.error(`[webmcp-relay-widget] relayHost must be a loopback address, got:`, u),
+              null);
+        }
+        function d(e) {
+          return !t(e) || typeof e.requestId != `string` || typeof e.type != `string`
+            ? null
+            : {
+                requestId: e.requestId,
+                type: e.type,
+                tools: e.tools,
+                result: e.result,
+                error: e.error,
+              };
+        }
+        function f() {
+          let e = u();
+          if (!e) {
+            console.warn(
+              `[webmcp-relay-widget] Missing required hostOrigin parameter. Widget will not start.`
             );
+            return;
+          }
+          S(e);
+        }
+        function p(e) {
+          return !t(e) ||
+            e.type !== `server-hello` ||
+            e.service !== `webmcp-local-relay` ||
+            e.version !== 1 ||
+            typeof e.host != `string` ||
+            typeof e.instanceId != `string` ||
+            typeof e.port != `number`
+            ? null
+            : {
+                type: `server-hello`,
+                service: `webmcp-local-relay`,
+                version: 1,
+                host: e.host,
+                instanceId: e.instanceId,
+                port: e.port,
+                ...(typeof e.label == `string` ? { label: e.label } : {}),
+                ...(typeof e.relayId == `string` ? { relayId: e.relayId } : {}),
+                ...(typeof e.workspace == `string` ? { workspace: e.workspace } : {}),
+              };
+        }
+        function m(e) {
+          return !t(e) || e.type !== `hello/accepted` ? null : { type: `hello/accepted` };
+        }
+        function h(e) {
+          return !t(e) ||
+            e.type !== `hello/rejected` ||
+            typeof e.message != `string` ||
+            typeof e.reason != `string`
+            ? null
+            : { type: `hello/rejected`, message: e.message, reason: e.reason };
+        }
+        function g(e) {
+          return o({
+            hostOrigin: e.hostOrigin,
+            ...(e.relayId ? { relayId: e.relayId } : {}),
+            ...(e.relayWorkspace ? { workspace: e.relayWorkspace } : {}),
           });
         }
-
-        /** @param {WebSocket} socket */
-        function sendHelloAndTools(socket) {
-          requestHost('webmcp.tools.list', {})
-            .then((message) => {
-              const tools = Array.isArray(message.tools) ? message.tools : [];
-              safeSend(
-                socket,
-                JSON.stringify({
-                  type: 'hello',
-                  tabId: config.tabId,
-                  origin: config.hostOrigin,
-                  url: config.hostUrl,
-                  title: config.hostTitle || document.referrer || 'Unknown page',
-                })
-              );
-              safeSend(socket, JSON.stringify({ type: 'tools/list', tools }));
-              helloSent = true;
-            })
-            .catch((error) => {
-              console.warn('[webmcp-relay-widget] Hello handshake failed:', error);
-              socket.close();
-            });
-        }
-
-        /**
-         * @param {WebSocket} socket
-         * @param {unknown} rawMessage
-         */
-        function handleRelayMessage(socket, rawMessage) {
-          let relayMessage;
+        function _(e) {
+          if (typeof sessionStorage > `u`) return null;
           try {
-            relayMessage = JSON.parse(String(rawMessage));
-          } catch (parseError) {
-            console.warn('[webmcp-relay-widget] Failed to parse relay message:', parseError);
-            return;
+            let t = sessionStorage.getItem(g(e));
+            if (!t) return null;
+            let n = JSON.parse(t);
+            return typeof n.host != `string` ||
+              n.host.length === 0 ||
+              typeof n.port != `number` ||
+              !Number.isInteger(n.port) ||
+              n.port < 1 ||
+              n.port > 65535
+              ? null
+              : { host: n.host, port: n.port };
+          } catch {
+            return null;
           }
-
-          if (!isJsonObject(relayMessage) || typeof relayMessage.type !== 'string') {
-            console.debug('[webmcp-relay-widget] Ignoring non-object or untyped relay message');
-            return;
-          }
-
-          if (relayMessage.type === 'ping') {
-            safeSend(socket, JSON.stringify({ type: 'pong' }));
-            return;
-          }
-
-          if (relayMessage.type === 'reload') {
-            window.parent.postMessage({ type: 'webmcp.reload' }, config.hostOrigin);
-            return;
-          }
-
-          if (relayMessage.type !== 'invoke') {
-            console.debug(
-              '[webmcp-relay-widget] Ignoring unrecognized message type:',
-              String(relayMessage.type).replace(/[\r\n]/g, '')
-            );
-            return;
-          }
-
-          requestHost('webmcp.tools.invoke', {
-            toolName: relayMessage.toolName,
-            args: isJsonObject(relayMessage.args) ? relayMessage.args : {},
-          })
-            .then((hostResponse) => {
-              safeSend(
-                socket,
-                JSON.stringify({
-                  type: 'result',
-                  callId: relayMessage.callId,
-                  result: hostResponse.result,
-                })
-              );
-            })
-            .catch((error) => {
-              safeSend(
-                socket,
-                JSON.stringify({
-                  type: 'result',
-                  callId: relayMessage.callId,
-                  result: {
-                    isError: true,
-                    content: [
-                      {
-                        type: 'text',
-                        text: String(error instanceof Error ? error.message : error),
-                      },
-                    ],
-                  },
-                })
-              );
-            });
         }
-
-        function connect() {
-          const socket = new WebSocket(config.wsUrl);
-          activeSocket = socket;
-
-          socket.addEventListener('open', () => {
-            reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
-            reconnectAttempts = 0;
-            sendHelloAndTools(socket);
-          });
-
-          socket.addEventListener('message', (event) => {
-            handleRelayMessage(socket, event.data);
-          });
-
-          socket.addEventListener('close', () => {
-            helloSent = false;
-            activeSocket = null;
-
-            for (const [requestId, pending] of pendingRequests) {
-              clearTimeout(pending.timeoutId);
-              pendingRequests.delete(requestId);
-              pending.reject(new Error('WebSocket connection lost'));
-            }
-
-            reconnectAttempts++;
-            if (reconnectAttempts % 10 === 0) {
-              console.warn(
-                `[webmcp-relay-widget] Still reconnecting after ${reconnectAttempts} attempts (delay: ${reconnectDelayMs}ms)`
-              );
-            }
-            setTimeout(connect, reconnectDelayMs);
-            reconnectDelayMs = Math.min(reconnectDelayMs * 1.5, RECONNECT_MAX_DELAY_MS);
-          });
-
-          socket.addEventListener('error', (event) => {
-            console.warn('[webmcp-relay-widget] WebSocket error:', event);
+        function v(e, t) {
+          if (!(typeof sessionStorage > `u`))
             try {
-              socket.close();
-            } catch (closeErr) {
-              console.warn('[webmcp-relay-widget] Error closing socket after error:', closeErr);
-            }
+              sessionStorage.setItem(g(e), JSON.stringify({ host: t.host, port: t.port }));
+            } catch {}
+        }
+        function y(e) {
+          if (!(typeof sessionStorage > `u`))
+            try {
+              sessionStorage.removeItem(g(e));
+            } catch {}
+        }
+        function b(e) {
+          let t = _(e),
+            n = new Set(),
+            r = [],
+            i = (e, t) => {
+              if (!Number.isInteger(t) || t < 1 || t > 65535) return;
+              let i = `${e}:${String(t)}`;
+              n.has(i) || (n.add(i), r.push({ host: e, port: t }));
+            };
+          (e.relayPortHint !== void 0 && i(e.relayHostHint, e.relayPortHint),
+            t && i(t.host, t.port));
+          for (let e of [`127.0.0.1`, `[::1]`]) for (let t = 9333; t <= 9348; t += 1) i(e, t);
+          return r;
+        }
+        async function x(e) {
+          let t = `ws://${e.host}:${String(e.port)}`;
+          return new Promise((n) => {
+            let r = !1,
+              i = new WebSocket(t, [`webmcp-discovery.v1`, `webmcp.v1`]),
+              a = (e) => {
+                if (!r) {
+                  if (
+                    ((r = !0),
+                    clearTimeout(l),
+                    i.removeEventListener(`close`, s),
+                    i.removeEventListener(`error`, o),
+                    i.removeEventListener(`message`, c),
+                    e === null)
+                  )
+                    try {
+                      i.close();
+                    } catch {}
+                  n(e);
+                }
+              },
+              o = () => {
+                a(null);
+              },
+              s = () => {
+                a(null);
+              },
+              c = (t) => {
+                let n;
+                try {
+                  n = JSON.parse(String(t.data));
+                } catch {
+                  return;
+                }
+                let r = p(n);
+                r && a({ endpoint: { hello: r, host: e.host, port: e.port }, socket: i });
+              },
+              l = setTimeout(() => {
+                a(null);
+              }, 1200);
+            (i.addEventListener(`close`, s, { once: !0 }),
+              i.addEventListener(`error`, o, { once: !0 }),
+              i.addEventListener(`message`, c));
           });
         }
-
-        connect();
+        function S(e) {
+          let n = new Map(),
+            o = null,
+            u = null,
+            f = 0,
+            g = !1,
+            S = null,
+            C = 500,
+            w = null,
+            T = `idle`,
+            E = 0,
+            D = null,
+            O = (e) => {
+              for (let [t, r] of n) (clearTimeout(r.timeoutId), n.delete(t), r.reject(Error(e)));
+            },
+            k = (e) => {
+              T = e;
+            };
+          function A(t, i) {
+            let a = r();
+            return new Promise((r, o) => {
+              let s = setTimeout(() => {
+                (n.delete(a), o(Error(`Host response timeout: ${t}`)));
+              }, e.requestTimeoutMs);
+              (n.set(a, {
+                resolve: r,
+                reject: o,
+                timeoutId: s,
+                responseType: `${t}.response`,
+                errorType: `${t}.error`,
+              }),
+                window.parent.postMessage(
+                  { type: `${t}.request`, requestId: a, ...i },
+                  e.hostOrigin
+                ));
+            });
+          }
+          let j = (n, r) => {
+              let s = [],
+                c = () => {
+                  S && (clearTimeout(S), (S = null));
+                },
+                l = () => {
+                  a(n, JSON.stringify({ type: `tools/list`, tools: s }));
+                };
+              (w && (clearTimeout(w), (w = null)),
+                (o = r),
+                (u = n),
+                (C = 500),
+                (E = 0),
+                (g = !1),
+                k(`connected`),
+                n.addEventListener(`message`, (s) => {
+                  let u;
+                  try {
+                    u = JSON.parse(String(s.data));
+                  } catch (e) {
+                    console.warn(`[webmcp-relay-widget] Failed to parse relay message:`, e);
+                    return;
+                  }
+                  let d = p(u);
+                  if (d) {
+                    o = { hello: d, host: r.host, port: r.port };
+                    return;
+                  }
+                  if (m(u)) {
+                    (c(), (g = !0), v(e, r), l());
+                    return;
+                  }
+                  let f = h(u);
+                  if (f) {
+                    (c(),
+                      (g = !1),
+                      y(e),
+                      window.parent.postMessage(
+                        {
+                          type: `webmcp.relay.rejected`,
+                          host: r.host,
+                          port: r.port,
+                          message: f.message,
+                          reason: f.reason,
+                        },
+                        e.hostOrigin
+                      ),
+                      console.error(
+                        `[webmcp-relay-widget] Relay rejected browser hello:`,
+                        f.reason,
+                        f.message
+                      ));
+                    try {
+                      n.close(1008, f.message);
+                    } catch {}
+                    return;
+                  }
+                  if (!t(u) || typeof u.type != `string`) {
+                    console.debug(
+                      `[webmcp-relay-widget] Ignoring non-object or untyped relay message`
+                    );
+                    return;
+                  }
+                  if (u.type === `ping`) {
+                    a(n, JSON.stringify({ type: `pong` }));
+                    return;
+                  }
+                  if (u.type === `reload`) {
+                    window.parent.postMessage({ type: `webmcp.reload` }, e.hostOrigin);
+                    return;
+                  }
+                  if (u.type === `elicitation-response`) {
+                    window.parent.postMessage(
+                      {
+                        type: `webmcp.elicitation.response`,
+                        callId: u.callId,
+                        result: t(u.result) ? u.result : { action: `decline`, content: null },
+                      },
+                      e.hostOrigin
+                    );
+                    return;
+                  }
+                  if (u.type !== `invoke`) {
+                    console.debug(
+                      `[webmcp-relay-widget] Ignoring unrecognized message type:`,
+                      i(u.type)
+                    );
+                    return;
+                  }
+                  A(`webmcp.tools.invoke`, { toolName: u.toolName, args: t(u.args) ? u.args : {} })
+                    .then((e) => {
+                      a(n, JSON.stringify({ type: `result`, callId: u.callId, result: e.result }));
+                    })
+                    .catch((e) => {
+                      a(
+                        n,
+                        JSON.stringify({
+                          type: `result`,
+                          callId: u.callId,
+                          result: {
+                            isError: !0,
+                            content: [
+                              { type: `text`, text: String(e instanceof Error ? e.message : e) },
+                            ],
+                          },
+                        })
+                      );
+                    });
+                }),
+                n.addEventListener(
+                  `close`,
+                  () => {
+                    if (u === n) {
+                      if (
+                        ((g = !1),
+                        (u = null),
+                        c(),
+                        O(`WebSocket connection lost`),
+                        (f += 1),
+                        f >= 5)
+                      ) {
+                        ((f = 0), F());
+                        return;
+                      }
+                      P();
+                    }
+                  },
+                  { once: !0 }
+                ),
+                n.addEventListener(`error`, (e) => {
+                  console.warn(`[webmcp-relay-widget] WebSocket error:`, e);
+                  try {
+                    n.close();
+                  } catch (e) {
+                    console.warn(`[webmcp-relay-widget] Error closing socket after error:`, e);
+                  }
+                }),
+                A(`webmcp.tools.list`, {})
+                  .then((t) => {
+                    ((s = Array.isArray(t.tools) ? t.tools : []),
+                      a(
+                        n,
+                        JSON.stringify({
+                          type: `hello`,
+                          tabId: e.tabId,
+                          origin: e.hostOrigin,
+                          title: e.hostTitle || document.referrer || `Unknown page`,
+                          url: e.hostUrl,
+                        })
+                      ),
+                      (S = setTimeout(() => {
+                        ((S = null),
+                          !(u !== n || n.readyState !== WebSocket.OPEN || g) &&
+                            ((g = !0), v(e, r), l()));
+                      }, 250)));
+                  })
+                  .catch((e) => {
+                    console.warn(`[webmcp-relay-widget] Hello handshake failed:`, e);
+                    try {
+                      n.close();
+                    } catch {}
+                  }));
+            },
+            M = async (t) => {
+              let n = await x({ host: t.host, port: t.port });
+              if (!n) return !1;
+              let r = n.endpoint;
+              return (e.relayId && r.hello.relayId !== e.relayId) ||
+                (e.relayWorkspace && r.hello.workspace !== e.relayWorkspace)
+                ? (n.socket.close(), !1)
+                : (j(n.socket, r), !0);
+            },
+            N = async () => {
+              k(`discovering`);
+              for (let t of b(e)) if (await M(t)) return ((f = 0), !0);
+              return !1;
+            },
+            P = () => {
+              if (!o || w) return;
+              k(`retry-same-endpoint`);
+              let e = { host: o.host, port: o.port },
+                t = Math.min(s, Math.round(C * (0.85 + Math.random() * 0.3)));
+              ((C = Math.min(Math.round(C * 1.5), s)),
+                (w = setTimeout(() => {
+                  ((w = null),
+                    M(e).then((e) => {
+                      if (e) {
+                        f = 0;
+                        return;
+                      }
+                      if (f >= 5) {
+                        ((f = 0), F());
+                        return;
+                      }
+                      P();
+                    }));
+                }, t)));
+            },
+            F = () => {
+              if (w) return;
+              if (E >= l) {
+                z();
+                return;
+              }
+              k(`rediscover`);
+              let e = c[E];
+              w = setTimeout(() => {
+                ((w = null),
+                  N().then((e) => {
+                    e || ((E += 1), F());
+                  }));
+              }, e);
+            },
+            I = () => {
+              document.visibilityState === `visible` && T === `dormant` && V();
+            },
+            L = () => {
+              T === `dormant` && V();
+            },
+            R = () => {
+              (document.removeEventListener(`visibilitychange`, I),
+                window.removeEventListener(`online`, L),
+                D !== null && (clearInterval(D), (D = null)));
+            },
+            z = () => {
+              T !== `dormant` &&
+                (k(`dormant`),
+                w && (clearTimeout(w), (w = null)),
+                document.addEventListener(`visibilitychange`, I),
+                window.addEventListener(`online`, L),
+                (D = setInterval(() => {
+                  B();
+                }, 12e4)));
+            },
+            B = async () => {
+              if (T !== `dormant`) return;
+              let t = new Set(),
+                n = [],
+                r = (e, r) => {
+                  let i = `${e}:${String(r)}`;
+                  t.has(i) || (t.add(i), n.push({ host: e, port: r }));
+                };
+              e.relayPortHint !== void 0 && r(e.relayHostHint, e.relayPortHint);
+              let i = _(e);
+              if ((i && r(i.host, i.port), n.length !== 0)) {
+                (k(`discovering`), R());
+                for (let e of n)
+                  if (await M(e)) {
+                    E = 0;
+                    return;
+                  }
+                z();
+              }
+            },
+            V = () => {
+              (R(),
+                (C = 500),
+                (E = 0),
+                N().then((e) => {
+                  e || z();
+                }));
+            };
+          (window.addEventListener(`message`, (r) => {
+            if (r.origin !== e.hostOrigin) return;
+            let i = r.data;
+            if (t(i) && i.type === `webmcp.tools.changed`) {
+              u &&
+                g &&
+                a(
+                  u,
+                  JSON.stringify({
+                    type: `tools/changed`,
+                    tools: Array.isArray(i.tools) ? i.tools : [],
+                  })
+                );
+              return;
+            }
+            if (t(i) && i.type === `webmcp.connect`) {
+              T === `dormant` ? V() : !u && T !== `discovering` && N();
+              return;
+            }
+            if (t(i) && i.type === `webmcp.elicitation.request`) {
+              u &&
+                u.readyState === WebSocket.OPEN &&
+                a(
+                  u,
+                  JSON.stringify({
+                    type: `elicitation-request`,
+                    callId: i.callId,
+                    params: t(i.params) ? i.params : {},
+                  })
+                );
+              return;
+            }
+            let o = d(i);
+            if (!o) return;
+            let s = n.get(o.requestId);
+            if (s) {
+              if (o.type === s.responseType) {
+                (clearTimeout(s.timeoutId), n.delete(o.requestId), s.resolve(o));
+                return;
+              }
+              o.type === s.errorType &&
+                (clearTimeout(s.timeoutId),
+                n.delete(o.requestId),
+                s.reject(Error(String(o.error || `Unknown host error`))));
+            }
+          }),
+            e.autoConnect
+              ? N().then((e) => {
+                  e || F();
+                })
+              : k(`idle`));
+        }
+        f();
       })();
     </script>
   </body>

--- a/packages/webmcp-local-relay/src/bridgeServer.test.ts
+++ b/packages/webmcp-local-relay/src/bridgeServer.test.ts
@@ -1881,4 +1881,81 @@ describe('RelayBridgeServer client mode', () => {
       await server.stop();
     }
   });
+
+  it('emits stateChanged only once when socket error triggers both error and close', async () => {
+    const bridge = new RelayBridgeServer({
+      host: '127.0.0.1',
+      port: 0,
+      allowedOrigins: ['*'],
+    });
+
+    try {
+      await bridge.start();
+
+      const ws = await connectAndRegister(bridge, {
+        tabId: 'tab-double-close',
+        url: 'https://example.com',
+        tools: [{ name: 'tool_a', description: 'A tool' }],
+      });
+
+      await waitFor(() => bridge.registry.listTools()[0]?.name);
+
+      let stateChangedCount = 0;
+      bridge.on('stateChanged', () => {
+        stateChangedCount++;
+      });
+
+      ws.terminate();
+
+      await waitFor(() => (bridge.registry.listSources().length === 0 ? true : undefined));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(stateChangedCount).toBe(1);
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  it('rejects pending invocations with payload-exceeded error when browser sends oversized result', async () => {
+    // Use a tiny maxPayloadBytes to trigger the 1009 close code.
+    const server = new RelayBridgeServer({
+      host: '127.0.0.1',
+      port: 0,
+      allowedOrigins: ['*'],
+      maxPayloadBytes: 256,
+      invokeTimeoutMs: 5000,
+    });
+
+    try {
+      await server.start();
+
+      const ws = await connectAndRegister(server, {
+        tabId: 'tab-payload',
+        url: 'https://example.com',
+        tools: [{ name: 'big_response', description: 'Returns large data' }],
+      });
+
+      // When invoked, respond with a payload that exceeds maxPayloadBytes.
+      ws.on('message', (raw) => {
+        const msg = JSON.parse(String(raw));
+        if (msg.type !== 'invoke') return;
+        const oversizedText = 'x'.repeat(1024);
+        ws.send(
+          JSON.stringify({
+            type: 'result',
+            callId: msg.callId,
+            result: { content: [{ type: 'text', text: oversizedText }] },
+          })
+        );
+      });
+
+      await waitFor(() => (server.registry.listTools().length >= 1 ? true : undefined));
+
+      const invokePromise = server.invokeTool('big_response', {});
+
+      await expect(invokePromise).rejects.toThrow(/exceeded maximum payload size/);
+    } finally {
+      await server.stop();
+    }
+  });
 });

--- a/packages/webmcp-local-relay/src/bridgeServer.ts
+++ b/packages/webmcp-local-relay/src/bridgeServer.ts
@@ -96,7 +96,7 @@ export interface RelayBridgeServerOptions {
   allowedOrigins?: string[];
   /**
    * Maximum WebSocket payload size in bytes.
-   * @defaultValue `1000000`
+   * @defaultValue `10000000`
    */
   maxPayloadBytes?: number;
   /**
@@ -192,7 +192,9 @@ export class RelayBridgeServer extends EventEmitter {
       options.portRangeEnd ?? Math.max(DEFAULT_RELAY_PORT_RANGE_END, this.preferredPort);
     this.persistPath = options.persistPath ?? defaultRelayPortPersistPath();
     this.allowedOrigins = options.allowedOrigins ?? ['*'];
-    this.maxPayloadBytes = options.maxPayloadBytes ?? 1_000_000;
+    // 10MB default — large enough for typical JSON API responses while
+    // still protecting the relay process from unbounded memory growth.
+    this.maxPayloadBytes = options.maxPayloadBytes ?? 10_000_000;
     this.invokeTimeoutMs = options.invokeTimeoutMs ?? 25_000;
     this.label = options.label;
     this.workspace = options.workspace;
@@ -505,15 +507,18 @@ export class RelayBridgeServer extends EventEmitter {
         this.onSocketMessage(connectionId, raw);
       });
 
-      socket.on('close', () => {
-        this.onSocketClose(connectionId);
+      socket.on('close', (code: number) => {
+        this.onSocketClose(connectionId, code);
       });
 
       socket.on('error', (err: Error) => {
         process.stderr.write(
           `[webmcp-local-relay] warn: socket error for connection ${connectionId}: ${err.message}\n`
         );
-        this.onSocketClose(connectionId);
+        // ws sets err.code = 'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH' when payload
+        // exceeds maxPayload. Pass 1009 so onSocketClose surfaces a clear error.
+        const code = (err as any).code === 'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH' ? 1009 : undefined;
+        this.onSocketClose(connectionId, code);
       });
 
       this.startHeartbeat(connectionId);
@@ -887,13 +892,25 @@ export class RelayBridgeServer extends EventEmitter {
 
   /**
    * Handles source disconnection and rejects in-flight calls owned by that source.
+   *
+   * Guarded against double-call: both 'error' and 'close' events fire on
+   * socket failure, but cleanup (and the stateChanged emission) runs only once.
    */
-  private onSocketClose(connectionId: string): void {
+  private onSocketClose(connectionId: string, code?: number): void {
+    // Guard against double invocation — ws fires both 'error' and 'close' for
+    // maxPayload violations. The second call is a no-op.
+    if (!this.socketByConnectionId.has(connectionId)) return;
+
     this.stopHeartbeat(connectionId);
     this.relayClientConnectionIds.delete(connectionId);
     this.registry.removeConnection(connectionId);
     this.socketByConnectionId.delete(connectionId);
     this.emit('stateChanged');
+
+    // WS close code 1009 = "Message Too Big" — the browser sent a response
+    // that exceeded maxPayloadBytes. Surface a clear error instead of letting
+    // the invocation time out silently after invokeTimeoutMs.
+    const isPayloadExceeded = code === 1009;
 
     for (const [callId, pending] of this.pendingInvocations.entries()) {
       if (pending.connectionId !== connectionId) {
@@ -902,7 +919,20 @@ export class RelayBridgeServer extends EventEmitter {
 
       clearTimeout(pending.timeoutId);
       this.pendingInvocations.delete(callId);
-      pending.reject(new Error(`Tool source ${connectionId} disconnected during invocation`));
+
+      if (isPayloadExceeded) {
+        const limitDisplay =
+          this.maxPayloadBytes >= 1_000_000
+            ? `${Math.floor(this.maxPayloadBytes / 1_000_000)}MB`
+            : `${this.maxPayloadBytes} bytes`;
+        pending.reject(
+          new Error(
+            `Tool result exceeded maximum payload size (${limitDisplay}). Use --max-payload to increase the limit.`
+          )
+        );
+      } else {
+        pending.reject(new Error(`Tool source ${connectionId} disconnected during invocation`));
+      }
     }
   }
 

--- a/packages/webmcp-local-relay/src/browser/embed.test.ts
+++ b/packages/webmcp-local-relay/src/browser/embed.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createToolReconciler, type RelayToolDescriptor } from './reconciler.js';
+
+/**
+ * Integration tests for the embed tool-sync wiring.
+ *
+ * embed.ts is a side-effect module that runs on import and depends on
+ * document.currentScript (only valid during script parsing). Rather than
+ * fighting these constraints with brittle import mocks, we test the
+ * integration contract:
+ *
+ * 1. The reconciler (tested exhaustively in reconciler.test.ts) is the
+ *    single source of truth for tool list changes.
+ * 2. embed.ts wires event sources → reconciler.scheduleReconcile()
+ * 3. embed.ts wires reconciler.onChanged → postMessage to widget
+ *
+ * Tests below verify the wiring logic that embed.ts performs, using the
+ * real reconciler and simulated event sources.
+ */
+
+describe('embed integration: event-to-reconciler wiring', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('toolchange event triggers reconcile and notifies on change', async () => {
+    const postMessage = vi.fn();
+    let tools: RelayToolDescriptor[] = [{ name: 'initial', description: 'Already registered' }];
+
+    const reconciler = createToolReconciler({
+      listTools: () => tools,
+      onChanged: (t) => postMessage({ type: 'webmcp.tools.changed', tools: t }),
+    });
+
+    // Simulate what embed.ts does: bind event → scheduleReconcile
+    const toolchangeHandler = () => reconciler.scheduleReconcile();
+
+    // Initial reconcile (embed.ts calls this on startup)
+    reconciler.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(1);
+    // Non-empty initial list differs from internal "" snapshot — triggers onChanged
+    expect(postMessage).toHaveBeenCalledTimes(1);
+
+    // Tool registered — event fires
+    tools = [
+      { name: 'initial', description: 'Already registered' },
+      { name: 'search', description: 'Search the web', inputSchema: { type: 'object' } },
+    ];
+    toolchangeHandler();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(postMessage).toHaveBeenCalledTimes(2);
+    expect(postMessage).toHaveBeenLastCalledWith({
+      type: 'webmcp.tools.changed',
+      tools: [
+        { name: 'initial', description: 'Already registered' },
+        { name: 'search', description: 'Search the web', inputSchema: { type: 'object' } },
+      ],
+    });
+  });
+
+  it('tool unregistered via AbortSignal detected by polling', async () => {
+    const postMessage = vi.fn();
+    let tools: RelayToolDescriptor[] = [
+      { name: 'tool-a', description: 'A' },
+      { name: 'tool-b', description: 'B' },
+    ];
+
+    const reconciler = createToolReconciler({
+      listTools: () => tools,
+      onChanged: (t) => postMessage({ type: 'webmcp.tools.changed', tools: t }),
+      pollInterval: 2000,
+    });
+
+    // Startup
+    reconciler.startPolling();
+    reconciler.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+
+    // Tool removed (AbortSignal — no event fires)
+    tools = [{ name: 'tool-a', description: 'A' }];
+
+    // Poll fires after 2000ms
+    await vi.advanceTimersByTimeAsync(2001);
+    expect(postMessage).toHaveBeenCalledTimes(2);
+    expect(postMessage).toHaveBeenLastCalledWith({
+      type: 'webmcp.tools.changed',
+      tools: [{ name: 'tool-a', description: 'A' }],
+    });
+
+    reconciler.dispose();
+  });
+
+  it('description/schema change detected without name change', async () => {
+    const postMessage = vi.fn();
+    let tools: RelayToolDescriptor[] = [
+      { name: 'api', description: 'v1', inputSchema: { type: 'object', properties: {} } },
+    ];
+
+    const reconciler = createToolReconciler({
+      listTools: () => tools,
+      onChanged: (t) => postMessage({ type: 'webmcp.tools.changed', tools: t }),
+      pollInterval: 2000,
+    });
+
+    reconciler.startPolling();
+    reconciler.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+
+    // Same name, different description and schema
+    tools = [
+      {
+        name: 'api',
+        description: 'v2',
+        inputSchema: { type: 'object', properties: { query: { type: 'string' } } },
+      },
+    ];
+
+    await vi.advanceTimersByTimeAsync(2001);
+    expect(postMessage).toHaveBeenCalledTimes(2);
+
+    reconciler.dispose();
+  });
+
+  it('debounces multiple scheduleReconcile calls within the same tick', async () => {
+    const listTools = vi.fn(() => [{ name: 'x', description: 'd' }] as RelayToolDescriptor[]);
+    const postMessage = vi.fn();
+
+    const reconciler = createToolReconciler({
+      listTools,
+      onChanged: (t) => postMessage({ type: 'webmcp.tools.changed', tools: t }),
+    });
+
+    // Multiple events fire in the same tick (before setTimeout resolves)
+    reconciler.scheduleReconcile();
+    reconciler.scheduleReconcile();
+    reconciler.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(1);
+
+    // listTools should only be called once due to debounce
+    expect(listTools).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('non-exclusive subscription: both modelContext and modelContextTesting can trigger reconcile', async () => {
+    const postMessage = vi.fn();
+    let callCount = 0;
+    const tools: RelayToolDescriptor[] = [{ name: 'tool', description: 'test' }];
+
+    const reconciler = createToolReconciler({
+      listTools: () => {
+        callCount++;
+        return tools;
+      },
+      onChanged: (t) => postMessage({ type: 'webmcp.tools.changed', tools: t }),
+    });
+
+    // Simulate two independent event sources (what embed.ts does)
+    const mcHandler = () => reconciler.scheduleReconcile();
+    const testingHandler = () => reconciler.scheduleReconcile();
+
+    // Both fire in the same tick (as would happen with non-exclusive subscription)
+    mcHandler();
+    testingHandler();
+    await vi.advanceTimersByTimeAsync(1);
+
+    // Debounce ensures only one reconcile
+    expect(callCount).toBe(1);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/webmcp-local-relay/src/browser/embed.ts
+++ b/packages/webmcp-local-relay/src/browser/embed.ts
@@ -18,21 +18,14 @@ import type {
   ToolListItem,
 } from '@mcp-b/webmcp-types';
 import { isJsonObject } from './shared.js';
+import {
+  createToolReconciler,
+  type RelayToolDescriptor,
+  type ToolReconciler,
+} from './reconciler.js';
 
 /** Loose JSON object — values aren't recursively typed since we just forward them. */
 type JsonObject = Record<string, unknown>;
-
-/**
- * Minimal tool shape sent to the relay widget — just name, description, and
- * a JSON-object inputSchema. Intentionally looser than ToolListItem so both
- * modelContext (ToolListItem) and modelContextTesting (string schema) can
- * be normalised into the same shape.
- */
-interface RelayToolDescriptor {
-  name: string;
-  description?: string;
-  inputSchema?: JsonObject;
-}
 
 interface ToolBridge {
   listTools: () => RelayToolDescriptor[] | Promise<RelayToolDescriptor[]>;
@@ -245,87 +238,105 @@ function getToolBridge(): ToolBridge | null {
   return null;
 }
 
-let pushScheduled = false;
+let reconciler: ToolReconciler | null = null;
 
-function onToolsChanged(): void {
-  if (pushScheduled || !widgetWindow) return;
-  pushScheduled = true;
-  setTimeout(() => {
-    pushScheduled = false;
-    if (!widgetWindow) return;
-    const bridge = getToolBridge();
-    const toolsPromise = bridge ? Promise.resolve(bridge.listTools()) : Promise.resolve([]);
-    toolsPromise
-      .then((tools) => {
-        if (!widgetWindow) return;
-        widgetWindow.postMessage(
-          {
-            type: 'webmcp.tools.changed',
-            tools: Array.isArray(tools) ? tools : [],
-          },
-          config.widgetOrigin
-        );
-      })
-      .catch((err: unknown) => {
-        debugWarn('Failed to push tool changes:', err);
-      });
-  }, 0);
+function initReconciler(): void {
+  reconciler = createToolReconciler({
+    listTools() {
+      const bridge = getToolBridge();
+      return bridge ? bridge.listTools() : [];
+    },
+    onChanged(tools) {
+      if (!widgetWindow) return;
+      widgetWindow.postMessage({ type: 'webmcp.tools.changed', tools }, config.widgetOrigin);
+    },
+  });
 }
 
+// Subscribe on BOTH modelContext and modelContextTesting (non-exclusive).
+// Chrome native fires toolchange on modelContextTesting; the polyfill fires on
+// modelContext. We subscribe to all available surfaces so no event is missed.
 function trySubscribe(): boolean {
+  if (!reconciler) return false;
+  let subscribed = false;
+
   const mc = getExtendedModelContext();
   if (mc) {
     try {
-      mc.addEventListener('toolchange', onToolsChanged);
-      return true;
+      mc.addEventListener('toolchange', () => reconciler!.scheduleReconcile());
+      subscribed = true;
     } catch (error) {
-      debugWarn('addEventListener threw:', error);
+      debugWarn('addEventListener on modelContext threw:', error);
     }
   }
+
   const testing = navigator.modelContextTesting as
     | (typeof navigator.modelContextTesting & Partial<ModelContextTestingPolyfillExtensions>)
     | undefined;
-  if (testing && typeof testing.registerToolsChangedCallback === 'function') {
-    try {
-      testing.registerToolsChangedCallback(onToolsChanged);
-      return true;
-    } catch (error) {
-      debugWarn('Failed to subscribe via registerToolsChangedCallback:', error);
+  if (testing) {
+    if (typeof testing.addEventListener === 'function') {
+      try {
+        testing.addEventListener('toolchange', () => reconciler!.scheduleReconcile());
+        subscribed = true;
+      } catch (error) {
+        debugWarn('addEventListener on modelContextTesting threw:', error);
+      }
+    } else if (typeof testing.registerToolsChangedCallback === 'function') {
+      try {
+        testing.registerToolsChangedCallback(() => reconciler!.scheduleReconcile());
+        subscribed = true;
+      } catch (error) {
+        debugWarn('Failed to subscribe via registerToolsChangedCallback:', error);
+      }
     }
   }
-  return false;
+
+  return subscribed;
 }
 
+// Polling fallback: Chrome 148+ removed unregisterTool(); tools are removed via
+// AbortSignal only, which does NOT fire a toolchange event. Polling every 2s
+// ensures we still detect those silent removals within a bounded delay.
 function subscribeToToolChanges(): void {
-  if (trySubscribe()) {
+  initReconciler();
+
+  if (!trySubscribe()) {
+    let retries = 0;
+    let retryDelayMs = 100;
+    const MAX_RETRIES = 40;
+    const MAX_RETRY_DELAY_MS = 1000;
+
+    // Runtime may not be initialized yet (e.g. async script loading). Retry
+    // with exponential backoff until modelContext/modelContextTesting appears.
+    const scheduleRetry = (): void => {
+      setTimeout(() => {
+        retries++;
+        if (trySubscribe()) {
+          reconciler!.startPolling();
+          reconciler!.scheduleReconcile();
+          return;
+        }
+
+        if (retries >= MAX_RETRIES) {
+          debugWarn(
+            `Could not subscribe to tool changes after ${MAX_RETRIES} retries. Dynamic tool updates will not be relayed.`
+          );
+          reconciler!.startPolling();
+          reconciler!.scheduleReconcile();
+          return;
+        }
+
+        retryDelayMs = Math.min(Math.round(retryDelayMs * 1.5), MAX_RETRY_DELAY_MS);
+        scheduleRetry();
+      }, retryDelayMs);
+    };
+
+    scheduleRetry();
     return;
   }
 
-  let retries = 0;
-  let retryDelayMs = 100;
-  const MAX_RETRIES = 40;
-  const MAX_RETRY_DELAY_MS = 1000;
-
-  const scheduleRetry = (): void => {
-    setTimeout(() => {
-      retries++;
-      if (trySubscribe()) {
-        return;
-      }
-
-      if (retries >= MAX_RETRIES) {
-        debugWarn(
-          `Could not subscribe to tool changes after ${MAX_RETRIES} retries. Dynamic tool updates will not be relayed.`
-        );
-        return;
-      }
-
-      retryDelayMs = Math.min(Math.round(retryDelayMs * 1.5), MAX_RETRY_DELAY_MS);
-      scheduleRetry();
-    }, retryDelayMs);
-  };
-
-  scheduleRetry();
+  reconciler!.startPolling();
+  reconciler!.scheduleReconcile();
 }
 
 function respondToSource(
@@ -619,4 +630,13 @@ if (!document.querySelector(RELAY_IFRAME_SELECTOR)) {
   }
 
   subscribeToToolChanges();
+
+  // Blob URL iframes do not receive visibilitychange events from the browser.
+  // Listen on the host page and forward to the widget iframe via postMessage
+  // so it can wake from dormant state when the tab becomes visible again.
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible' && widgetWindow) {
+      widgetWindow.postMessage({ type: 'webmcp.connect' }, config.widgetOrigin);
+    }
+  });
 }

--- a/packages/webmcp-local-relay/src/browser/reconciler.test.ts
+++ b/packages/webmcp-local-relay/src/browser/reconciler.test.ts
@@ -1,0 +1,229 @@
+// packages/webmcp-local-relay/src/browser/reconciler.test.ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createSnapshot,
+  createToolReconciler,
+  stableStringify,
+  type RelayToolDescriptor,
+} from './reconciler.js';
+
+describe('stableStringify', () => {
+  it('sorts object keys recursively', () => {
+    const obj = { b: 1, a: { d: 2, c: 3 } };
+    expect(stableStringify(obj)).toBe('{"a":{"c":3,"d":2},"b":1}');
+  });
+
+  it('handles arrays without reordering', () => {
+    expect(stableStringify([3, 1, 2])).toBe('[3,1,2]');
+  });
+
+  it('handles null and primitives', () => {
+    expect(stableStringify(null)).toBe('null');
+    expect(stableStringify('hello')).toBe('"hello"');
+    expect(stableStringify(42)).toBe('42');
+    expect(stableStringify(true)).toBe('true');
+  });
+});
+
+describe('createSnapshot', () => {
+  it('sorts tools by name', () => {
+    const tools: RelayToolDescriptor[] = [
+      { name: 'zeta', description: 'z' },
+      { name: 'alpha', description: 'a' },
+    ];
+    const snapshot = createSnapshot(tools);
+    expect(snapshot.indexOf('alpha')).toBeLessThan(snapshot.indexOf('zeta'));
+  });
+
+  it('produces identical output for same tools in different order', () => {
+    const a: RelayToolDescriptor[] = [
+      { name: 'foo', description: 'f', inputSchema: { type: 'object' } },
+      { name: 'bar', description: 'b' },
+    ];
+    const b: RelayToolDescriptor[] = [
+      { name: 'bar', description: 'b' },
+      { name: 'foo', description: 'f', inputSchema: { type: 'object' } },
+    ];
+    expect(createSnapshot(a)).toBe(createSnapshot(b));
+  });
+
+  it('differs when description changes', () => {
+    const v1: RelayToolDescriptor[] = [{ name: 'tool', description: 'v1' }];
+    const v2: RelayToolDescriptor[] = [{ name: 'tool', description: 'v2' }];
+    expect(createSnapshot(v1)).not.toBe(createSnapshot(v2));
+  });
+
+  it('differs when inputSchema changes', () => {
+    const v1: RelayToolDescriptor[] = [
+      { name: 'tool', inputSchema: { type: 'object', properties: { a: { type: 'string' } } } },
+    ];
+    const v2: RelayToolDescriptor[] = [
+      { name: 'tool', inputSchema: { type: 'object', properties: { a: { type: 'number' } } } },
+    ];
+    expect(createSnapshot(v1)).not.toBe(createSnapshot(v2));
+  });
+});
+
+describe('createToolReconciler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('triggers onChanged when tools change', async () => {
+    const onChanged = vi.fn();
+    const tools: RelayToolDescriptor[] = [{ name: 'test', description: 'desc' }];
+
+    const r = createToolReconciler({ listTools: () => tools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    expect(onChanged).toHaveBeenCalledWith(tools);
+  });
+
+  it('does not trigger onChanged when tools are unchanged', async () => {
+    const onChanged = vi.fn();
+    const tools: RelayToolDescriptor[] = [{ name: 'test', description: 'desc' }];
+
+    const r = createToolReconciler({ listTools: () => tools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('triggers onChanged when only description changes', async () => {
+    const onChanged = vi.fn();
+    let tools: RelayToolDescriptor[] = [{ name: 'foo', description: 'v1' }];
+
+    const r = createToolReconciler({ listTools: () => tools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    tools = [{ name: 'foo', description: 'v2' }];
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(2);
+  });
+
+  it('triggers onChanged when only inputSchema changes', async () => {
+    const onChanged = vi.fn();
+    let tools: RelayToolDescriptor[] = [
+      { name: 'foo', inputSchema: { type: 'object', properties: { x: { type: 'string' } } } },
+    ];
+
+    const r = createToolReconciler({ listTools: () => tools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    tools = [
+      { name: 'foo', inputSchema: { type: 'object', properties: { x: { type: 'number' } } } },
+    ];
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not trigger when tool order changes', async () => {
+    const onChanged = vi.fn();
+    let tools: RelayToolDescriptor[] = [
+      { name: 'b', description: 'B' },
+      { name: 'a', description: 'A' },
+    ];
+
+    const r = createToolReconciler({ listTools: () => tools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    tools = [
+      { name: 'a', description: 'A' },
+      { name: 'b', description: 'B' },
+    ];
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('debounces multiple scheduleReconcile calls in the same tick', async () => {
+    const listTools = vi.fn(() => [{ name: 'x', description: 'd' }] as RelayToolDescriptor[]);
+    const onChanged = vi.fn();
+
+    const r = createToolReconciler({ listTools, onChanged });
+    r.scheduleReconcile();
+    r.scheduleReconcile();
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(listTools).toHaveBeenCalledTimes(1);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('startPolling triggers scheduleReconcile at the configured interval', async () => {
+    const onChanged = vi.fn();
+    let tools: RelayToolDescriptor[] = [];
+
+    const r = createToolReconciler({ listTools: () => tools, onChanged, pollInterval: 500 });
+    r.startPolling();
+
+    // First poll fires at 500ms; +1ms to flush the setTimeout(0) inside scheduleReconcile
+    tools = [{ name: 'new-tool', description: 'added' }];
+    await vi.advanceTimersByTimeAsync(501);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    // Second poll at 1000ms - no change
+    await vi.advanceTimersByTimeAsync(501);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    r.dispose();
+  });
+
+  it('dispose stops polling', async () => {
+    const listTools = vi.fn(() => [] as RelayToolDescriptor[]);
+    const onChanged = vi.fn();
+
+    const r = createToolReconciler({ listTools, onChanged, pollInterval: 100 });
+    r.startPolling();
+    r.dispose();
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(listTools).not.toHaveBeenCalled();
+  });
+
+  it('handles async listTools', async () => {
+    const onChanged = vi.fn();
+    const tools: RelayToolDescriptor[] = [{ name: 'async-tool', description: 'async' }];
+    const listTools = () => Promise.resolve(tools);
+
+    const r = createToolReconciler({ listTools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    // flush microtask for the Promise
+    await Promise.resolve();
+
+    expect(onChanged).toHaveBeenCalledWith(tools);
+  });
+
+  it('does not crash or notify when listTools throws', async () => {
+    const onChanged = vi.fn();
+    const listTools = () => {
+      throw new Error('fail');
+    };
+
+    const r = createToolReconciler({ listTools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+});

--- a/packages/webmcp-local-relay/src/browser/reconciler.ts
+++ b/packages/webmcp-local-relay/src/browser/reconciler.ts
@@ -1,0 +1,98 @@
+// Tool list reconciler — single source of truth for detecting tool changes.
+// All event surfaces and the poll timer funnel into scheduleReconcile().
+// Compares full tool descriptors (name + description + inputSchema) via stable
+// JSON serialization, so schema-only changes are detected.
+
+type JsonObject = Record<string, unknown>;
+
+export interface RelayToolDescriptor {
+  name: string;
+  description?: string;
+  inputSchema?: JsonObject;
+}
+
+export interface ReconcilerOptions {
+  listTools: () => RelayToolDescriptor[] | Promise<RelayToolDescriptor[]>;
+  onChanged: (tools: RelayToolDescriptor[]) => void;
+  pollInterval?: number;
+}
+
+export interface ToolReconciler {
+  scheduleReconcile(): void;
+  startPolling(): void;
+  dispose(): void;
+}
+
+// Deterministic JSON: recursively sorts object keys so property insertion order
+// doesn't affect the output. Required because inputSchema objects from different
+// sources may have identical content but different key ordering.
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(stableStringify).join(',') + ']';
+  }
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  return (
+    '{' +
+    keys
+      .map((k) => JSON.stringify(k) + ':' + stableStringify((value as Record<string, unknown>)[k]))
+      .join(',') +
+    '}'
+  );
+}
+
+export function createSnapshot(tools: RelayToolDescriptor[]): string {
+  const sorted = [...tools].sort((a, b) => a.name.localeCompare(b.name));
+  return sorted.map(stableStringify).join('\n');
+}
+
+export function createToolReconciler(options: ReconcilerOptions): ToolReconciler {
+  const DEFAULT_POLL_INTERVAL = 2000;
+  let lastSnapshot = '';
+  let scheduled = false;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  function reconcile(): void {
+    scheduled = false;
+    // Outer try-catch: Promise.resolve(fn()) evaluates fn() synchronously,
+    // so a synchronous throw from listTools() escapes the .catch() handler.
+    try {
+      Promise.resolve(options.listTools())
+        .then((tools) => {
+          const list = Array.isArray(tools) ? tools : [];
+          const snapshot = createSnapshot(list);
+          if (snapshot !== lastSnapshot) {
+            lastSnapshot = snapshot;
+            options.onChanged(list);
+          }
+        })
+        .catch(() => {}); // listTools rejected asynchronously — skip this cycle
+    } catch {
+      // listTools threw synchronously — skip this cycle
+    }
+  }
+
+  // Debounce: multiple event firings in the same tick collapse into one reconcile.
+  function scheduleReconcile(): void {
+    if (scheduled) return;
+    scheduled = true;
+    setTimeout(reconcile, 0);
+  }
+
+  function startPolling(): void {
+    if (pollTimer) return;
+    pollTimer = setInterval(scheduleReconcile, options.pollInterval ?? DEFAULT_POLL_INTERVAL);
+  }
+
+  function dispose(): void {
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+    scheduled = false;
+  }
+
+  return { scheduleReconcile, startPolling, dispose };
+}

--- a/packages/webmcp-local-relay/src/browser/widget.test.ts
+++ b/packages/webmcp-local-relay/src/browser/widget.test.ts
@@ -677,13 +677,6 @@ describe('widget runtime', () => {
       );
     });
 
-    connection.client.send(JSON.stringify(42));
-    await vi.waitFor(() => {
-      expect(debug).toHaveBeenCalledWith(
-        '[webmcp-relay-widget] Ignoring non-object or untyped relay message'
-      );
-    });
-
     connection.client.send(JSON.stringify({ type: 'ping' }));
     await vi.waitFor(() => {
       expect(connection.messages).toContainEqual({ type: 'pong' });
@@ -920,5 +913,277 @@ describe('widget runtime', () => {
     await waitForConnection(env);
 
     expect(warn).toHaveBeenCalledTimes(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dormant reconnection tests
+// ---------------------------------------------------------------------------
+
+describe('dormant reconnection', () => {
+  /**
+   * Saves the original WebSocket constructor for restoration in afterEach.
+   * This describe block replaces WebSocket with a mock that always fails
+   * immediately, paired with fake timers to control delay progression.
+   */
+  let savedWebSocket: typeof WebSocket;
+  let wsUrls: string[];
+
+  /**
+   * Creates a MockWebSocket that always fails immediately.
+   * Fires error + close via queueMicrotask after construction so
+   * probeRelayEndpoint resolves to null without waiting.
+   */
+  function createFailingWebSocket(): typeof WebSocket {
+    return class MockWebSocket {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly CLOSING = 2;
+      static readonly CLOSED = 3;
+      readonly CONNECTING = 0;
+      readonly OPEN = 1;
+      readonly CLOSING = 2;
+      readonly CLOSED = 3;
+      url: string;
+      readyState = 0;
+      protocol = '';
+      private _map = new Map<string, Array<{ fn: Function; once?: boolean }>>();
+
+      constructor(url: string, _protocols?: string | string[]) {
+        this.url = url;
+        wsUrls.push(url);
+        queueMicrotask(() => {
+          this.readyState = 3;
+          this._emit('error', new Event('error'));
+          this._emit('close', new CloseEvent('close'));
+        });
+      }
+
+      addEventListener(t: string, fn: Function, opts?: { once?: boolean }): void {
+        if (!this._map.has(t)) this._map.set(t, []);
+        this._map.get(t)!.push({ fn, once: opts?.once });
+      }
+
+      removeEventListener(t: string, fn: Function): void {
+        const arr = this._map.get(t);
+        if (!arr) return;
+        const i = arr.findIndex((e) => e.fn === fn);
+        if (i >= 0) arr.splice(i, 1);
+      }
+
+      close(): void {
+        this.readyState = 3;
+      }
+
+      send(_d: string): void {}
+
+      private _emit(t: string, ev: Event): void {
+        for (const e of [...(this._map.get(t) ?? [])]) {
+          e.fn(ev);
+          if (e.once) {
+            const arr = this._map.get(t)!;
+            const i = arr.indexOf(e);
+            if (i >= 0) arr.splice(i, 1);
+          }
+        }
+      }
+    } as unknown as typeof WebSocket;
+  }
+
+  interface DormantEnv {
+    docListeners: Map<string, Set<Function>>;
+    winListeners: Map<string, Set<Function>>;
+    setVisibility: (v: DocumentVisibilityState) => void;
+    fireDocEvent: (type: string) => void;
+    fireWinEvent: (type: string) => void;
+  }
+
+  /**
+   * Sets up a mock environment for dormant tests.
+   * Extends installEnvironment with:
+   * - document.addEventListener / removeEventListener (visibilitychange)
+   * - document.visibilityState getter
+   */
+  function setupDormantEnv(port = 9333): DormantEnv {
+    wsUrls = [];
+    const docListeners = new Map<string, Set<Function>>();
+    const winListeners = new Map<string, Set<Function>>();
+    let vis: DocumentVisibilityState = 'visible';
+
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      writable: true,
+      value: {
+        referrer: '',
+        get visibilityState() {
+          return vis;
+        },
+        addEventListener(t: string, fn: Function) {
+          if (!docListeners.has(t)) docListeners.set(t, new Set());
+          docListeners.get(t)!.add(fn);
+        },
+        removeEventListener(t: string, fn: Function) {
+          docListeners.get(t)?.delete(fn);
+        },
+      },
+    });
+
+    const store = new Map<string, string>();
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      configurable: true,
+      writable: true,
+      value: {
+        getItem: (k: string) => store.get(k) ?? null,
+        setItem: (k: string, v: string) => store.set(k, v),
+        removeItem: (k: string) => store.delete(k),
+        clear: () => store.clear(),
+      },
+    });
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      writable: true,
+      value: {
+        addEventListener(t: string, fn: Function) {
+          if (!winListeners.has(t)) winListeners.set(t, new Set());
+          winListeners.get(t)!.add(fn);
+        },
+        removeEventListener(t: string, fn: Function) {
+          winListeners.get(t)?.delete(fn);
+        },
+        location: {
+          search: buildSearch({
+            hostOrigin: APP_ORIGIN,
+            relayHost: '127.0.0.1',
+            relayPort: String(port),
+            tabId: 'tab-dormant',
+          }),
+        },
+        parent: { postMessage: vi.fn() },
+      },
+    });
+
+    return {
+      docListeners,
+      winListeners,
+      setVisibility(v: DocumentVisibilityState) {
+        vis = v;
+      },
+      fireDocEvent(type: string) {
+        for (const fn of docListeners.get(type) ?? []) fn(new Event(type));
+      },
+      fireWinEvent(type: string) {
+        for (const fn of winListeners.get(type) ?? []) fn(new Event(type));
+      },
+    };
+  }
+
+  /**
+   * Fast-forwards to dormant state.
+   * Initial discovery + 3 rediscovery rounds (10s + 20s + 30s delays) all fail → dormant.
+   * Mock WebSocket fails immediately via microtask; advanceTimersByTimeAsync advances delays.
+   */
+  async function fastForwardToDormant(): Promise<void> {
+    startWidgetRuntime();
+    // Total delay ≈ 60s (10 + 20 + 30); use 70s to ensure margin
+    await vi.advanceTimersByTimeAsync(70000);
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    savedWebSocket = globalThis.WebSocket;
+    globalThis.WebSocket = createFailingWebSocket();
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = savedWebSocket;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    restoreGlobal('document', originalDescriptors.document);
+    restoreGlobal('sessionStorage', originalDescriptors.sessionStorage);
+    restoreGlobal('window', originalDescriptors.window);
+  });
+
+  it('enters dormant after 3 failed rediscovery cycles and stops connections', async () => {
+    setupDormantEnv();
+    await fastForwardToDormant();
+
+    // After entering dormant, no new connections within 60s (heartbeat interval is 120s)
+    wsUrls.length = 0;
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(wsUrls).toHaveLength(0);
+  });
+
+  it('registers visibilitychange listener in dormant state', async () => {
+    const env = setupDormantEnv();
+    await fastForwardToDormant();
+
+    expect(env.docListeners.get('visibilitychange')?.size).toBe(1);
+  });
+
+  it('heartbeat only probes configured port, not full range', async () => {
+    setupDormantEnv(9333);
+    await fastForwardToDormant();
+
+    wsUrls.length = 0;
+    // Advance to heartbeat interval (120s) to trigger heartbeatProbe
+    await vi.advanceTimersByTimeAsync(120000);
+
+    // Heartbeat only probes configured port (1-2 connections), not full range scan (32)
+    expect(wsUrls.length).toBeGreaterThan(0);
+    expect(wsUrls.length).toBeLessThanOrEqual(2);
+    expect(wsUrls[0]).toContain('9333');
+  });
+
+  it('wakes from dormant on visibilitychange and re-enters dormant on failure', async () => {
+    const env = setupDormantEnv();
+    await fastForwardToDormant();
+
+    wsUrls.length = 0;
+    env.setVisibility('visible');
+    env.fireDocEvent('visibilitychange');
+    // After wake, runs full-range discovery
+    await vi.advanceTimersByTimeAsync(500);
+
+    // wakeFromDormant runs full-range discovery (32 candidate endpoints)
+    expect(wsUrls.length).toBeGreaterThan(2);
+    // After discovery failure, re-enters dormant; visibilitychange listener restored
+    expect(env.docListeners.get('visibilitychange')?.size).toBe(1);
+  });
+
+  it('wakes from dormant on webmcp.connect message', async () => {
+    const env = setupDormantEnv();
+    await fastForwardToDormant();
+
+    wsUrls.length = 0;
+    // Simulate host page sending webmcp.connect message
+    for (const fn of env.winListeners.get('message') ?? []) {
+      (fn as (event: { origin: string; data: unknown }) => void)({
+        origin: APP_ORIGIN,
+        data: { type: 'webmcp.connect' },
+      });
+    }
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(wsUrls.length).toBeGreaterThan(2);
+  });
+
+  it('does not duplicate listeners when re-entering dormant after wake failure', async () => {
+    const env = setupDormantEnv();
+    await fastForwardToDormant();
+
+    // First wake → discovery fails → re-enters dormant
+    env.setVisibility('visible');
+    env.fireDocEvent('visibilitychange');
+    await vi.advanceTimersByTimeAsync(500);
+
+    // Second wake → discovery fails → re-enters dormant
+    env.setVisibility('hidden');
+    env.setVisibility('visible');
+    env.fireDocEvent('visibilitychange');
+    await vi.advanceTimersByTimeAsync(500);
+
+    // visibilitychange listener should be exactly 1, not accumulated
+    expect(env.docListeners.get('visibilitychange')?.size).toBe(1);
   });
 });

--- a/packages/webmcp-local-relay/src/browser/widgetRuntime.ts
+++ b/packages/webmcp-local-relay/src/browser/widgetRuntime.ts
@@ -85,7 +85,8 @@ type RelayRuntimeState =
   | 'discovering'
   | 'connected'
   | 'retry-same-endpoint'
-  | 'rediscover';
+  | 'rediscover'
+  | 'dormant';
 
 const RECONNECT_INITIAL_DELAY_MS = 500;
 const RECONNECT_MAX_DELAY_MS = 3000;
@@ -93,6 +94,12 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 60000;
 const RELAY_SERVER_HELLO_TIMEOUT_MS = 1200;
 const RELAY_HELLO_ACK_TIMEOUT_MS = 250;
 const MAX_ENDPOINT_FAILURES_BEFORE_REDISCOVERY = 5;
+
+/** Delay between rediscovery attempts (ms). */
+const REDISCOVERY_DELAYS_MS = [10000, 20000, 30000];
+const MAX_DISCOVERY_CYCLES_BEFORE_DORMANT = REDISCOVERY_DELAYS_MS.length;
+/** Heartbeat probe interval while dormant (ms). */
+const DORMANT_HEARTBEAT_INTERVAL_MS = 120000;
 
 export function parseConfig(search = window.location.search): WidgetConfig | null {
   const params = new URLSearchParams(search);
@@ -433,6 +440,8 @@ export function runWidget(cfg: WidgetConfig): void {
   let reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
   let scheduledReconnect: ReturnType<typeof setTimeout> | null = null;
   let state: RelayRuntimeState = 'idle';
+  let discoveryCycleCount = 0;
+  let dormantHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
   const rejectPendingRequests = (reason: string): void => {
     for (const [requestId, pending] of pendingRequests) {
@@ -493,6 +502,7 @@ export function runWidget(cfg: WidgetConfig): void {
     activeEndpoint = endpoint;
     activeSocket = socket;
     reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
+    discoveryCycleCount = 0;
     helloAccepted = false;
     setState('connected');
 
@@ -553,7 +563,6 @@ export function runWidget(cfg: WidgetConfig): void {
       }
 
       if (!isJsonObject(relayMessage) || typeof relayMessage.type !== 'string') {
-        console.debug('[webmcp-relay-widget] Ignoring non-object or untyped relay message');
         return;
       }
 
@@ -767,26 +776,136 @@ export function runWidget(cfg: WidgetConfig): void {
     }, delay);
   };
 
+  /**
+   * Schedules a full-range rediscovery attempt with increasing delays.
+   * After {@link MAX_DISCOVERY_CYCLES_BEFORE_DORMANT} failed cycles,
+   * transitions to dormant state.
+   */
   const scheduleRediscovery = (): void => {
     if (scheduledReconnect) {
       return;
     }
 
+    if (discoveryCycleCount >= MAX_DISCOVERY_CYCLES_BEFORE_DORMANT) {
+      enterDormant();
+      return;
+    }
+
     setState('rediscover');
-    const delay = Math.min(
-      RECONNECT_MAX_DELAY_MS,
-      Math.round(reconnectDelayMs * (0.85 + Math.random() * 0.3))
-    );
-    reconnectDelayMs = Math.min(Math.round(reconnectDelayMs * 1.5), RECONNECT_MAX_DELAY_MS);
+    const delay = REDISCOVERY_DELAYS_MS[discoveryCycleCount]!;
 
     scheduledReconnect = setTimeout(() => {
       scheduledReconnect = null;
       void discoverRelay().then((connected) => {
         if (!connected) {
+          discoveryCycleCount += 1;
           scheduleRediscovery();
         }
       });
     }, delay);
+  };
+
+  const onDormantVisibilityChange = (): void => {
+    if (document.visibilityState === 'visible' && state === 'dormant') {
+      wakeFromDormant();
+    }
+  };
+
+  const cleanupDormantListeners = (): void => {
+    document.removeEventListener('visibilitychange', onDormantVisibilityChange);
+    if (dormantHeartbeatTimer !== null) {
+      clearInterval(dormantHeartbeatTimer);
+      dormantHeartbeatTimer = null;
+    }
+  };
+
+  /**
+   * Enters dormant state — stops active reconnection and relies on
+   * visibilitychange events and periodic heartbeat probes to detect
+   * a relay that comes online later.
+   */
+  const enterDormant = (): void => {
+    if (state === 'dormant') {
+      return;
+    }
+
+    setState('dormant');
+
+    if (scheduledReconnect) {
+      clearTimeout(scheduledReconnect);
+      scheduledReconnect = null;
+    }
+
+    document.addEventListener('visibilitychange', onDormantVisibilityChange);
+
+    dormantHeartbeatTimer = setInterval(() => {
+      void heartbeatProbe();
+    }, DORMANT_HEARTBEAT_INTERVAL_MS);
+  };
+
+  /**
+   * Lightweight probe: only checks the configured port and cached endpoint,
+   * skipping a full-range discovery scan.
+   */
+  const heartbeatProbe = async (): Promise<void> => {
+    if (state !== 'dormant') {
+      return;
+    }
+
+    const seen = new Set<string>();
+    const candidates: Array<{ host: string; port: number }> = [];
+
+    const pushCandidate = (host: string, port: number): void => {
+      const key = `${host}:${String(port)}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      candidates.push({ host, port });
+    };
+
+    if (cfg.relayPortHint !== undefined) {
+      pushCandidate(cfg.relayHostHint, cfg.relayPortHint);
+    }
+
+    const cached = readCachedEndpoint(cfg);
+    if (cached) {
+      pushCandidate(cached.host, cached.port);
+    }
+
+    if (candidates.length === 0) {
+      return;
+    }
+
+    // Transition state and remove listeners to prevent concurrent event-driven wakes.
+    setState('discovering');
+    cleanupDormantListeners();
+
+    for (const candidate of candidates) {
+      const connected = await connectToEndpoint(candidate);
+      if (connected) {
+        discoveryCycleCount = 0;
+        return;
+      }
+    }
+
+    // Probe failed — go back to dormant.
+    enterDormant();
+  };
+
+  /**
+   * Wakes from dormant state: cleans up listeners, resets backoff
+   * counters, and runs a full-range discovery. Falls back to dormant
+   * again if discovery fails.
+   */
+  const wakeFromDormant = (): void => {
+    cleanupDormantListeners();
+    reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
+    discoveryCycleCount = 0;
+
+    void discoverRelay().then((connected) => {
+      if (!connected) {
+        enterDormant();
+      }
+    });
   };
 
   window.addEventListener('message', (event: MessageEvent) => {
@@ -809,7 +928,9 @@ export function runWidget(cfg: WidgetConfig): void {
     }
 
     if (isJsonObject(data) && data.type === 'webmcp.connect') {
-      if (!activeSocket && state !== 'discovering') {
+      if (state === 'dormant') {
+        wakeFromDormant();
+      } else if (!activeSocket && state !== 'discovering') {
         void discoverRelay();
       }
       return;

--- a/packages/webmcp-local-relay/src/cli-utils.test.ts
+++ b/packages/webmcp-local-relay/src/cli-utils.test.ts
@@ -136,4 +136,28 @@ describe('parseCliOptions', () => {
     const options = parseCliOptions(argv);
     expect(options.host).toBe('0.0.0.0');
   });
+
+  it('parses --max-payload flag', () => {
+    const options = parseCliOptions(['--max-payload', '20000000']);
+    expect(options.maxPayloadBytes).toBe(20000000);
+  });
+
+  it('throws for non-numeric --max-payload', () => {
+    expect(() => parseCliOptions(['--max-payload', 'abc'])).toThrow('Invalid max-payload "abc"');
+  });
+
+  it('throws for zero --max-payload', () => {
+    expect(() => parseCliOptions(['--max-payload', '0'])).toThrow('Invalid max-payload "0"');
+  });
+
+  it('throws for negative --max-payload', () => {
+    expect(() => parseCliOptions(['--max-payload', '-5'])).toThrow(
+      'Missing value for --max-payload'
+    );
+  });
+
+  it('returns undefined maxPayloadBytes when --max-payload is not provided', () => {
+    const options = parseCliOptions([]);
+    expect(options.maxPayloadBytes).toBeUndefined();
+  });
 });

--- a/packages/webmcp-local-relay/src/cli-utils.ts
+++ b/packages/webmcp-local-relay/src/cli-utils.ts
@@ -9,6 +9,7 @@ export interface CliOptions {
   label?: string;
   workspace?: string;
   relayId?: string;
+  maxPayloadBytes?: number;
 }
 
 /**
@@ -88,6 +89,17 @@ export function parseCliOptions(argv: string[]): CliOptions {
       continue;
     }
 
+    if (token === '--max-payload') {
+      const raw = readFlagValue(token, i);
+      i += 1;
+      const value = Number.parseInt(raw, 10);
+      if (!Number.isFinite(value) || value <= 0) {
+        throw new Error(`Invalid max-payload "${raw}". Must be a positive integer (bytes).`);
+      }
+      options.maxPayloadBytes = value;
+      continue;
+    }
+
     if (token === '--help' || token === '-h') {
       printHelp();
       process.exit(0);
@@ -125,6 +137,7 @@ export function printHelp(): void {
       '  --label                  Human-readable relay label reported during discovery',
       '  --workspace              Optional workspace name reported during discovery',
       '  --relay-id               Stable relay identifier reported during discovery',
+      '  --max-payload            Maximum WebSocket payload size in bytes (default: 10000000)',
       '  --help, -h               Show help',
       '',
     ].join('\n')

--- a/packages/webmcp-local-relay/src/cli.ts
+++ b/packages/webmcp-local-relay/src/cli.ts
@@ -27,6 +27,7 @@ const bridgeOptions = {
   ...(options.label ? { label: options.label } : {}),
   ...(options.relayId ? { relayId: options.relayId } : {}),
   ...(options.workspace ? { workspace: options.workspace } : {}),
+  ...(options.maxPayloadBytes ? { maxPayloadBytes: options.maxPayloadBytes } : {}),
 };
 
 const relay = new LocalRelayMcpServer({

--- a/packages/webmcp-local-relay/src/mcpRelayServer.test.ts
+++ b/packages/webmcp-local-relay/src/mcpRelayServer.test.ts
@@ -30,6 +30,15 @@ async function waitFor<T>(
   throw new Error('Timed out waiting for condition');
 }
 
+type ListedTool = Awaited<ReturnType<Client['listTools']>>['tools'][number];
+
+async function waitForClientTool(client: Client, toolName: string): Promise<ListedTool> {
+  return waitFor(async () => {
+    const list = await client.listTools();
+    return list.tools.find((tool) => tool.name === toolName);
+  });
+}
+
 /**
  * Extracts text items from MCP call tool result content.
  */
@@ -494,9 +503,7 @@ describe('LocalRelayMcpServer', () => {
 
     const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-    const list = await client.listTools();
-    const tool = list.tools.find((t) => t.name === toolName);
-    expect(tool).toBeTruthy();
+    const tool = await waitForClientTool(client, toolName);
     expect(tool?.annotations?.readOnlyHint).toBe(true);
 
     ws.close();
@@ -527,9 +534,7 @@ describe('LocalRelayMcpServer', () => {
 
     const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-    const list = await client.listTools();
-    const tool = list.tools.find((t) => t.name === toolName);
-    expect(tool).toBeTruthy();
+    const tool = await waitForClientTool(client, toolName);
     expect(tool?.inputSchema).toEqual({
       type: 'object',
       properties: {
@@ -943,9 +948,7 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-      const list = await client.listTools();
-      const tool = list.tools.find((t) => t.name === toolName);
-      expect(tool).toBeTruthy();
+      const tool = await waitForClientTool(client, toolName);
       expect(tool?.inputSchema).toEqual({
         type: 'object',
         properties: {},
@@ -989,9 +992,7 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-      const list = await client.listTools();
-      const tool = list.tools.find((t) => t.name === toolName);
-      expect(tool).toBeTruthy();
+      const tool = await waitForClientTool(client, toolName);
       expect(tool?.inputSchema).toEqual(complexSchema);
 
       ws.close();
@@ -1018,9 +1019,7 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-      const list = await client.listTools();
-      const tool = list.tools.find((t) => t.name === toolName);
-      expect(tool).toBeTruthy();
+      const tool = await waitForClientTool(client, toolName);
       expect(tool?.inputSchema).toEqual(inputSchema);
       expect((tool as Record<string, unknown>).outputSchema).toEqual(outputSchema);
 
@@ -1089,6 +1088,7 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
+      await waitForClientTool(client, toolName);
       const list = await client.listTools();
 
       const expectedStaticSchemas: Record<string, Record<string, unknown>> = {
@@ -1138,8 +1138,7 @@ describe('LocalRelayMcpServer', () => {
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
       // Verify initial schema
-      const list1 = await client.listTools();
-      const tool1 = list1.tools.find((t) => t.name === toolName);
+      const tool1 = await waitForClientTool(client, toolName);
       expect(tool1?.inputSchema).toEqual(initialSchema);
 
       // Send updated schema
@@ -1184,8 +1183,11 @@ describe('LocalRelayMcpServer', () => {
       await waitFor(() => bridge.registry.listTools()[0]?.name);
 
       // Verify tool is listed
-      const list1 = await client.listTools();
-      expect(list1.tools.find((t) => !t.name.startsWith('webmcp_'))).toBeTruthy();
+      await waitFor(async () => {
+        const list = await client.listTools();
+        const dynamic = list.tools.filter((t) => !t.name.startsWith('webmcp_'));
+        return dynamic.length > 0 ? true : undefined;
+      });
 
       // Disconnect browser
       ws.close();
@@ -1278,9 +1280,7 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-      const list = await client.listTools();
-      const tool = list.tools.find((t) => t.name === toolName);
-      expect(tool).toBeTruthy();
+      const tool = await waitForClientTool(client, toolName);
       expect(tool?.inputSchema).toEqual(inputSchema);
       expect((tool as Record<string, unknown>).outputSchema).toEqual(outputSchema);
       expect(tool?.annotations?.readOnlyHint).toBe(true);
@@ -1301,9 +1301,7 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-      const list = await client.listTools();
-      const tool = list.tools.find((t) => t.name === toolName);
-      expect(tool).toBeTruthy();
+      const tool = await waitForClientTool(client, toolName);
       expect(tool?.inputSchema).toEqual({
         type: 'object',
         properties: {},
@@ -1353,11 +1351,114 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
+      const tool = await waitForClientTool(client, toolName);
       const list = await client.listTools();
       expect(list.tools).toHaveLength(5); // 4 static + 1 dynamic
-      const tool = list.tools.find((t) => t.name === toolName);
-      expect(tool).toBeTruthy();
       expect(tool?.inputSchema).toEqual(finalSchema);
+
+      ws.close();
+      await cleanup();
+    });
+  });
+
+  describe('notification debouncing', () => {
+    it('does not re-register tools when a browser reconnects with the same tools', async () => {
+      const { bridge, client, cleanup } = await createConnectedRelay();
+
+      const tools = [
+        { name: 'stable_tool', description: 'A stable tool' },
+        { name: 'another_tool', description: 'Another tool' },
+      ];
+
+      const ws1 = await connectBrowser(bridge, {
+        tabId: 'tab-reconnect',
+        url: 'https://example.com',
+        tools,
+      });
+
+      const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
+      expect(toolName).toBeTruthy();
+
+      const list1 = await waitFor(async () => {
+        const list = await client.listTools();
+        return list.tools.length === 6 ? list : undefined; // 4 static + 2 dynamic
+      });
+      expect(list1.tools).toHaveLength(6);
+
+      ws1.close();
+      await waitFor(() => (bridge.registry.listSources().length === 0 ? true : undefined));
+
+      await waitFor(async () => {
+        const list = await client.listTools();
+        return list.tools.length === 4 ? true : undefined; // only static tools
+      });
+
+      const ws2 = await connectBrowser(bridge, {
+        tabId: 'tab-reconnect',
+        url: 'https://example.com',
+        tools,
+      });
+
+      const list2 = await waitFor(async () => {
+        const list = await client.listTools();
+        return list.tools.length === 6 ? list : undefined;
+      });
+
+      const dynamicTools2 = list2.tools.filter((t) => !t.name.startsWith('webmcp_'));
+      expect(dynamicTools2).toHaveLength(2);
+      expect(dynamicTools2.map((t) => t.name).sort()).toEqual(
+        list1.tools
+          .filter((t) => !t.name.startsWith('webmcp_'))
+          .map((t) => t.name)
+          .sort()
+      );
+
+      ws2.close();
+      await cleanup();
+    });
+
+    it('batches rapid stateChanged events into a single sync', async () => {
+      const { bridge, relay, cleanup } = await createConnectedRelay();
+
+      const ws = await connectBrowser(bridge, {
+        tabId: 'tab-batch',
+        url: 'https://example.com',
+        tools: [{ name: 'batch_tool', description: 'Batch test' }],
+      });
+
+      await waitFor(() => bridge.registry.listTools()[0]?.name);
+
+      const syncCountBefore = relay.listDynamicToolNames().length;
+      expect(syncCountBefore).toBe(1);
+
+      ws.send(
+        JSON.stringify({
+          type: 'tools/changed',
+          tools: [
+            { name: 'batch_tool', description: 'Batch test' },
+            { name: 'extra_tool', description: 'Extra' },
+          ],
+        })
+      );
+
+      ws.send(
+        JSON.stringify({
+          type: 'tools/changed',
+          tools: [
+            { name: 'batch_tool', description: 'Batch test v2' },
+            { name: 'extra_tool', description: 'Extra v2' },
+          ],
+        })
+      );
+
+      await waitFor(() => {
+        const names = relay.listDynamicToolNames();
+        return names.length === 2 ? true : undefined;
+      });
+
+      const names = relay.listDynamicToolNames();
+      expect(names).toContain('batch_tool');
+      expect(names).toContain('extra_tool');
 
       ws.close();
       await cleanup();

--- a/packages/webmcp-local-relay/src/mcpRelayServer.ts
+++ b/packages/webmcp-local-relay/src/mcpRelayServer.ts
@@ -83,6 +83,7 @@ export class LocalRelayMcpServer {
 
   private syncing = false;
   private syncRequested = false;
+  private syncDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private connected = false;
 
   /**
@@ -97,9 +98,7 @@ export class LocalRelayMcpServer {
     });
 
     this.bridge.on('stateChanged', () => {
-      void this.syncDynamicTools().catch((err) => {
-        this.logSyncError(err);
-      });
+      this.debouncedSyncDynamicTools();
     });
 
     // Forward elicitation requests from browser tool handlers to the MCP client.
@@ -175,6 +174,12 @@ export class LocalRelayMcpServer {
    */
   async stop(): Promise<void> {
     this.connected = false;
+
+    if (this.syncDebounceTimer) {
+      clearTimeout(this.syncDebounceTimer);
+      this.syncDebounceTimer = null;
+    }
+
     let mcpCloseError: unknown;
     try {
       await this.mcpServer.close();
@@ -554,6 +559,27 @@ export class LocalRelayMcpServer {
   }
 
   /**
+   * Debounces rapid stateChanged events into a single sync pass.
+   *
+   * Browser reconnections emit multiple stateChanged events in quick
+   * succession (hello, tools/list). Without debouncing, each triggers a
+   * full sync that removes and re-registers tools — sending per-operation
+   * notifications through the stdio transport and overwhelming the agent.
+   */
+  private debouncedSyncDynamicTools(): void {
+    if (this.syncDebounceTimer) {
+      return;
+    }
+
+    this.syncDebounceTimer = setTimeout(() => {
+      this.syncDebounceTimer = null;
+      void this.syncDynamicTools().catch((err) => {
+        this.logSyncError(err);
+      });
+    }, 16);
+  }
+
+  /**
    * Coalesces concurrent sync requests into a single serialized sync loop.
    */
   private async syncDynamicTools(): Promise<void> {
@@ -733,6 +759,10 @@ export class LocalRelayMcpServer {
 
   /**
    * Produces a stable signature for change detection of dynamic tool metadata.
+   *
+   * Deliberately excludes `sourceId` (which is a per-connection UUID that
+   * changes on every browser reconnect) so that a reconnecting tab with the
+   * same tools does not trigger a needless remove+re-register cycle.
    */
   private toolSignature(tool: AggregatedTool): string {
     return JSON.stringify({
@@ -747,7 +777,6 @@ export class LocalRelayMcpServer {
       _meta: tool._meta,
       icons: tool.icons,
       sources: tool.sources.map((source) => ({
-        sourceId: source.sourceId,
         tabId: source.tabId,
       })),
     });


### PR DESCRIPTION
## Summary

This draft PR now contains only the local relay consolidation work from recent contributor PRs. The unrelated formatter fix and SDK runtime dependency fix have been split into separate prerequisite PRs.

## Stack

- #239 formats the chrome-devtools package verifier so repo `vp check` passes cleanly.
- #240 declares the MCP SDK runtime dependencies needed by the browser bundle path.
- This PR is stacked on #240 and should review as local relay only. Full GitHub CI may not report while the PR base is this non-main stack branch; retarget to `main` after prerequisites merge.

## References

- https://github.com/WebMCP-org/npm-packages/pull/220 - reduce reconnect notification storms
- https://github.com/WebMCP-org/npm-packages/pull/221 - reconcile browser tool-list changes from listTools as source of truth
- https://github.com/WebMCP-org/npm-packages/pull/229 - add dormant reconnect state for relay widget runtime
- https://github.com/WebMCP-org/npm-packages/pull/230 - raise/default-configure max WebSocket payload
- https://github.com/WebMCP-org/npm-packages/issues/168 - stale tool list after user-driven navigation, addressed by the reconciler path
- https://github.com/WebMCP-org/npm-packages/issues/231 - duplicate usewebmcp registration in StrictMode/HMR, intentionally not fixed in this PR

## What changed

- Debounces dynamic tool sync and avoids re-registering unchanged tools across reconnects.
- Adds a browser-side tool reconciler that reads listTools as the source of truth, compares stable full descriptors, and uses the same reconcile path for events and polling.
- Adds a dormant reconnect state for widget WebSocket rediscovery so missing relay servers do not cause an infinite reconnect loop.
- Raises the default local relay WebSocket payload limit to 10 MB, adds `--max-payload`, and surfaces payload-limit failures immediately.
- Waits schema-fidelity tests on client-visible tool registration to avoid the dynamic-tool debounce race seen in CI coverage runs.

## Notes

I intentionally did not bring over the large `docs/superpowers` planning/spec files from PR #221. The behavior and direct tests are included, but the branch keeps the merge surface focused on package code, tests, generated relay assets, and a changeset.

## Validation

- `pnpm --filter @mcp-b/webmcp-local-relay run typecheck`
- `pnpm --filter @mcp-b/webmcp-local-relay test -- --coverage` - 316 passed
- `pnpm --filter @mcp-b/webmcp-local-relay test:e2e` - 10 passed
- `CI=true pnpm exec vp check` - formatting passes; existing `skills/webmcp-setup/scripts/verify-setup.js` warnings remain unchanged