### PR TITLE
fix: declare MCP SDK runtime dependencies

### DIFF
--- a/.changeset/fix-browser-sdk-runtime-deps.md
+++ b/.changeset/fix-browser-sdk-runtime-deps.md
@@ -1,0 +1,6 @@
+---
+'@mcp-b/transports': patch
+'@mcp-b/webmcp-ts-sdk': patch
+---
+
+Declare the MCP TypeScript SDK as a runtime dependency for browser packages that emit runtime SDK imports.

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -79,6 +79,7 @@
   },
   "dependencies": {
     "@mcp-b/webmcp-ts-sdk": "workspace:*",
+    "@modelcontextprotocol/sdk": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/webmcp-ts-sdk/package.json
+++ b/packages/webmcp-ts-sdk/package.json
@@ -72,10 +72,10 @@
   },
   "dependencies": {
     "@mcp-b/webmcp-polyfill": "workspace:*",
-    "@mcp-b/webmcp-types": "workspace:*"
+    "@mcp-b/webmcp-types": "workspace:*",
+    "@modelcontextprotocol/sdk": "catalog:"
   },
   "devDependencies": {
-    "@modelcontextprotocol/sdk": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vite-plus": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -920,6 +920,9 @@ importers:
       '@mcp-b/webmcp-ts-sdk':
         specifier: workspace:*
         version: link:../webmcp-ts-sdk
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -1068,6 +1071,9 @@ importers:
       '@mcp-b/webmcp-types':
         specifier: workspace:*
         version: link:../webmcp-types
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       zod:
         specifier: ^3.25 || ^4.0
         version: 4.4.3
@@ -1075,9 +1081,6 @@ importers:
         specifier: ^3.25.0
         version: 3.25.1(zod@4.4.3)
     devDependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: 'catalog:'
-        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@types/node':
         specifier: 'catalog:'
         version: 22.17.2


### PR DESCRIPTION
## Summary
- Move `@modelcontextprotocol/sdk` into runtime dependencies for browser packages that emit SDK imports.
- Update the lockfile and add a patch changeset for `@mcp-b/transports` and `@mcp-b/webmcp-ts-sdk`.

## Why
The local relay browser bundle exposed that the emitted browser packages can import the MCP SDK at runtime, so consumers need it available as a dependency instead of only as a devDependency.

## Stack
- Stacked on #239 to avoid mixing the repo formatter prerequisite into this PR.

## Validation
- `pnpm --filter @mcp-b/webmcp-ts-sdk --filter @mcp-b/transports --filter @mcp-b/global run typecheck`
- `pnpm exec syncpack lint`
- `CI=true pnpm exec vp check`