### PR TITLE
fix(webmcp-local-relay): consolidate relay cleanup

### DIFF
--- a/packages/webmcp-local-relay/src/bridgeServer.test.ts
+++ b/packages/webmcp-local-relay/src/bridgeServer.test.ts
@@ -1649,7 +1649,7 @@ describe('RelayBridgeServer client mode', () => {
         return sources.length > 0 ? sources : undefined;
       });
 
-      // Stop the server — client should clear source data
+      // Stop the server; client should clear source data
       await server.stop();
       await new Promise((resolve) => setTimeout(resolve, 200));
 
@@ -1702,7 +1702,7 @@ describe('RelayBridgeServer client mode', () => {
       await client.start();
       expect(client.mode).toBe('client');
 
-      // Kill the server — client should eventually promote to server
+      // Kill the server; client should eventually promote to server
       await server.stop();
 
       // Wait for the client to become a server
@@ -1732,6 +1732,9 @@ describe('RelayBridgeServer client mode', () => {
     expect(() => new RelayBridgeServer({ port: 70000 })).toThrow(/Invalid port/);
     expect(() => new RelayBridgeServer({ maxPayloadBytes: 0 })).toThrow(/Invalid maxPayloadBytes/);
     expect(() => new RelayBridgeServer({ maxPayloadBytes: -5 })).toThrow(/Invalid maxPayloadBytes/);
+    expect(() => new RelayBridgeServer({ maxPayloadBytes: 1.5 })).toThrow(
+      /Invalid maxPayloadBytes/
+    );
     expect(() => new RelayBridgeServer({ invokeTimeoutMs: 0 })).toThrow(/Invalid invokeTimeoutMs/);
     expect(() => new RelayBridgeServer({ invokeTimeoutMs: -100 })).toThrow(
       /Invalid invokeTimeoutMs/
@@ -1873,7 +1876,7 @@ describe('RelayBridgeServer client mode', () => {
       // Start an invocation that will never complete
       const invokePromise = client.invokeTool(firstClientTool.name, {});
 
-      // Stop the client — should reject the pending invocation
+      // Stop the client; should reject the pending invocation
       await client.stop();
 
       await expect(invokePromise).rejects.toThrow(/Relay client stopped/);
@@ -1913,6 +1916,49 @@ describe('RelayBridgeServer client mode', () => {
       expect(stateChangedCount).toBe(1);
     } finally {
       await bridge.stop();
+    }
+  });
+
+  it('rejects pending invocations with payload-exceeded error when browser sends oversized result', async () => {
+    // Use a tiny maxPayloadBytes to trigger the 1009 close code.
+    const server = new RelayBridgeServer({
+      host: '127.0.0.1',
+      port: 0,
+      allowedOrigins: ['*'],
+      maxPayloadBytes: 256,
+      invokeTimeoutMs: 5000,
+    });
+
+    try {
+      await server.start();
+
+      const ws = await connectAndRegister(server, {
+        tabId: 'tab-payload',
+        url: 'https://example.com',
+        tools: [{ name: 'big_response', description: 'Returns large data' }],
+      });
+
+      // When invoked, respond with a payload that exceeds maxPayloadBytes.
+      ws.on('message', (raw) => {
+        const msg = JSON.parse(String(raw));
+        if (msg.type !== 'invoke') return;
+        const oversizedText = 'x'.repeat(1024);
+        ws.send(
+          JSON.stringify({
+            type: 'result',
+            callId: msg.callId,
+            result: { content: [{ type: 'text', text: oversizedText }] },
+          })
+        );
+      });
+
+      await waitFor(() => (server.registry.listTools().length >= 1 ? true : undefined));
+
+      const invokePromise = server.invokeTool('big_response', {});
+
+      await expect(invokePromise).rejects.toThrow(/exceeded maximum payload size/);
+    } finally {
+      await server.stop();
     }
   });
 });

--- a/packages/webmcp-local-relay/src/bridgeServer.ts
+++ b/packages/webmcp-local-relay/src/bridgeServer.ts
@@ -52,6 +52,17 @@ interface PendingInvocation {
   reject: (error: Error) => void;
 }
 
+interface WebSocketErrorWithCode extends Error {
+  code?: string;
+}
+
+function formatPayloadLimit(bytes: number): string {
+  if (bytes >= 1_000_000 && bytes % 1_000_000 === 0) {
+    return `${String(bytes / 1_000_000)}MB`;
+  }
+  return `${String(bytes)} bytes`;
+}
+
 /**
  * Runtime options for {@link RelayBridgeServer}.
  */
@@ -86,7 +97,7 @@ export interface RelayBridgeServerOptions {
    * Allowed host page origins reported by browser `hello` messages.
    * Use `["*"]` to allow all origins.
    *
-   * Permissive by default for zero-config developer experience — any browser
+   * Permissive by default for zero-config developer experience: any browser
    * page can connect and register tools without additional setup. For production
    * or shared machines, restrict to trusted host origins via the
    * `--widget-origin` CLI flag or by passing explicit origins here.
@@ -96,7 +107,7 @@ export interface RelayBridgeServerOptions {
   allowedOrigins?: string[];
   /**
    * Maximum WebSocket payload size in bytes.
-   * @defaultValue `1000000`
+   * @defaultValue `10000000`
    */
   maxPayloadBytes?: number;
   /**
@@ -192,7 +203,9 @@ export class RelayBridgeServer extends EventEmitter {
       options.portRangeEnd ?? Math.max(DEFAULT_RELAY_PORT_RANGE_END, this.preferredPort);
     this.persistPath = options.persistPath ?? defaultRelayPortPersistPath();
     this.allowedOrigins = options.allowedOrigins ?? ['*'];
-    this.maxPayloadBytes = options.maxPayloadBytes ?? 1_000_000;
+    // 10MB default: large enough for typical JSON API responses while
+    // still protecting the relay process from unbounded memory growth.
+    this.maxPayloadBytes = options.maxPayloadBytes ?? 10_000_000;
     this.invokeTimeoutMs = options.invokeTimeoutMs ?? 25_000;
     this.label = options.label;
     this.workspace = options.workspace;
@@ -209,8 +222,10 @@ export class RelayBridgeServer extends EventEmitter {
         `Invalid port range ${this.preferredPort}-${this.portRangeEnd}. rangeEnd must be greater than or equal to the preferred port.`
       );
     }
-    if (this.maxPayloadBytes <= 0) {
-      throw new Error(`Invalid maxPayloadBytes ${this.maxPayloadBytes}. Must be greater than 0.`);
+    if (!Number.isInteger(this.maxPayloadBytes) || this.maxPayloadBytes <= 0) {
+      throw new Error(
+        `Invalid maxPayloadBytes ${this.maxPayloadBytes}. Must be a positive integer.`
+      );
     }
     if (this.invokeTimeoutMs <= 0) {
       throw new Error(`Invalid invokeTimeoutMs ${this.invokeTimeoutMs}. Must be greater than 0.`);
@@ -505,15 +520,19 @@ export class RelayBridgeServer extends EventEmitter {
         this.onSocketMessage(connectionId, raw);
       });
 
-      socket.on('close', () => {
-        this.onSocketClose(connectionId);
+      socket.on('close', (code: number) => {
+        this.onSocketClose(connectionId, code);
       });
 
       socket.on('error', (err: Error) => {
         process.stderr.write(
           `[webmcp-local-relay] warn: socket error for connection ${connectionId}: ${err.message}\n`
         );
-        this.onSocketClose(connectionId);
+        const code =
+          (err as WebSocketErrorWithCode).code === 'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH'
+            ? 1009
+            : undefined;
+        this.onSocketClose(connectionId, code);
       });
 
       this.startHeartbeat(connectionId);
@@ -759,7 +778,7 @@ export class RelayBridgeServer extends EventEmitter {
     const socket = this.socketByConnectionId.get(connectionId);
     if (!socket || socket.readyState !== WebSocket.OPEN) {
       process.stderr.write(
-        `[webmcp-local-relay] warn: cannot send elicitation response — source ${connectionId} disconnected\n`
+        `[webmcp-local-relay] warn: cannot send elicitation response: source ${connectionId} disconnected\n`
       );
       return;
     }
@@ -891,16 +910,21 @@ export class RelayBridgeServer extends EventEmitter {
    * Guarded against double-call: both 'error' and 'close' events fire on
    * socket failure, but cleanup (and the stateChanged emission) runs only once.
    */
-  private onSocketClose(connectionId: string): void {
-    if (!this.socketByConnectionId.has(connectionId)) {
-      return;
-    }
+  private onSocketClose(connectionId: string, code?: number): void {
+    // Guard against double invocation: ws fires both 'error' and 'close' for
+    // maxPayload violations. The second call is a no-op.
+    if (!this.socketByConnectionId.has(connectionId)) return;
 
     this.stopHeartbeat(connectionId);
     this.relayClientConnectionIds.delete(connectionId);
     this.registry.removeConnection(connectionId);
     this.socketByConnectionId.delete(connectionId);
     this.emit('stateChanged');
+
+    // WS close code 1009 = "Message Too Big": the browser sent a response
+    // that exceeded maxPayloadBytes. Surface a clear error instead of letting
+    // the invocation time out silently after invokeTimeoutMs.
+    const isPayloadExceeded = code === 1009;
 
     for (const [callId, pending] of this.pendingInvocations.entries()) {
       if (pending.connectionId !== connectionId) {
@@ -909,7 +933,16 @@ export class RelayBridgeServer extends EventEmitter {
 
       clearTimeout(pending.timeoutId);
       this.pendingInvocations.delete(callId);
-      pending.reject(new Error(`Tool source ${connectionId} disconnected during invocation`));
+
+      if (isPayloadExceeded) {
+        pending.reject(
+          new Error(
+            `Tool result exceeded maximum payload size (${formatPayloadLimit(this.maxPayloadBytes)}). Use --max-payload to increase the limit.`
+          )
+        );
+      } else {
+        pending.reject(new Error(`Tool source ${connectionId} disconnected during invocation`));
+      }
     }
   }
 
@@ -923,7 +956,7 @@ export class RelayBridgeServer extends EventEmitter {
         return;
       }
 
-      // Skip heartbeat for relay client connections — they have their own reconnect logic.
+      // Skip heartbeat for relay client connections; they have their own reconnect logic.
       if (this.relayClientConnectionIds.has(connectionId)) {
         return;
       }

--- a/packages/webmcp-local-relay/src/browser/embed.test.ts
+++ b/packages/webmcp-local-relay/src/browser/embed.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Listener = (event: { data?: unknown; origin?: string; source?: unknown }) => void;
+
+interface FakeIframe {
+  contentWindow: { postMessage: ReturnType<typeof vi.fn> };
+  src: string;
+  style: { display: string };
+  addEventListener(type: string, listener: Listener): void;
+  setAttribute(name: string, value: string): void;
+}
+
+const originalDescriptors = {
+  Blob: Object.getOwnPropertyDescriptor(globalThis, 'Blob'),
+  HTMLScriptElement: Object.getOwnPropertyDescriptor(globalThis, 'HTMLScriptElement'),
+  URL: Object.getOwnPropertyDescriptor(globalThis, 'URL'),
+  crypto: Object.getOwnPropertyDescriptor(globalThis, 'crypto'),
+  document: Object.getOwnPropertyDescriptor(globalThis, 'document'),
+  fetch: Object.getOwnPropertyDescriptor(globalThis, 'fetch'),
+  navigator: Object.getOwnPropertyDescriptor(globalThis, 'navigator'),
+  sessionStorage: Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage'),
+  window: Object.getOwnPropertyDescriptor(globalThis, 'window'),
+};
+
+function restoreGlobal(key: keyof typeof originalDescriptors): void {
+  const descriptor = originalDescriptors[key];
+  if (descriptor) {
+    Object.defineProperty(globalThis, key, descriptor);
+    return;
+  }
+  delete (globalThis as Record<string, unknown>)[key];
+}
+
+async function importFreshEmbed(): Promise<void> {
+  vi.resetModules();
+  await import('./embed.js');
+}
+
+function installEmbedEnvironment(options?: {
+  modelContext?: unknown;
+  modelContextTesting?: unknown;
+}): {
+  iframe: FakeIframe;
+  windowListeners: Map<string, Set<Listener>>;
+} {
+  class FakeHTMLScriptElement {}
+
+  Object.defineProperty(globalThis, 'HTMLScriptElement', {
+    configurable: true,
+    value: FakeHTMLScriptElement,
+  });
+
+  const iframe: FakeIframe = {
+    contentWindow: { postMessage: vi.fn() },
+    src: '',
+    style: { display: '' },
+    addEventListener: vi.fn(),
+    setAttribute: vi.fn(),
+  };
+
+  const script = Object.create(FakeHTMLScriptElement.prototype) as HTMLScriptElement;
+  Object.defineProperties(script, {
+    getAttribute: {
+      value: (name: string) => {
+        const attrs: Record<string, string> = {
+          'data-auto-connect': 'false',
+          'data-relay-host': '127.0.0.1',
+          'data-relay-port': '9333',
+          'data-widget-url': 'https://cdn.example.com/widget.html',
+        };
+        return attrs[name] ?? null;
+      },
+    },
+    hasAttribute: { value: () => false },
+    src: { value: 'https://cdn.example.com/embed.js' },
+  });
+
+  const windowListeners = new Map<string, Set<Listener>>();
+  const documentListeners = new Map<string, Set<Listener>>();
+  const body = {
+    appendChild: vi.fn((node: FakeIframe) => node),
+  };
+
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: {
+      body,
+      addEventListener(type: string, listener: Listener) {
+        if (!documentListeners.has(type)) {
+          documentListeners.set(type, new Set());
+        }
+        documentListeners.get(type)!.add(listener);
+      },
+      createElement: vi.fn((tagName: string) => {
+        if (tagName !== 'iframe') {
+          throw new Error(`Unexpected element: ${tagName}`);
+        }
+        return iframe;
+      }),
+      currentScript: script,
+      querySelector: vi.fn(() => null),
+      title: 'Relay test',
+    },
+  });
+
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      addEventListener(type: string, listener: Listener) {
+        if (!windowListeners.has(type)) {
+          windowListeners.set(type, new Set());
+        }
+        windowListeners.get(type)!.add(listener);
+      },
+      location: {
+        hash: '#ignored',
+        href: 'https://app.example.com/page?debug=1#ignored',
+        origin: 'https://app.example.com',
+        reload: vi.fn(),
+        search: '?debug=1',
+      },
+      removeEventListener(type: string, listener: Listener) {
+        windowListeners.get(type)?.delete(listener);
+      },
+    },
+  });
+
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    value: {
+      getItem: vi.fn(() => 'tab-1'),
+      setItem: vi.fn(),
+    },
+  });
+
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {
+      ...(options?.modelContext ? { modelContext: options.modelContext } : {}),
+      ...(options?.modelContextTesting ? { modelContextTesting: options.modelContextTesting } : {}),
+    },
+  });
+
+  Object.defineProperty(globalThis, 'fetch', {
+    configurable: true,
+    value: vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      text: async () => '',
+    })),
+  });
+
+  return { iframe, windowListeners };
+}
+
+describe('relay embed tool sync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.resetModules();
+    for (const key of Object.keys(originalDescriptors) as Array<keyof typeof originalDescriptors>) {
+      restoreGlobal(key);
+    }
+  });
+
+  it('subscribes to both runtime event surfaces and posts changed tools from listTools', async () => {
+    const modelContextListeners = new Map<string, Listener>();
+    const testingListeners = new Map<string, Listener>();
+    let tools = [{ name: 'search', description: 'Search', inputSchema: { type: 'object' } }];
+    const env = installEmbedEnvironment({
+      modelContext: {
+        addEventListener: vi.fn((type: string, listener: Listener) => {
+          modelContextListeners.set(type, listener);
+        }),
+        callTool: vi.fn(),
+        listTools: vi.fn(() => tools),
+      },
+      modelContextTesting: {
+        addEventListener: vi.fn((type: string, listener: Listener) => {
+          testingListeners.set(type, listener);
+        }),
+        executeTool: vi.fn(),
+        listTools: vi.fn(() => []),
+      },
+    });
+
+    await importFreshEmbed();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(modelContextListeners.has('toolchange')).toBe(true);
+    expect(testingListeners.has('toolchange')).toBe(true);
+    expect(env.iframe.contentWindow.postMessage).toHaveBeenLastCalledWith(
+      { type: 'webmcp.tools.changed', tools },
+      'https://cdn.example.com'
+    );
+
+    tools = [
+      {
+        name: 'search',
+        description: 'Search v2',
+        inputSchema: { type: 'object', properties: { q: { type: 'string' } } },
+      },
+    ];
+    modelContextListeners.get('toolchange')?.({});
+    testingListeners.get('toolchange')?.({});
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(env.iframe.contentWindow.postMessage).toHaveBeenCalledTimes(2);
+    expect(env.iframe.contentWindow.postMessage).toHaveBeenLastCalledWith(
+      { type: 'webmcp.tools.changed', tools },
+      'https://cdn.example.com'
+    );
+  });
+
+  it('polls for silent AbortSignal tool removal after subscribing', async () => {
+    let tools = [
+      { name: 'alpha', description: 'A' },
+      { name: 'beta', description: 'B' },
+    ];
+    const env = installEmbedEnvironment({
+      modelContextTesting: {
+        addEventListener: vi.fn(),
+        executeTool: vi.fn(),
+        listTools: vi.fn(() =>
+          tools.map((tool) => ({
+            description: tool.description,
+            inputSchema: JSON.stringify({ type: 'object' }),
+            name: tool.name,
+          }))
+        ),
+      },
+    });
+
+    await importFreshEmbed();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(env.iframe.contentWindow.postMessage).toHaveBeenCalledTimes(1);
+
+    tools = [{ name: 'alpha', description: 'A' }];
+    await vi.advanceTimersByTimeAsync(2001);
+
+    expect(env.iframe.contentWindow.postMessage).toHaveBeenCalledTimes(2);
+    expect(env.iframe.contentWindow.postMessage).toHaveBeenLastCalledWith(
+      {
+        type: 'webmcp.tools.changed',
+        tools: [{ name: 'alpha', description: 'A', inputSchema: { type: 'object' } }],
+      },
+      'https://cdn.example.com'
+    );
+  });
+
+  it('polls immediately when no event subscription API exists', async () => {
+    let tools = [{ name: 'alpha', description: 'A' }];
+    const env = installEmbedEnvironment({
+      modelContextTesting: {
+        executeTool: vi.fn(),
+        listTools: vi.fn(() =>
+          tools.map((tool) => ({
+            description: tool.description,
+            inputSchema: JSON.stringify({ type: 'object' }),
+            name: tool.name,
+          }))
+        ),
+      },
+    });
+
+    await importFreshEmbed();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(env.iframe.contentWindow.postMessage).toHaveBeenCalledTimes(1);
+
+    tools = [{ name: 'alpha', description: 'A2' }];
+    await vi.advanceTimersByTimeAsync(2001);
+
+    expect(env.iframe.contentWindow.postMessage).toHaveBeenCalledTimes(2);
+    expect(env.iframe.contentWindow.postMessage).toHaveBeenLastCalledWith(
+      {
+        type: 'webmcp.tools.changed',
+        tools: [{ name: 'alpha', description: 'A2', inputSchema: { type: 'object' } }],
+      },
+      'https://cdn.example.com'
+    );
+  });
+});

