### PR TITLE
docs(usewebmcp): update Chrome 147/148 compatibility notes in comment and README

### DIFF
--- a/packages/usewebmcp/README.md
+++ b/packages/usewebmcp/README.md
@@ -101,7 +101,7 @@ export function CounterTool() {
 ## How `useWebMCP` Works
 
 - Registers a tool on mount with `document.modelContext.registerTool(tool, { signal })` and aborts the controller on unmount.
-- On Chrome Beta 147 native (which ignores the second arg) cleanup cannot remove the tool. Install `@mcp-b/global` or `@mcp-b/webmcp-polyfill` for spec-aligned behavior.
+- On Chrome 147/148, aborting the controller does not remove the tool. Install `@mcp-b/global` or `@mcp-b/webmcp-polyfill` for those versions. Chrome 149+ works natively.
 - Exposes local execution state:
   - `state.isExecuting`
   - `state.lastResult`

--- a/packages/usewebmcp/README.md
+++ b/packages/usewebmcp/README.md
@@ -101,7 +101,7 @@ export function CounterTool() {
 ## How `useWebMCP` Works
 
 - Registers a tool on mount with `document.modelContext.registerTool(tool, { signal })` and aborts the controller on unmount.
-- On Chrome 147/148, aborting the controller does not remove the tool. Install `@mcp-b/global` or `@mcp-b/webmcp-polyfill` for those versions. Chrome 149+ works natively.
+- On Chrome 147/148, aborting the controller does not remove the tool. Install `@mcp-b/global` or `@mcp-b/webmcp-polyfill` for those versions. Chrome 149+ removes the tool on abort in the native implementation.
 - Exposes local execution state:
   - `state.isExecuting`
   - `state.lastResult`

--- a/packages/usewebmcp/src/useWebMCP.ts
+++ b/packages/usewebmcp/src/useWebMCP.ts
@@ -114,9 +114,9 @@ function isDev(): boolean {
 }
 
 /**
- * On Chrome Beta 147 native (which ignores the second arg), aborting
- * the controller cannot remove the tool. Install `@mcp-b/global`
- * or `@mcp-b/webmcp-polyfill` there.
+ * On Chrome 147/148, aborting the controller does not remove the tool.
+ * Install `@mcp-b/global` or `@mcp-b/webmcp-polyfill` for those versions.
+ * Chrome 149+ works natively.
  */
 function registerToolWithCleanup(
   modelContext: ModelContextSurface,

--- a/packages/usewebmcp/src/useWebMCP.ts
+++ b/packages/usewebmcp/src/useWebMCP.ts
@@ -116,7 +116,7 @@ function isDev(): boolean {
 /**
  * On Chrome 147/148, aborting the controller does not remove the tool.
  * Install `@mcp-b/global` or `@mcp-b/webmcp-polyfill` for those versions.
- * Chrome 149+ works natively.
+ * Chrome 149+ removes the tool on abort in the native implementation.
  */
 function registerToolWithCleanup(
   modelContext: ModelContextSurface,


### PR DESCRIPTION
## Summary
Based on the issue #231 , I tested and validated that the chrome bug which lead to duplicate tool name error has been fixed in chrome v149. Fixes doc.

Also Fyi, Chrome 148 did add some support but it was not fully fixed due to a GC bug.

## Changes

This PR updates Readme and TSDoc, highlighting issue in chrome 147/148 and advices to use 149+.

## Related Issues
#231 

## Checklist

- [x] PR title follows conventional commit format: `type(scope): description`
- [x] I followed `docs/AI_CONTRIBUTION_MANIFESTO.md` for safety, contracts, and SSOT decisions
- [x] I followed `docs/MCPB_PACKAGE_PHILOSOPHY.md` for package boundaries and ownership
- [x] I followed `docs/TESTING_PHILOSOPHY.md` and selected the right test layer(s)
- [ ] Code builds without errors (`pnpm build`)
- [ ] Tests pass (`pnpm test:unit`)
- [ ] Linting passes (`pnpm check`)
- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Changeset added (if this is a user-facing change) - run `pnpm changeset`

## Testing

These changes were tested in a custom AI generated script - https://gist.github.com/lokeshgoel177/132ac01326afdf92a21e69ee5a5df101 

## Screenshots

After updating chrome to 149, the re-register bug was resolved.
<img width="1099" height="1062" alt="image" src="https://github.com/user-attachments/assets/355ae8f8-395a-4855-8a8b-9ac560dd6dc9" />

