### PR TITLE
fix(release): use workflow token for release PRs

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -76,9 +76,7 @@ jobs:
           # Create GitHub releases for each published package
           createGithubReleases: true
         env:
-          # Use PAT if available (allows triggering other workflows)
-          # Falls back to GITHUB_TOKEN (won't trigger other workflows)
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate SBOM
         if: steps.changesets.outputs.published == 'true'

--- a/.npmrc
+++ b/.npmrc
@@ -4,7 +4,6 @@ strict-peer-dependencies=false
 link-workspace-packages=true
 auto-install-peers=true
 registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 
 # Catalog mode: prefer catalog versions when adding dependencies
 catalog-mode=prefer


### PR DESCRIPTION
## References

- Failing release run: https://github.com/WebMCP-org/npm-packages/actions/runs/27318645452
- npm trusted publishing: https://docs.npmjs.com/trusted-publishers/
- GitHub Actions OIDC overview: https://docs.github.com/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect
- GitHub GITHUB_TOKEN authentication: https://docs.github.com/actions/reference/authentication-in-a-workflow

## What changed

- Use the job-scoped GITHUB_TOKEN for the Changesets action instead of preferring the repository PAT_TOKEN secret.
- Remove the project-level npm auth-token placeholder from .npmrc now that release publishing is intended to use npm trusted publishing/OIDC.

## Why

The release job already grants contents: write, pull-requests: write, and id-token: write. npm publishing is set up for trusted publishing, but the GitHub API side of the Changesets action was still using PAT_TOKEN when present. The current PAT can push changeset-release/main, but GitHub rejects release PR creation with: Resource not accessible by personal access token.

Using GITHUB_TOKEN keeps GitHub API operations scoped to the workflow job permissions and avoids the stale PAT path.

## Validation

- git diff --check
- pnpm check:ci (passes with existing repo warnings, 0 errors)