--- a/packages/webmcp-local-relay/src/browser/embed.ts
+++ b/packages/webmcp-local-relay/src/browser/embed.ts
@@ -18,21 +18,14 @@ import type {
   ToolListItem,
 } from '@mcp-b/webmcp-types';
 import { isJsonObject } from './shared.js';
+import {
+  createToolReconciler,
+  type RelayToolDescriptor,
+  type ToolReconciler,
+} from './reconciler.js';
 
-/** Loose JSON object — values aren't recursively typed since we just forward them. */
+/** Loose JSON object: values aren't recursively typed since we just forward them. */
 type JsonObject = Record<string, unknown>;
-
-/**
- * Minimal tool shape sent to the relay widget — just name, description, and
- * a JSON-object inputSchema. Intentionally looser than ToolListItem so both
- * modelContext (ToolListItem) and modelContextTesting (string schema) can
- * be normalised into the same shape.
- */
-interface RelayToolDescriptor {
-  name: string;
-  description?: string;
-  inputSchema?: JsonObject;
-}
 
 interface ToolBridge {
   listTools: () => RelayToolDescriptor[] | Promise<RelayToolDescriptor[]>;
@@ -245,58 +238,74 @@ function getToolBridge(): ToolBridge | null {
   return null;
 }
 
-let pushScheduled = false;
+let reconciler: ToolReconciler | null = null;
 
-function onToolsChanged(): void {
-  if (pushScheduled || !widgetWindow) return;
-  pushScheduled = true;
-  setTimeout(() => {
-    pushScheduled = false;
-    if (!widgetWindow) return;
-    const bridge = getToolBridge();
-    const toolsPromise = bridge ? Promise.resolve(bridge.listTools()) : Promise.resolve([]);
-    toolsPromise
-      .then((tools) => {
-        if (!widgetWindow) return;
-        widgetWindow.postMessage(
-          {
-            type: 'webmcp.tools.changed',
-            tools: Array.isArray(tools) ? tools : [],
-          },
-          config.widgetOrigin
-        );
-      })
-      .catch((err: unknown) => {
-        debugWarn('Failed to push tool changes:', err);
-      });
-  }, 0);
+function scheduleToolReconcile(): void {
+  reconciler?.scheduleReconcile();
 }
 
+function initReconciler(): void {
+  reconciler = createToolReconciler({
+    listTools() {
+      const bridge = getToolBridge();
+      return bridge ? bridge.listTools() : [];
+    },
+    onChanged(tools) {
+      if (!widgetWindow) return;
+      widgetWindow.postMessage({ type: 'webmcp.tools.changed', tools }, config.widgetOrigin);
+    },
+  });
+}
+
+// Subscribe on BOTH modelContext and modelContextTesting (non-exclusive).
+// Chrome native fires toolchange on modelContextTesting; the polyfill fires on
+// modelContext. We subscribe to all available surfaces so no event is missed.
 function trySubscribe(): boolean {
+  if (!reconciler) return false;
+  let subscribed = false;
+
   const mc = getExtendedModelContext();
   if (mc) {
     try {
-      mc.addEventListener('toolchange', onToolsChanged);
-      return true;
+      mc.addEventListener('toolchange', scheduleToolReconcile);
+      subscribed = true;
     } catch (error) {
-      debugWarn('addEventListener threw:', error);
+      debugWarn('addEventListener on modelContext threw:', error);
     }
   }
+
   const testing = navigator.modelContextTesting as
     | (typeof navigator.modelContextTesting & Partial<ModelContextTestingPolyfillExtensions>)
     | undefined;
-  if (testing && typeof testing.registerToolsChangedCallback === 'function') {
-    try {
-      testing.registerToolsChangedCallback(onToolsChanged);
-      return true;
-    } catch (error) {
-      debugWarn('Failed to subscribe via registerToolsChangedCallback:', error);
+  if (testing) {
+    if (typeof testing.addEventListener === 'function') {
+      try {
+        testing.addEventListener('toolchange', scheduleToolReconcile);
+        subscribed = true;
+      } catch (error) {
+        debugWarn('addEventListener on modelContextTesting threw:', error);
+      }
+    } else if (typeof testing.registerToolsChangedCallback === 'function') {
+      try {
+        testing.registerToolsChangedCallback(scheduleToolReconcile);
+        subscribed = true;
+      } catch (error) {
+        debugWarn('Failed to subscribe via registerToolsChangedCallback:', error);
+      }
     }
   }
-  return false;
+
+  return subscribed;
 }
 
+// Polling fallback: Chrome 148+ removed unregisterTool(); tools are removed via
+// AbortSignal only, which does NOT fire a toolchange event. Polling every 2s
+// ensures we still detect those silent removals within a bounded delay.
 function subscribeToToolChanges(): void {
+  initReconciler();
+  reconciler!.startPolling();
+  reconciler!.scheduleReconcile();
+
   if (trySubscribe()) {
     return;
   }
@@ -315,7 +324,7 @@ function subscribeToToolChanges(): void {
 
       if (retries >= MAX_RETRIES) {
         debugWarn(
-          `Could not subscribe to tool changes after ${MAX_RETRIES} retries. Dynamic tool updates will not be relayed.`
+          `Could not subscribe to tool changes after ${MAX_RETRIES} retries. Dynamic tool updates will rely on polling.`
         );
         return;
       }
@@ -619,4 +628,10 @@ if (!document.querySelector(RELAY_IFRAME_SELECTOR)) {
   }
 
   subscribeToToolChanges();
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible' && widgetWindow) {
+      widgetWindow.postMessage({ type: 'webmcp.connect' }, config.widgetOrigin);
+    }
+  });
 }

--- a/packages/webmcp-local-relay/src/browser/reconciler.test.ts
+++ b/packages/webmcp-local-relay/src/browser/reconciler.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createSnapshot,
+  createToolReconciler,
+  stableStringify,
+  type RelayToolDescriptor,
+} from './reconciler.js';
+
+describe('stableStringify', () => {
+  it('sorts object keys recursively', () => {
+    const obj = { b: 1, a: { d: 2, c: 3 } };
+    expect(stableStringify(obj)).toBe('{"a":{"c":3,"d":2},"b":1}');
+  });
+
+  it('handles arrays without reordering', () => {
+    expect(stableStringify([3, 1, 2])).toBe('[3,1,2]');
+  });
+
+  it('handles null and primitives', () => {
+    expect(stableStringify(null)).toBe('null');
+    expect(stableStringify('hello')).toBe('"hello"');
+    expect(stableStringify(42)).toBe('42');
+    expect(stableStringify(true)).toBe('true');
+  });
+});
+
+describe('createSnapshot', () => {
+  it('sorts tools by name', () => {
+    const tools: RelayToolDescriptor[] = [
+      { name: 'zeta', description: 'z' },
+      { name: 'alpha', description: 'a' },
+    ];
+    const snapshot = createSnapshot(tools);
+    expect(snapshot.indexOf('alpha')).toBeLessThan(snapshot.indexOf('zeta'));
+  });
+
+  it('produces identical output for same tools in different order', () => {
+    const a: RelayToolDescriptor[] = [
+      { name: 'foo', description: 'f', inputSchema: { type: 'object' } },
+      { name: 'bar', description: 'b' },
+    ];
+    const b: RelayToolDescriptor[] = [
+      { name: 'bar', description: 'b' },
+      { name: 'foo', description: 'f', inputSchema: { type: 'object' } },
+    ];
+    expect(createSnapshot(a)).toBe(createSnapshot(b));
+  });
+
+  it('differs when description changes', () => {
+    const v1: RelayToolDescriptor[] = [{ name: 'tool', description: 'v1' }];
+    const v2: RelayToolDescriptor[] = [{ name: 'tool', description: 'v2' }];
+    expect(createSnapshot(v1)).not.toBe(createSnapshot(v2));
+  });
+
+  it('differs when inputSchema changes', () => {
+    const v1: RelayToolDescriptor[] = [
+      { name: 'tool', inputSchema: { type: 'object', properties: { a: { type: 'string' } } } },
+    ];
+    const v2: RelayToolDescriptor[] = [
+      { name: 'tool', inputSchema: { type: 'object', properties: { a: { type: 'number' } } } },
+    ];
+    expect(createSnapshot(v1)).not.toBe(createSnapshot(v2));
+  });
+});
+
+describe('createToolReconciler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('triggers onChanged when tools change', async () => {
+    const onChanged = vi.fn();
+    const tools: RelayToolDescriptor[] = [{ name: 'test', description: 'desc' }];
+
+    const r = createToolReconciler({ listTools: () => tools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    expect(onChanged).toHaveBeenCalledWith(tools);
+  });
+
+  it('does not trigger onChanged when tools are unchanged', async () => {
+    const onChanged = vi.fn();
+    const tools: RelayToolDescriptor[] = [{ name: 'test', description: 'desc' }];
+
+    const r = createToolReconciler({ listTools: () => tools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('triggers onChanged when only description changes', async () => {
+    const onChanged = vi.fn();
+    let tools: RelayToolDescriptor[] = [{ name: 'foo', description: 'v1' }];
+
+    const r = createToolReconciler({ listTools: () => tools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    tools = [{ name: 'foo', description: 'v2' }];
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(2);
+  });
+
+  it('triggers onChanged when only inputSchema changes', async () => {
+    const onChanged = vi.fn();
+    let tools: RelayToolDescriptor[] = [
+      { name: 'foo', inputSchema: { type: 'object', properties: { x: { type: 'string' } } } },
+    ];
+
+    const r = createToolReconciler({ listTools: () => tools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    tools = [
+      { name: 'foo', inputSchema: { type: 'object', properties: { x: { type: 'number' } } } },
+    ];
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not trigger when tool order changes', async () => {
+    const onChanged = vi.fn();
+    let tools: RelayToolDescriptor[] = [
+      { name: 'b', description: 'B' },
+      { name: 'a', description: 'A' },
+    ];
+
+    const r = createToolReconciler({ listTools: () => tools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    tools = [
+      { name: 'a', description: 'A' },
+      { name: 'b', description: 'B' },
+    ];
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('debounces multiple scheduleReconcile calls in the same tick', async () => {
+    const listTools = vi.fn(() => [{ name: 'x', description: 'd' }] as RelayToolDescriptor[]);
+    const onChanged = vi.fn();
+
+    const r = createToolReconciler({ listTools, onChanged });
+    r.scheduleReconcile();
+    r.scheduleReconcile();
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(listTools).toHaveBeenCalledTimes(1);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('startPolling triggers scheduleReconcile at the configured interval', async () => {
+    const onChanged = vi.fn();
+    let tools: RelayToolDescriptor[] = [];
+
+    const r = createToolReconciler({ listTools: () => tools, onChanged, pollInterval: 500 });
+    r.startPolling();
+
+    tools = [{ name: 'new-tool', description: 'added' }];
+    await vi.advanceTimersByTimeAsync(501);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(501);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+
+    r.dispose();
+  });
+
+  it('dispose stops polling', async () => {
+    const listTools = vi.fn(() => [] as RelayToolDescriptor[]);
+    const onChanged = vi.fn();
+
+    const r = createToolReconciler({ listTools, onChanged, pollInterval: 100 });
+    r.startPolling();
+    r.dispose();
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(listTools).not.toHaveBeenCalled();
+  });
+
+  it('dispose cancels a scheduled reconcile', async () => {
+    const listTools = vi.fn(() => [{ name: 'x' }] as RelayToolDescriptor[]);
+    const onChanged = vi.fn();
+
+    const r = createToolReconciler({ listTools, onChanged });
+    r.scheduleReconcile();
+    r.dispose();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(listTools).not.toHaveBeenCalled();
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it('handles async listTools', async () => {
+    const onChanged = vi.fn();
+    const tools: RelayToolDescriptor[] = [{ name: 'async-tool', description: 'async' }];
+    const listTools = () => Promise.resolve(tools);
+
+    const r = createToolReconciler({ listTools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+
+    expect(onChanged).toHaveBeenCalledWith(tools);
+  });
+
+  it('does not crash or notify when listTools throws', async () => {
+    const onChanged = vi.fn();
+    const listTools = () => {
+      throw new Error('fail');
+    };
+
+    const r = createToolReconciler({ listTools, onChanged });
+    r.scheduleReconcile();
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+});

--- a/packages/webmcp-local-relay/src/browser/reconciler.ts
+++ b/packages/webmcp-local-relay/src/browser/reconciler.ts
@@ -1,0 +1,96 @@
+type JsonObject = Record<string, unknown>;
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+
+export interface RelayToolDescriptor {
+  name: string;
+  description?: string;
+  inputSchema?: JsonObject;
+}
+
+export interface ReconcilerOptions {
+  listTools: () => RelayToolDescriptor[] | Promise<RelayToolDescriptor[]>;
+  onChanged: (tools: RelayToolDescriptor[]) => void;
+  pollInterval?: number;
+}
+
+export interface ToolReconciler {
+  scheduleReconcile(): void;
+  startPolling(): void;
+  dispose(): void;
+}
+
+// Deterministic JSON: recursively sorts object keys so property insertion order
+// doesn't affect the output. Required because inputSchema objects from different
+// sources may have identical content but different key ordering.
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(stableStringify).join(',') + ']';
+  }
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  return (
+    '{' +
+    keys
+      .map((k) => JSON.stringify(k) + ':' + stableStringify((value as Record<string, unknown>)[k]))
+      .join(',') +
+    '}'
+  );
+}
+
+export function createSnapshot(tools: RelayToolDescriptor[]): string {
+  return [...tools]
+    .map(stableStringify)
+    .sort((a, b) => a.localeCompare(b))
+    .join('\n');
+}
+
+export function createToolReconciler(options: ReconcilerOptions): ToolReconciler {
+  let lastSnapshot = '';
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let scheduledTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function reconcile(): void {
+    scheduledTimer = null;
+    // Outer try-catch: Promise.resolve(fn()) evaluates fn() synchronously,
+    // so a synchronous throw from listTools() escapes the .catch() handler.
+    try {
+      Promise.resolve(options.listTools())
+        .then((tools) => {
+          const list = Array.isArray(tools) ? tools : [];
+          const snapshot = createSnapshot(list);
+          if (snapshot !== lastSnapshot) {
+            lastSnapshot = snapshot;
+            options.onChanged(list);
+          }
+        })
+        .catch(() => {}); // listTools rejected asynchronously; skip this cycle
+    } catch {
+      // listTools threw synchronously; skip this cycle
+    }
+  }
+
+  function scheduleReconcile(): void {
+    if (scheduledTimer) return;
+    scheduledTimer = setTimeout(reconcile, 0);
+  }
+
+  function startPolling(): void {
+    if (pollTimer) return;
+    pollTimer = setInterval(scheduleReconcile, options.pollInterval ?? DEFAULT_POLL_INTERVAL_MS);
+  }
+
+  function dispose(): void {
+    if (scheduledTimer) {
+      clearTimeout(scheduledTimer);
+      scheduledTimer = null;
+    }
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  return { scheduleReconcile, startPolling, dispose };
+}

--- a/packages/webmcp-local-relay/src/browser/widget.test.ts
+++ b/packages/webmcp-local-relay/src/browser/widget.test.ts
@@ -677,13 +677,6 @@ describe('widget runtime', () => {
       );
     });
 
-    connection.client.send(JSON.stringify(42));
-    await vi.waitFor(() => {
-      expect(debug).toHaveBeenCalledWith(
-        '[webmcp-relay-widget] Ignoring non-object or untyped relay message'
-      );
-    });
-
     connection.client.send(JSON.stringify({ type: 'ping' }));
     await vi.waitFor(() => {
       expect(connection.messages).toContainEqual({ type: 'pong' });
@@ -920,5 +913,243 @@ describe('widget runtime', () => {
     await waitForConnection(env);
 
     expect(warn).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('dormant reconnection', () => {
+  type Listener = (event: unknown) => void;
+
+  let savedWebSocket: typeof WebSocket;
+  let wsUrls: string[];
+
+  function createFailingWebSocket(): typeof WebSocket {
+    return class MockWebSocket {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly CLOSING = 2;
+      static readonly CLOSED = 3;
+      readonly CONNECTING = 0;
+      readonly OPEN = 1;
+      readonly CLOSING = 2;
+      readonly CLOSED = 3;
+      url: string;
+      readyState = 0;
+      protocol = '';
+      private listeners = new Map<string, Array<{ fn: Listener; once?: boolean }>>();
+
+      constructor(url: string, _protocols?: string | string[]) {
+        this.url = url;
+        wsUrls.push(url);
+        queueMicrotask(() => {
+          this.readyState = 3;
+          this._emit('error', new Event('error'));
+          this._emit('close', new CloseEvent('close'));
+        });
+      }
+
+      addEventListener(t: string, fn: Listener, opts?: { once?: boolean }): void {
+        if (!this.listeners.has(t)) this.listeners.set(t, []);
+        this.listeners.get(t)!.push({ fn, once: opts?.once });
+      }
+
+      removeEventListener(t: string, fn: Listener): void {
+        const arr = this.listeners.get(t);
+        if (!arr) return;
+        const i = arr.findIndex((e) => e.fn === fn);
+        if (i >= 0) arr.splice(i, 1);
+      }
+
+      close(): void {
+        this.readyState = 3;
+      }
+
+      send(_d: string): void {}
+
+      private _emit(t: string, ev: Event): void {
+        for (const e of [...(this.listeners.get(t) ?? [])]) {
+          e.fn(ev);
+          if (e.once) {
+            const arr = this.listeners.get(t)!;
+            const i = arr.indexOf(e);
+            if (i >= 0) arr.splice(i, 1);
+          }
+        }
+      }
+    } as unknown as typeof WebSocket;
+  }
+
+  interface DormantEnv {
+    docListeners: Map<string, Set<Listener>>;
+    winListeners: Map<string, Set<Listener>>;
+    setVisibility: (v: DocumentVisibilityState) => void;
+    fireDocEvent: (type: string) => void;
+    fireWinEvent: (type: string) => void;
+  }
+
+  function setupDormantEnv(port = 9333): DormantEnv {
+    wsUrls = [];
+    const docListeners = new Map<string, Set<Listener>>();
+    const winListeners = new Map<string, Set<Listener>>();
+    let vis: DocumentVisibilityState = 'visible';
+
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      writable: true,
+      value: {
+        referrer: '',
+        get visibilityState() {
+          return vis;
+        },
+        addEventListener(t: string, fn: Listener) {
+          if (!docListeners.has(t)) docListeners.set(t, new Set());
+          docListeners.get(t)!.add(fn);
+        },
+        removeEventListener(t: string, fn: Listener) {
+          docListeners.get(t)?.delete(fn);
+        },
+      },
+    });
+
+    const store = new Map<string, string>();
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      configurable: true,
+      writable: true,
+      value: {
+        getItem: (k: string) => store.get(k) ?? null,
+        setItem: (k: string, v: string) => store.set(k, v),
+        removeItem: (k: string) => store.delete(k),
+        clear: () => store.clear(),
+      },
+    });
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      writable: true,
+      value: {
+        addEventListener(t: string, fn: Listener) {
+          if (!winListeners.has(t)) winListeners.set(t, new Set());
+          winListeners.get(t)!.add(fn);
+        },
+        removeEventListener(t: string, fn: Listener) {
+          winListeners.get(t)?.delete(fn);
+        },
+        location: {
+          search: buildSearch({
+            hostOrigin: APP_ORIGIN,
+            relayHost: '127.0.0.1',
+            relayPort: String(port),
+            tabId: 'tab-dormant',
+          }),
+        },
+        parent: { postMessage: vi.fn() },
+      },
+    });
+
+    return {
+      docListeners,
+      winListeners,
+      setVisibility(v: DocumentVisibilityState) {
+        vis = v;
+      },
+      fireDocEvent(type: string) {
+        for (const fn of docListeners.get(type) ?? []) fn(new Event(type));
+      },
+      fireWinEvent(type: string) {
+        for (const fn of winListeners.get(type) ?? []) fn(new Event(type));
+      },
+    };
+  }
+
+  async function fastForwardToDormant(): Promise<void> {
+    startWidgetRuntime();
+    await vi.advanceTimersByTimeAsync(70000);
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    savedWebSocket = globalThis.WebSocket;
+    globalThis.WebSocket = createFailingWebSocket();
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = savedWebSocket;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    restoreGlobal('document', originalDescriptors.document);
+    restoreGlobal('sessionStorage', originalDescriptors.sessionStorage);
+    restoreGlobal('window', originalDescriptors.window);
+  });
+
+  it('enters dormant after 3 failed rediscovery cycles and stops connections', async () => {
+    setupDormantEnv();
+    await fastForwardToDormant();
+
+    wsUrls.length = 0;
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(wsUrls).toHaveLength(0);
+  });
+
+  it('registers visibilitychange listener in dormant state', async () => {
+    const env = setupDormantEnv();
+    await fastForwardToDormant();
+
+    expect(env.docListeners.get('visibilitychange')?.size).toBe(1);
+  });
+
+  it('heartbeat only probes configured port, not full range', async () => {
+    setupDormantEnv(9333);
+    await fastForwardToDormant();
+
+    wsUrls.length = 0;
+    await vi.advanceTimersByTimeAsync(120000);
+
+    expect(wsUrls.length).toBeGreaterThan(0);
+    expect(wsUrls.length).toBeLessThanOrEqual(2);
+    expect(wsUrls[0]).toContain('9333');
+  });
+
+  it('wakes from dormant on visibilitychange and re-enters dormant on failure', async () => {
+    const env = setupDormantEnv();
+    await fastForwardToDormant();
+
+    wsUrls.length = 0;
+    env.setVisibility('visible');
+    env.fireDocEvent('visibilitychange');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(wsUrls.length).toBeGreaterThan(2);
+    expect(env.docListeners.get('visibilitychange')?.size).toBe(1);
+  });
+
+  it('wakes from dormant on webmcp.connect message', async () => {
+    const env = setupDormantEnv();
+    await fastForwardToDormant();
+
+    wsUrls.length = 0;
+    for (const fn of env.winListeners.get('message') ?? []) {
+      (fn as (event: { origin: string; data: unknown }) => void)({
+        origin: APP_ORIGIN,
+        data: { type: 'webmcp.connect' },
+      });
+    }
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(wsUrls.length).toBeGreaterThan(2);
+  });
+
+  it('does not duplicate listeners when re-entering dormant after wake failure', async () => {
+    const env = setupDormantEnv();
+    await fastForwardToDormant();
+
+    env.setVisibility('visible');
+    env.fireDocEvent('visibilitychange');
+    await vi.advanceTimersByTimeAsync(500);
+
+    env.setVisibility('hidden');
+    env.setVisibility('visible');
+    env.fireDocEvent('visibilitychange');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(env.docListeners.get('visibilitychange')?.size).toBe(1);
   });
 });

--- a/packages/webmcp-local-relay/src/browser/widgetRuntime.ts
+++ b/packages/webmcp-local-relay/src/browser/widgetRuntime.ts
@@ -85,7 +85,8 @@ type RelayRuntimeState =
   | 'discovering'
   | 'connected'
   | 'retry-same-endpoint'
-  | 'rediscover';
+  | 'rediscover'
+  | 'dormant';
 
 const RECONNECT_INITIAL_DELAY_MS = 500;
 const RECONNECT_MAX_DELAY_MS = 3000;
@@ -93,6 +94,12 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 60000;
 const RELAY_SERVER_HELLO_TIMEOUT_MS = 1200;
 const RELAY_HELLO_ACK_TIMEOUT_MS = 250;
 const MAX_ENDPOINT_FAILURES_BEFORE_REDISCOVERY = 5;
+
+/** Delay between rediscovery attempts (ms). */
+const REDISCOVERY_DELAYS_MS = [10000, 20000, 30000];
+const MAX_DISCOVERY_CYCLES_BEFORE_DORMANT = REDISCOVERY_DELAYS_MS.length;
+/** Heartbeat probe interval while dormant (ms). */
+const DORMANT_HEARTBEAT_INTERVAL_MS = 120000;
 
 export function parseConfig(search = window.location.search): WidgetConfig | null {
   const params = new URLSearchParams(search);
@@ -433,6 +440,8 @@ export function runWidget(cfg: WidgetConfig): void {
   let reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
   let scheduledReconnect: ReturnType<typeof setTimeout> | null = null;
   let state: RelayRuntimeState = 'idle';
+  let discoveryCycleCount = 0;
+  let dormantHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
   const rejectPendingRequests = (reason: string): void => {
     for (const [requestId, pending] of pendingRequests) {
@@ -493,6 +502,7 @@ export function runWidget(cfg: WidgetConfig): void {
     activeEndpoint = endpoint;
     activeSocket = socket;
     reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
+    discoveryCycleCount = 0;
     helloAccepted = false;
     setState('connected');
 
@@ -553,7 +563,6 @@ export function runWidget(cfg: WidgetConfig): void {
       }
 
       if (!isJsonObject(relayMessage) || typeof relayMessage.type !== 'string') {
-        console.debug('[webmcp-relay-widget] Ignoring non-object or untyped relay message');
         return;
       }
 
@@ -767,26 +776,136 @@ export function runWidget(cfg: WidgetConfig): void {
     }, delay);
   };
 
+  /**
+   * Schedules a full-range rediscovery attempt with increasing delays.
+   * After {@link MAX_DISCOVERY_CYCLES_BEFORE_DORMANT} failed cycles,
+   * transitions to dormant state.
+   */
   const scheduleRediscovery = (): void => {
     if (scheduledReconnect) {
       return;
     }
 
+    if (discoveryCycleCount >= MAX_DISCOVERY_CYCLES_BEFORE_DORMANT) {
+      enterDormant();
+      return;
+    }
+
     setState('rediscover');
-    const delay = Math.min(
-      RECONNECT_MAX_DELAY_MS,
-      Math.round(reconnectDelayMs * (0.85 + Math.random() * 0.3))
-    );
-    reconnectDelayMs = Math.min(Math.round(reconnectDelayMs * 1.5), RECONNECT_MAX_DELAY_MS);
+    const delay = REDISCOVERY_DELAYS_MS[discoveryCycleCount]!;
 
     scheduledReconnect = setTimeout(() => {
       scheduledReconnect = null;
       void discoverRelay().then((connected) => {
         if (!connected) {
+          discoveryCycleCount += 1;
           scheduleRediscovery();
         }
       });
     }, delay);
+  };
+
+  const onDormantVisibilityChange = (): void => {
+    if (document.visibilityState === 'visible' && state === 'dormant') {
+      wakeFromDormant();
+    }
+  };
+
+  const cleanupDormantListeners = (): void => {
+    document.removeEventListener('visibilitychange', onDormantVisibilityChange);
+    if (dormantHeartbeatTimer !== null) {
+      clearInterval(dormantHeartbeatTimer);
+      dormantHeartbeatTimer = null;
+    }
+  };
+
+  /**
+   * Enters dormant state: stops active reconnection and relies on
+   * visibilitychange events and periodic heartbeat probes to detect
+   * a relay that comes online later.
+   */
+  const enterDormant = (): void => {
+    if (state === 'dormant') {
+      return;
+    }
+
+    setState('dormant');
+
+    if (scheduledReconnect) {
+      clearTimeout(scheduledReconnect);
+      scheduledReconnect = null;
+    }
+
+    document.addEventListener('visibilitychange', onDormantVisibilityChange);
+
+    dormantHeartbeatTimer = setInterval(() => {
+      void heartbeatProbe();
+    }, DORMANT_HEARTBEAT_INTERVAL_MS);
+  };
+
+  /**
+   * Lightweight probe: only checks the configured port and cached endpoint,
+   * skipping a full-range discovery scan.
+   */
+  const heartbeatProbe = async (): Promise<void> => {
+    if (state !== 'dormant') {
+      return;
+    }
+
+    const seen = new Set<string>();
+    const candidates: Array<{ host: string; port: number }> = [];
+
+    const pushCandidate = (host: string, port: number): void => {
+      const key = `${host}:${String(port)}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      candidates.push({ host, port });
+    };
+
+    if (cfg.relayPortHint !== undefined) {
+      pushCandidate(cfg.relayHostHint, cfg.relayPortHint);
+    }
+
+    const cached = readCachedEndpoint(cfg);
+    if (cached) {
+      pushCandidate(cached.host, cached.port);
+    }
+
+    if (candidates.length === 0) {
+      return;
+    }
+
+    // Transition state and remove listeners to prevent concurrent event-driven wakes.
+    setState('discovering');
+    cleanupDormantListeners();
+
+    for (const candidate of candidates) {
+      const connected = await connectToEndpoint(candidate);
+      if (connected) {
+        discoveryCycleCount = 0;
+        return;
+      }
+    }
+
+    // Probe failed; go back to dormant.
+    enterDormant();
+  };
+
+  /**
+   * Wakes from dormant state: cleans up listeners, resets backoff
+   * counters, and runs a full-range discovery. Falls back to dormant
+   * again if discovery fails.
+   */
+  const wakeFromDormant = (): void => {
+    cleanupDormantListeners();
+    reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
+    discoveryCycleCount = 0;
+
+    void discoverRelay().then((connected) => {
+      if (!connected) {
+        enterDormant();
+      }
+    });
   };
 
   window.addEventListener('message', (event: MessageEvent) => {
@@ -809,7 +928,9 @@ export function runWidget(cfg: WidgetConfig): void {
     }
 
     if (isJsonObject(data) && data.type === 'webmcp.connect') {
-      if (!activeSocket && state !== 'discovering') {
+      if (state === 'dormant') {
+        wakeFromDormant();
+      } else if (!activeSocket && state !== 'discovering') {
         void discoverRelay();
       }
       return;

--- a/packages/webmcp-local-relay/src/cli-utils.test.ts
+++ b/packages/webmcp-local-relay/src/cli-utils.test.ts
@@ -136,4 +136,36 @@ describe('parseCliOptions', () => {
     const options = parseCliOptions(argv);
     expect(options.host).toBe('0.0.0.0');
   });
+
+  it('parses --max-payload flag', () => {
+    const options = parseCliOptions(['--max-payload', '20000000']);
+    expect(options.maxPayloadBytes).toBe(20000000);
+  });
+
+  it('throws for non-numeric --max-payload', () => {
+    expect(() => parseCliOptions(['--max-payload', 'abc'])).toThrow('Invalid max-payload "abc"');
+  });
+
+  it('throws for decimal --max-payload', () => {
+    expect(() => parseCliOptions(['--max-payload', '1.5'])).toThrow('Invalid max-payload "1.5"');
+  });
+
+  it('throws for suffixed --max-payload', () => {
+    expect(() => parseCliOptions(['--max-payload', '10mb'])).toThrow('Invalid max-payload "10mb"');
+  });
+
+  it('throws for zero --max-payload', () => {
+    expect(() => parseCliOptions(['--max-payload', '0'])).toThrow('Invalid max-payload "0"');
+  });
+
+  it('throws for negative --max-payload', () => {
+    expect(() => parseCliOptions(['--max-payload', '-5'])).toThrow(
+      'Missing value for --max-payload'
+    );
+  });
+
+  it('returns undefined maxPayloadBytes when --max-payload is not provided', () => {
+    const options = parseCliOptions([]);
+    expect(options.maxPayloadBytes).toBeUndefined();
+  });
 });

--- a/packages/webmcp-local-relay/src/cli-utils.ts
+++ b/packages/webmcp-local-relay/src/cli-utils.ts
@@ -9,6 +9,7 @@ export interface CliOptions {
   label?: string;
   workspace?: string;
   relayId?: string;
+  maxPayloadBytes?: number;
 }
 
 /**
@@ -19,7 +20,7 @@ export function parseCliOptions(argv: string[]): CliOptions {
     host: '127.0.0.1',
     port: 9333,
     portExplicitlySet: false,
-    // Permissive by default for zero-config local development — any browser page can connect.
+    // Permissive by default for zero-config local development: any browser page can connect.
     // Use --widget-origin to restrict to trusted origins on shared machines or in production.
     allowedOrigins: ['*'],
   };
@@ -88,6 +89,17 @@ export function parseCliOptions(argv: string[]): CliOptions {
       continue;
     }
 
+    if (token === '--max-payload') {
+      const raw = readFlagValue(token, i);
+      i += 1;
+      const value = Number(raw);
+      if (!Number.isInteger(value) || value <= 0) {
+        throw new Error(`Invalid max-payload "${raw}". Must be a positive integer (bytes).`);
+      }
+      options.maxPayloadBytes = value;
+      continue;
+    }
+
     if (token === '--help' || token === '-h') {
       printHelp();
       process.exit(0);
@@ -125,6 +137,7 @@ export function printHelp(): void {
       '  --label                  Human-readable relay label reported during discovery',
       '  --workspace              Optional workspace name reported during discovery',
       '  --relay-id               Stable relay identifier reported during discovery',
+      '  --max-payload            Maximum WebSocket payload size in bytes (default: 10000000)',
       '  --help, -h               Show help',
       '',
     ].join('\n')

--- a/packages/webmcp-local-relay/src/cli.ts
+++ b/packages/webmcp-local-relay/src/cli.ts
@@ -27,6 +27,7 @@ const bridgeOptions = {
   ...(options.label ? { label: options.label } : {}),
   ...(options.relayId ? { relayId: options.relayId } : {}),
   ...(options.workspace ? { workspace: options.workspace } : {}),
+  ...(options.maxPayloadBytes ? { maxPayloadBytes: options.maxPayloadBytes } : {}),
 };
 
 const relay = new LocalRelayMcpServer({


### PR DESCRIPTION
## Sources

Consolidates the useful local-relay work from:

- #221 by @aliciqin: tool-list sync on unregister and abort cleanup
- #229 by @aliciqin: dormant WebSocket reconnect behavior
- #230 by @aliciqin: higher payload ceiling and `--max-payload`

This also builds on the already-merged #220 CPU/reconnect fix by @aliciqin. The commit keeps a `Co-authored-by` trailer for the contributor and links the original PRs here so attribution is explicit.

## What Changed

- Adds a small browser-side tool reconciler that treats `listTools()` as the source of truth.
- Starts polling immediately so silent AbortSignal unregisters and eventless runtimes still sync.
- Subscribes to both `modelContext` and `modelContextTesting` toolchange surfaces when available.
- Adds actual side-effect embed tests instead of only testing simulated wiring.
- Adds dormant widget reconnect behavior after repeated rediscovery failures.
- Wakes dormant widgets via host `visibilitychange`, `webmcp.connect`, or a lightweight heartbeat probe.
- Raises the default relay WebSocket payload limit from 1MB to 10MB.
- Adds `--max-payload` with stricter positive-integer byte parsing.
- Rejects oversized browser tool results immediately instead of waiting for invocation timeout.

## Cleanup Choices

- Dropped the `docs/superpowers` plan/spec files from #221.
- Dropped generated showcase/example browser bundle churn from #229.
- Kept this source/test-only so the diff is reviewable and the package build remains the artifact source.

## Validation

- `pnpm --filter @mcp-b/webmcp-local-relay run check`
- `pnpm --filter @mcp-b/webmcp-local-relay run typecheck`
- `pnpm --filter @mcp-b/webmcp-local-relay test -- --coverage` - 317 tests passed
- `pnpm --filter @mcp-b/webmcp-local-relay test:e2e` - 10 tests passed
- `CI=true pnpm exec vp check` - exit 0; existing warnings remain in `skills/webmcp-setup/scripts/verify-setup.js`
