### PR TITLE
chore(webmcp-local-relay): simplify browser runtime

### DIFF
--- a/packages/webmcp-local-relay/src/browser/embed.ts
+++ b/packages/webmcp-local-relay/src/browser/embed.ts
@@ -240,6 +240,15 @@ function getToolBridge(): ToolBridge | null {
   return null;
 }
 
+function listRelayTools(): Promise<RelayToolDescriptor[]> {
+  const bridge = getToolBridge();
+  if (!bridge) {
+    return Promise.resolve([]);
+  }
+
+  return Promise.resolve(bridge.listTools()).then((tools) => (Array.isArray(tools) ? tools : []));
+}
+
 let toolSyncScheduled = false;
 let toolSyncPollTimer: ReturnType<typeof setInterval> | null = null;
 let lastToolsSnapshot = '';
@@ -264,16 +273,13 @@ function toolsSnapshot(tools: RelayToolDescriptor[]): string {
 
 function pushToolsIfChanged(): void {
   toolSyncScheduled = false;
-  const bridge = getToolBridge();
-  const toolsPromise = bridge ? Promise.resolve(bridge.listTools()) : Promise.resolve([]);
 
-  toolsPromise
+  listRelayTools()
     .then((tools) => {
-      const list = Array.isArray(tools) ? tools : [];
-      const nextSnapshot = toolsSnapshot(list);
+      const nextSnapshot = toolsSnapshot(tools);
       if (nextSnapshot === lastToolsSnapshot || !widgetWindow) return;
       lastToolsSnapshot = nextSnapshot;
-      widgetWindow.postMessage({ type: 'webmcp.tools.changed', tools: list }, config.widgetOrigin);
+      widgetWindow.postMessage({ type: 'webmcp.tools.changed', tools }, config.widgetOrigin);
     })
     .catch((err: unknown) => {
       debugWarn('Failed to sync tool changes:', err);
@@ -399,15 +405,12 @@ function parseWidgetRequest(value: unknown): WidgetRequestMessage | null {
 }
 
 function handleListRequest(request: WidgetRequestMessage, event: MessageEvent): void {
-  const bridge = getToolBridge();
-  const toolsPromise = bridge ? Promise.resolve(bridge.listTools()) : Promise.resolve([]);
-
-  toolsPromise
+  listRelayTools()
     .then((tools) => {
       respondToSource(event.source, event.origin, {
         type: 'webmcp.tools.list.response',
         requestId: request.requestId,
-        tools: Array.isArray(tools) ? tools : [],
+        tools,
       });
     })
     .catch((error: unknown) => {
@@ -486,10 +489,11 @@ function installElicitBridge(widgetSource: MessageEventSource, widgetOrigin: str
       };
       window.addEventListener('message', handler);
 
-      (widgetSource as Window).postMessage(
-        { type: 'webmcp.elicitation.request', callId, params },
-        widgetOrigin
-      );
+      respondToSource(widgetSource, widgetOrigin, {
+        type: 'webmcp.elicitation.request',
+        callId,
+        params,
+      });
     });
   };
 
@@ -571,14 +575,14 @@ async function injectRelayWidget(cfg: RelayConfig): Promise<void> {
       console.warn(
         `[webmcp-relay-embed] Widget HTML fetch returned ${String(response.status)}; falling back to direct iframe src.`
       );
-    } else if (response.ok) {
+    } else {
       const html = await response.text();
       const configScript = `<script>window.__WEBMCP_RELAY_CONFIG=${JSON.stringify(Object.fromEntries(searchParams))};</script>`;
       const blob = new Blob([html.replace('</head>', `${configScript}</head>`)], {
         type: 'text/html',
       });
       blobUrl = URL.createObjectURL(blob);
-      config.widgetOrigin = window.location.origin;
+      cfg.widgetOrigin = window.location.origin;
     }
   } catch (err) {
     debugWarn('Failed to fetch widget HTML for blob URL:', err);

--- a/packages/webmcp-local-relay/src/browser/widgetRuntime.ts
+++ b/packages/webmcp-local-relay/src/browser/widgetRuntime.ts
@@ -80,13 +80,7 @@ interface CachedRelayEndpoint {
   port: number;
 }
 
-type RelayRuntimeState =
-  | 'idle'
-  | 'discovering'
-  | 'connected'
-  | 'retry-same-endpoint'
-  | 'rediscover'
-  | 'dormant';
+type RelayRuntimePhase = 'idle' | 'discovering' | 'dormant';
 
 const RECONNECT_INITIAL_DELAY_MS = 500;
 const RECONNECT_MAX_DELAY_MS = 3000;
@@ -439,7 +433,7 @@ export function runWidget(cfg: WidgetConfig): void {
   let helloAckTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
   let scheduledReconnect: ReturnType<typeof setTimeout> | null = null;
-  let state: RelayRuntimeState = 'idle';
+  let phase: RelayRuntimePhase = 'idle';
   let discoveryCycleCount = 0;
   let dormantHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -449,10 +443,6 @@ export function runWidget(cfg: WidgetConfig): void {
       pendingRequests.delete(requestId);
       pending.reject(new Error(reason));
     }
-  };
-
-  const setState = (nextState: RelayRuntimeState): void => {
-    state = nextState;
   };
 
   function requestHost(baseType: string, payload: Record<string, unknown>): Promise<HostMessage> {
@@ -504,7 +494,7 @@ export function runWidget(cfg: WidgetConfig): void {
     reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS;
     discoveryCycleCount = 0;
     helloAccepted = false;
-    setState('connected');
+    phase = 'idle';
 
     socket.addEventListener('message', (event) => {
       let relayMessage: Record<string, unknown>;
@@ -728,17 +718,23 @@ export function runWidget(cfg: WidgetConfig): void {
   };
 
   const discoverRelay = async (): Promise<boolean> => {
-    setState('discovering');
+    phase = 'discovering';
 
-    for (const candidate of buildDiscoveryCandidates(cfg)) {
-      const connected = await connectToEndpoint(candidate);
-      if (connected) {
-        consecutiveEndpointFailures = 0;
-        return true;
+    try {
+      for (const candidate of buildDiscoveryCandidates(cfg)) {
+        const connected = await connectToEndpoint(candidate);
+        if (connected) {
+          consecutiveEndpointFailures = 0;
+          return true;
+        }
+      }
+
+      return false;
+    } finally {
+      if (phase === 'discovering') {
+        phase = 'idle';
       }
     }
-
-    return false;
   };
 
   const scheduleRetrySameEndpoint = (): void => {
@@ -746,7 +742,6 @@ export function runWidget(cfg: WidgetConfig): void {
       return;
     }
 
-    setState('retry-same-endpoint');
     const retryEndpoint = {
       host: activeEndpoint.host,
       port: activeEndpoint.port,
@@ -791,7 +786,6 @@ export function runWidget(cfg: WidgetConfig): void {
       return;
     }
 
-    setState('rediscover');
     const delay = REDISCOVERY_DELAYS_MS[discoveryCycleCount]!;
 
     scheduledReconnect = setTimeout(() => {
@@ -806,7 +800,7 @@ export function runWidget(cfg: WidgetConfig): void {
   };
 
   const onDormantVisibilityChange = (): void => {
-    if (document.visibilityState === 'visible' && state === 'dormant') {
+    if (document.visibilityState === 'visible' && phase === 'dormant') {
       wakeFromDormant();
     }
   };
@@ -825,11 +819,11 @@ export function runWidget(cfg: WidgetConfig): void {
    * a relay that comes online later.
    */
   const enterDormant = (): void => {
-    if (state === 'dormant') {
+    if (phase === 'dormant') {
       return;
     }
 
-    setState('dormant');
+    phase = 'dormant';
 
     if (scheduledReconnect) {
       clearTimeout(scheduledReconnect);
@@ -848,7 +842,7 @@ export function runWidget(cfg: WidgetConfig): void {
    * skipping a full-range discovery scan.
    */
   const heartbeatProbe = async (): Promise<void> => {
-    if (state !== 'dormant') {
+    if (phase !== 'dormant') {
       return;
     }
 
@@ -876,7 +870,7 @@ export function runWidget(cfg: WidgetConfig): void {
     }
 
     // Transition state and remove listeners to prevent concurrent event-driven wakes.
-    setState('discovering');
+    phase = 'discovering';
     cleanupDormantListeners();
 
     for (const candidate of candidates) {
@@ -928,9 +922,9 @@ export function runWidget(cfg: WidgetConfig): void {
     }
 
     if (isJsonObject(data) && data.type === 'webmcp.connect') {
-      if (state === 'dormant') {
+      if (phase === 'dormant') {
         wakeFromDormant();
-      } else if (!activeSocket && state !== 'discovering') {
+      } else if (!activeSocket && phase !== 'discovering') {
         void discoverRelay();
       }
       return;
@@ -981,7 +975,5 @@ export function runWidget(cfg: WidgetConfig): void {
         scheduleRediscovery();
       }
     });
-  } else {
-    setState('idle');
   }
 }

--- a/packages/webmcp-local-relay/src/mcpRelayServer.test.ts
+++ b/packages/webmcp-local-relay/src/mcpRelayServer.test.ts
@@ -30,6 +30,25 @@ async function waitFor<T>(
   throw new Error('Timed out waiting for condition');
 }
 
+type ClientToolList = Awaited<ReturnType<Client['listTools']>>;
+type ClientTool = ClientToolList['tools'][number];
+
+async function waitForClientToolList(client: Client, toolName: string): Promise<ClientToolList> {
+  return waitFor(async () => {
+    const list = await client.listTools();
+    return list.tools.some((tool) => tool.name === toolName) ? list : undefined;
+  });
+}
+
+async function waitForClientTool(client: Client, toolName: string): Promise<ClientTool> {
+  const list = await waitForClientToolList(client, toolName);
+  const tool = list.tools.find((entry) => entry.name === toolName);
+  if (!tool) {
+    throw new Error(`Timed out waiting for client-visible tool ${toolName}`);
+  }
+  return tool;
+}
+
 /**
  * Extracts text items from MCP call tool result content.
  */
@@ -494,9 +513,7 @@ describe('LocalRelayMcpServer', () => {
 
     const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-    const list = await client.listTools();
-    const tool = list.tools.find((t) => t.name === toolName);
-    expect(tool).toBeTruthy();
+    const tool = await waitForClientTool(client, toolName);
     expect(tool?.annotations?.readOnlyHint).toBe(true);
 
     ws.close();
@@ -527,9 +544,7 @@ describe('LocalRelayMcpServer', () => {
 
     const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-    const list = await client.listTools();
-    const tool = list.tools.find((t) => t.name === toolName);
-    expect(tool).toBeTruthy();
+    const tool = await waitForClientTool(client, toolName);
     expect(tool?.inputSchema).toEqual({
       type: 'object',
       properties: {
@@ -943,9 +958,7 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-      const list = await client.listTools();
-      const tool = list.tools.find((t) => t.name === toolName);
-      expect(tool).toBeTruthy();
+      const tool = await waitForClientTool(client, toolName);
       expect(tool?.inputSchema).toEqual({
         type: 'object',
         properties: {},
@@ -989,9 +1002,7 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-      const list = await client.listTools();
-      const tool = list.tools.find((t) => t.name === toolName);
-      expect(tool).toBeTruthy();
+      const tool = await waitForClientTool(client, toolName);
       expect(tool?.inputSchema).toEqual(complexSchema);
 
       ws.close();
@@ -1018,9 +1029,7 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-      const list = await client.listTools();
-      const tool = list.tools.find((t) => t.name === toolName);
-      expect(tool).toBeTruthy();
+      const tool = await waitForClientTool(client, toolName);
       expect(tool?.inputSchema).toEqual(inputSchema);
       expect((tool as Record<string, unknown>).outputSchema).toEqual(outputSchema);
 
@@ -1089,7 +1098,7 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-      const list = await client.listTools();
+      const list = await waitForClientToolList(client, toolName);
 
       const expectedStaticSchemas: Record<string, Record<string, unknown>> = {
         webmcp_list_sources: publicInputSchemaFromZodShape(EMPTY_STATIC_TOOL_INPUT_SHAPE),
@@ -1107,7 +1116,6 @@ describe('LocalRelayMcpServer', () => {
 
       // Dynamic tool present with real schema
       const dynamicTool = list.tools.find((t) => t.name === toolName);
-      expect(dynamicTool).toBeTruthy();
       expect(dynamicTool?.inputSchema).toEqual(dynamicSchema);
 
       // Total count: 4 static + 1 dynamic
@@ -1138,8 +1146,7 @@ describe('LocalRelayMcpServer', () => {
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
       // Verify initial schema
-      const list1 = await client.listTools();
-      const tool1 = list1.tools.find((t) => t.name === toolName);
+      const tool1 = await waitForClientTool(client, toolName);
       expect(tool1?.inputSchema).toEqual(initialSchema);
 
       // Send updated schema
@@ -1184,7 +1191,10 @@ describe('LocalRelayMcpServer', () => {
       await waitFor(() => bridge.registry.listTools()[0]?.name);
 
       // Verify tool is listed
-      const list1 = await client.listTools();
+      const list1 = await waitFor(async () => {
+        const list = await client.listTools();
+        return list.tools.some((tool) => !tool.name.startsWith('webmcp_')) ? list : undefined;
+      });
       expect(list1.tools.find((t) => !t.name.startsWith('webmcp_'))).toBeTruthy();
 
       // Disconnect browser
@@ -1278,9 +1288,7 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-      const list = await client.listTools();
-      const tool = list.tools.find((t) => t.name === toolName);
-      expect(tool).toBeTruthy();
+      const tool = await waitForClientTool(client, toolName);
       expect(tool?.inputSchema).toEqual(inputSchema);
       expect((tool as Record<string, unknown>).outputSchema).toEqual(outputSchema);
       expect(tool?.annotations?.readOnlyHint).toBe(true);
@@ -1301,9 +1309,7 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-      const list = await client.listTools();
-      const tool = list.tools.find((t) => t.name === toolName);
-      expect(tool).toBeTruthy();
+      const tool = await waitForClientTool(client, toolName);
       expect(tool?.inputSchema).toEqual({
         type: 'object',
         properties: {},
@@ -1353,10 +1359,9 @@ describe('LocalRelayMcpServer', () => {
 
       const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
 
-      const list = await client.listTools();
+      const list = await waitForClientToolList(client, toolName);
       expect(list.tools).toHaveLength(5); // 4 static + 1 dynamic
       const tool = list.tools.find((t) => t.name === toolName);
-      expect(tool).toBeTruthy();
       expect(tool?.inputSchema).toEqual(finalSchema);
 
       ws.close();


### PR DESCRIPTION
## Summary

Follow-up to:
- https://github.com/WebMCP-org/npm-packages/pull/243
- https://github.com/WebMCP-org/npm-packages/pull/244

This keeps shaving down the local relay browser code after the larger cleanup landed. The behavior stays the same, but the runtime has fewer states and fewer duplicate tool-listing paths.

## What changed

- Removed widget runtime phases that were assigned but never observed (`connected`, `retry-same-endpoint`, `rediscover`).
- Kept only the phases that control behavior: `idle`, `discovering`, and `dormant`.
- Centralized host tool listing normalization in `embed.ts` so list responses and tool-change pushes use the same path.
- Reused the existing guarded `postMessage` helper for elicitation forwarding.
- Simplified the widget HTML fetch branch and updated `injectRelayWidget` to mutate its local config parameter instead of the outer global.
- Stabilized schema-fidelity tests so they wait for the MCP client-visible tool list, not just the bridge registry.

## Why

The previous cleanup made the local relay behavior safer, but there was still some leftover scaffolding that future agents would probably copy or over-interpret. This trims that down without changing reconnect, dormant wakeup, or tool sync semantics.

The first CI run exposed an existing race in `mcpRelayServer.test.ts`: the bridge registry could show a dynamic tool before `client.listTools()` observed it. The updated tests now wait on the client-visible contract they assert.

## Validation

- `pnpm --filter @mcp-b/webmcp-local-relay run check`
- `pnpm --filter @mcp-b/webmcp-local-relay run typecheck`
- `pnpm --filter @mcp-b/webmcp-local-relay test -- --coverage`
- `pnpm --filter @mcp-b/webmcp-local-relay test:e2e`
- `CI=true pnpm exec vp check` exits 0; remaining 37 warnings are existing repo-baseline warnings outside this diff.

Note: attempted `pnpm exec fallow audit --format json --quiet --base main --explain`, but `fallow` is not installed in this workspace.
