### PR TITLE
feat(webmcp-polyfill): serialize image tool results

### DIFF
--- a/docs/plans/WEBMCP_IMAGE_TOOL_CONTENT_INVESTIGATION.md
+++ b/docs/plans/WEBMCP_IMAGE_TOOL_CONTENT_INVESTIGATION.md
@@ -1,0 +1,426 @@
+# WebMCP Image Tool Content Investigation
+
+Date: 2026-06-11
+
+## Scope
+
+This is an investigation note for adding image input/output support to the
+WebMCP polyfill and preparing a shared end-to-end conformance suite that can run
+against both the polyfill and a future Chromium implementation.
+
+Companion execution plan:
+[`WEBMCP_IMAGE_TOOL_CONTENT_TDD_PLAN.md`](./WEBMCP_IMAGE_TOOL_CONTENT_TDD_PLAN.md).
+
+Implementation correction after spec review: this work extends the WebMCP API,
+not the MCP API. The implementation should return direct WebMCP image values
+through `document.modelContext.executeTool(...)`; it should not introduce MCP
+`content` blocks, MCP clients, or the MCPB global runtime into the WebMCP
+conformance path.
+
+The motivating issue is
+[webmachinelearning/webmcp#41](https://github.com/webmachinelearning/webmcp/issues/41),
+which asks for image input to tools and image output from tools. The issue
+specifically calls out an ergonomic browser shape such as:
+
+```js
+document.modelContext.registerTool({
+  name: 'get_product_image',
+  description: 'Get the product image from the page',
+  inputSchema: {
+    type: 'object',
+    properties: { productId: { type: 'string' } },
+  },
+  async execute({ productId }) {
+    const img = document.querySelector(`#product-${productId} img`);
+    return { content: [{ type: 'image', value: img }] };
+  },
+});
+```
+
+For this WebMCP package, that ergonomic browser-source idea should be translated
+to a direct value instead of an MCP `content` array:
+
+```js
+return { type: 'image', value: img };
+```
+
+## Refresh Status
+
+`npm-packages` was fetched and pulled from all configured remotes. The local
+checkout is clean and `main` is already at `origin/main`:
+
+- `bf03420d chore(webmcp-local-relay): simplify browser runtime`
+
+Chromium is different:
+
+- Worktree: `chromium/src`
+- Current branch: `webmcp-streaming-review`
+- Current `HEAD`: `33601c04c6bf WebMCP: clean up streaming impl - remove ModelContextClient, simplify`
+- Current `origin/main`: `d36b68b00695 [headless] Relocate default headless mode user data directory`
+- Dirty files: 31,764
+
+Because the Chromium checkout is on the unmerged streaming branch with a large
+dirty worktree, I did not switch, rebase, or pull it in place. I read current
+Chromium from `origin/main` via `git show origin/main:...`, and treated the
+streaming branch as reference material only.
+
+The broad Chromium fetch stalled in `index-pack` once, but a narrower filtered
+fetch completed and updated local `origin/main` to match the remote ref. A
+future implementation pass should either clean/create a separate Chromium
+worktree or run `gclient sync` from a clean branch before editing Chromium.
+
+## Latest Spec Snapshot
+
+The live WebMCP spec at
+[webmachinelearning.github.io/webmcp](https://webmachinelearning.github.io/webmcp/)
+is dated 2026-06-11.
+
+Important current-spec details:
+
+- The primary surface is `document.modelContext`, not
+  `navigator.modelContext`.
+- `Document` has a `[SameObject] readonly attribute ModelContext modelContext`.
+- `ModelContext` extends `EventTarget`.
+- `registerTool(tool, options?)` returns `Promise<undefined>`.
+- Registration is abort-signal driven through
+  `ModelContextRegisterToolOptions.signal`.
+- `ModelContextRegisterToolOptions` also has `exposedTo`.
+- `ModelContextTool` includes `name`, `title`, `description`, `inputSchema`,
+  `execute`, and `annotations`.
+- `ToolAnnotations` includes `readOnlyHint` and `untrustedContentHint`.
+- Tool names are constrained to ASCII alnum, underscore, hyphen, and period,
+  length 1-128.
+
+The spec does not yet define image content blocks, browser object-backed image
+content, `content[]` result normalization, or a testing API shape for image
+serialization. That means the polyfill can prototype this, but the Chromium CR
+will need either spec text first or a clearly experimental implementation.
+
+## Related Spec/Issue Signals
+
+[webmcp#41](https://github.com/webmachinelearning/webmcp/issues/41) captures the
+core image request:
+
+- Support image input to tools.
+- Support image output from tools.
+- Prefer browser-side conversion so developers can pass page images/elements.
+- Consider MCP's `{ type: "image", data, mimeType }` shape.
+- Consider how JSON/structured responses reference associated images.
+
+[webmcp#92](https://github.com/webmachinelearning/webmcp/issues/92) asks who
+owns validation of `inputSchema`. That matters because image-bearing input is
+not just JSON Schema validation; it may require WebIDL union handling,
+structured clone rules, and/or explicit normalization before `execute`.
+
+The issue comments mention Prompt API precedent: image input should consider
+`ImageBitmapSource` and `BufferSource`; audio analogs include `AudioBuffer`,
+`BufferSource`, and `Blob`.
+
+## Current Polyfill State
+
+Relevant files:
+
+- `packages/webmcp-polyfill/src/index.ts`
+- `packages/webmcp-types/src/common.ts`
+- `packages/webmcp-types/src/model-context.ts`
+- `packages/webmcp-types/src/tool.ts`
+- `packages/webmcp-ts-sdk/src/browser-server.ts`
+
+Current behavior:
+
+- The polyfill installs `document.modelContext` as canonical and
+  `navigator.modelContext` as a deprecated alias.
+- It avoids overriding native `document.modelContext`/`navigator.modelContext`.
+- `registerTool(...)` currently returns `void`, even though the live spec now
+  says `Promise<undefined>`.
+- `registerTool(tool, { signal })` unregisters when the signal aborts.
+- `navigator.modelContextTesting` can be installed as a testing shim.
+- `modelContextTesting.executeTool(name, inputArgsJson)` accepts JSON-string
+  arguments and returns a serialized string or `null`.
+- `document.modelContext.getTools()` and
+  `document.modelContext.executeTool(tool, inputArgsJson)` are implemented as a
+  Chromium producer-preview compatibility surface.
+- `normalizeToolResponse(...)` passes through objects that already look like a
+  `CallToolResult`, meaning `{ content: [...] }` survives as returned.
+- Non-`CallToolResult` values are wrapped into a text block and optional
+  `structuredContent`.
+
+Types already include MCP-style content blocks:
+
+- `TextContent`
+- `ImageContent` with `{ type: "image", data: string, mimeType: string }`
+- `AudioContent`
+- `ResourceLink`
+- `EmbeddedResource`
+- `CallToolResult.content: Array<ContentBlock | LooseContentBlock>`
+
+Tests already assert that raw image blocks are serializable enough for current
+polyfill behavior. For example, tests cover error paths containing
+`{ type: "image", data: "base64data", mimeType: "image/png" }`.
+
+Missing for issue #41:
+
+- No typed browser-source image block such as `{ type: "image", element }`,
+  `{ type: "image", blob }`, `{ type: "image", imageBitmap }`, or
+  `{ type: "image", source }`.
+- No runtime conversion from `HTMLImageElement`, `HTMLCanvasElement`,
+  `SVGImageElement`, `ImageBitmap`, `Blob`, `BufferSource`, etc. to base64
+  `ImageContent`.
+- No async normalization path for `CallToolResult.content`.
+- No conformance tests for image conversion, CORS/tainted canvas behavior,
+  MIME inference, ordering, or error handling.
+
+## Current Chromium `origin/main`
+
+Relevant current-baseline files read from Chromium `origin/main`:
+
+- `third_party/blink/renderer/core/script_tools/model_context.idl`
+- `third_party/blink/renderer/core/script_tools/model_context_tool.idl`
+- `third_party/blink/renderer/core/script_tools/model_context_testing.idl`
+- `third_party/blink/renderer/core/script_tools/model_context.cc`
+- `third_party/blink/renderer/core/script_tools/model_context_testing.cc`
+- `third_party/blink/public/mojom/content_extraction/script_tools.mojom`
+- `third_party/blink/renderer/core/script_tools/model_context_test.cc`
+
+Current Chromium main is behind the live spec and behind this repo's polyfill in
+some ways, but much less than the older local streaming branch:
+
+- It exposes `document.modelContext` and keeps `navigator.modelContext` as a
+  deprecated alias.
+- `ModelContext` is an `EventTarget`.
+- `registerTool(...)` still returns `undefined`, while the live spec says
+  `Promise<undefined>`.
+- `unregisterTool(...)` is no longer in current Chromium `origin/main` IDL;
+  registration cleanup is signal-driven.
+- `ModelContextTool` has `name`, `title`, `description`, `inputSchema`,
+  `execute`, and `annotations`.
+- `ToolAnnotations` has `readOnlyHint` and `untrustedContentHint`.
+- `ModelContextRegisterToolOptions` has `signal` and `exposedTo`.
+- `ModelContext.getTools(options?)` returns `Promise<sequence<RegisteredTool>>`
+  and supports `fromOrigins`.
+- `ModelContext.executeTool(RegisteredTool, inputArgsJson, options?)` exists.
+- `ModelContextTesting.executeTool(...)` only accepts JSON-string arguments.
+- Tool execution returns `DOMString?`.
+- JS tool results are stringified by `JSON.stringify` if object-like, otherwise
+  `ToString`, then returned through the `DOMString?` callback.
+- `script_tools.mojom` now carries cross-document discovery/invocation metadata:
+  `name`, `title`, `description`, `input_schema`, `annotations`,
+  `exposed_origins`, owner frame token, and origin.
+- `script_tools.mojom` explicitly notes tool results are always strings for now
+  and points to a Chromium bug for changing that.
+
+There is no image-specific support in Chromium `origin/main`.
+
+## Unmerged Streaming Branch Reference
+
+The local Chromium branch `webmcp-streaming-review` is unmerged, but it shows a
+useful implementation pattern for adding non-plain-JSON tool inputs.
+
+Files added/changed by that branch include:
+
+- `third_party/blink/renderer/core/script_tools/streamed_tool_call.idl`
+- `third_party/blink/renderer/core/script_tools/streamed_tool_call.h`
+- `third_party/blink/renderer/core/script_tools/streamed_tool_call.cc`
+- `third_party/blink/renderer/core/script_tools/model_context_tool.idl`
+- `third_party/blink/renderer/core/script_tools/model_context_testing.idl`
+- `third_party/blink/renderer/core/script_tools/model_context.{h,cc}`
+- `third_party/blink/renderer/core/script_tools/model_context_test.cc`
+- `third_party/blink/renderer/core/script_tools/build.gni`
+
+The pattern:
+
+- Add new WebIDL types for the new input shape.
+- Add a tool metadata flag (`stream = false`) to `ModelContextTool`.
+- Mirror that flag into testing/discovery (`RegisteredTool.stream`) and Mojo
+  discovery metadata (`ScriptTool.stream`).
+- Add an overloaded `ModelContextTesting.executeTool(...)` for the new input
+  form.
+- Convert the testing input into a wrapper object delivered to the tool
+  callback.
+- Bridge complex values across script worlds where needed.
+- Keep cancellation tied to `AbortSignal`.
+- Add Blink unit coverage in `model_context_test.cc`.
+
+The branch's `StreamedToolCall` wrapper is the main architectural reference:
+
+- It is a `ScriptWrappable`.
+- It exposes an async iterable to JavaScript.
+- It owns either synthetic chunks or a `ReadableStream`.
+- It validates chunk shape at iteration time.
+- It cancels/cleans up reader state when aborted or finished.
+
+For image support, the analogous object might not need async iteration, but the
+same approach applies: define a wrapper/normalizer for browser-native inputs,
+convert or reject at a clear boundary, and test cross-world/cancellation/error
+semantics explicitly.
+
+## Proposed Polyfill Direction
+
+Use an explicit direct-value type model:
+
+1. Serialized WebMCP image values:
+   `{ type: "image", data, mimeType }`.
+2. Browser-source image values accepted by the WebMCP polyfill and normalized
+   before the result crosses producer execution:
+   `element`, `blob`, and later `bufferSource`/`imageBitmap` if the spec needs
+   them.
+
+Candidate type additions:
+
+```ts
+export type WebMCPImageValue =
+  | { type: 'image'; data: string; mimeType: string }
+  | { type: 'image'; value: Blob | HTMLImageElement | HTMLCanvasElement; mimeType?: string };
+// The {type, value} source shape mirrors the Prompt API's
+// LanguageModelToolResultContent.
+```
+
+For implementation, prefer a single async normalization function at the strict
+producer execution boundary:
+
+```ts
+async function normalizeWebMCPExecutionResult(value: unknown): Promise<unknown>;
+async function normalizeWebMCPImageValue(value: WebMCPImageValue): Promise<SerializedImageValue>;
+```
+
+Initial conversion policy:
+
+- Existing `{ type: "image", data, mimeType }` passes through unchanged when
+  `mimeType` is non-empty.
+- `Blob` uses `arrayBuffer()` and base64 conversion; MIME from `blob.type` or
+  explicit `mimeType`.
+- `HTMLCanvasElement` uses `toBlob(...)`; reject if tainted.
+- `HTMLImageElement` draws to a canvas after `decode()` if needed; reject on
+  tainted canvas or incomplete/failed image.
+- `ImageBitmap` draws to canvas; do not close it unless explicitly documented.
+- `BufferSource` requires explicit `mimeType`.
+- Prefer PNG as default canvas encoding unless the caller supplies another
+  supported MIME type.
+
+Do not silently convert arbitrary URLs in the first pass. Fetching URLs raises
+network, CORS, credentials, timing, and privacy questions. Element-backed
+conversion is enough to validate the core API ergonomics.
+
+## Proposed Chromium Direction
+
+Chromium should not start from the streaming branch. Start from a clean
+`origin/main`/current upstream branch and port only the relevant patterns.
+
+Likely Chromium implementation surfaces:
+
+- Update WebIDL for explicit image result values if/when the spec has shape:
+  `WebMCPImageValue`, `SerializedImageValue`, or similar dictionaries.
+- If accepting browser object-backed image values, define WebIDL unions or
+  dictionaries for accepted source types.
+- Convert image sources in the renderer before resolving the tool execution
+  result string.
+- Reuse existing canvas/image encoding infrastructure instead of ad hoc binary
+  handling.
+- Keep `ModelContextTesting.executeTool(...)` returning `DOMString?` until the
+  testing API changes; conformance can parse JSON from that string.
+- Add Blink unit tests for each accepted source type and failure mode.
+
+Open Chromium design questions:
+
+- Should conversion happen only when the result has the explicit
+  `{ type: "image", ... }` discriminator?
+- How should tainted/cross-origin images fail: reject the tool invocation or
+  return a typed image conversion error?
+- Should `HTMLVideoElement` be in scope for "image" via current frame capture?
+- Should SVG images preserve SVG MIME/data or rasterize to PNG?
+- What are size limits for encoded image output?
+- Does DevTools/content extraction need image-capability metadata in
+  `script_tools.mojom`, or is this only result-time behavior?
+
+## Conformance Suite Shape
+
+Create a shared Playwright suite for image tool content, not a polyfill-only
+unit suite. It should run in two lanes:
+
+1. Polyfill lane: load a simple page with `@mcp-b/webmcp-polyfill`.
+2. Native lane: launch Chromium with WebMCP flags and execute the same tests
+   against the browser API.
+
+Use the same public boundary in both lanes:
+
+- Register via `document.modelContext`.
+- Discover through `document.modelContext.getTools()`.
+- Execute through `document.modelContext.executeTool(tool, inputArgsJson)`.
+- Parse the returned `DOMString?` as a direct WebMCP value. Image values are not
+  MCP `content` blocks.
+
+Suggested test helper:
+
+```ts
+async function executeDocumentImageTool(page, name, args) {
+  return page.evaluate(
+    async ({ name, args }) => {
+      const tools = await document.modelContext.getTools();
+      const tool = tools.find((candidate) => candidate.name === name);
+      if (!tool) throw new Error(`Tool not found: ${name}`);
+
+      const result = await document.modelContext.executeTool(tool, JSON.stringify(args));
+      return result === null ? null : JSON.parse(result);
+    },
+    { name, args }
+  );
+}
+```
+
+Core conformance cases:
+
+- Existing direct base64 image value passes through unchanged.
+- `Blob` image output is converted to `{ type: "image", data, mimeType }`.
+- `HTMLCanvasElement` output is converted to PNG base64.
+- `HTMLImageElement` output is converted after decode.
+- Missing/unsupported MIME behavior is deterministic.
+- Tainted/cross-origin image conversion rejects with a predictable error.
+- Raw JSON values still survive when no explicit image value is present.
+- `null` result behavior remains unchanged.
+
+Use small deterministic test images:
+
+- 1x1 or 2x2 PNG data URL for same-origin image tests.
+- Canvas-drawn colored pixels for conversion tests.
+- A cross-origin image fixture only when the test server setup can reliably
+  create a tainted canvas case.
+
+## Immediate Next Steps
+
+1. Add polyfill/type support for direct browser-source image value normalization.
+2. Add shared Playwright image conformance tests under `e2e/tests/`.
+3. Add a polyfill Playwright config/lane if the existing runtime-contract page
+   is not a clean fit.
+4. Run the new suite against the polyfill.
+5. After the Chromium CR starts from clean upstream main, run the same suite
+   against the native implementation via `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`
+   and WebMCP flags.
+
+## Commands Useful Later
+
+Polyfill/unit checks:
+
+```bash
+pnpm --filter @mcp-b/webmcp-polyfill test
+pnpm --filter @mcp-b/webmcp-types test
+```
+
+Native conformance lane:
+
+```bash
+cd e2e
+CHROME_BIN="/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary" \
+PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary" \
+PLAYWRIGHT_ENABLE_WEBMCP_FLAGS=1 \
+pnpm test:native-contract:default
+```
+
+Read latest Chromium baseline without switching away from the dirty streaming
+branch:
+
+```bash
+cd chromium/src
+git show origin/main:third_party/blink/renderer/core/script_tools/model_context.idl
+git show origin/main:third_party/blink/renderer/core/script_tools/model_context_tool.idl
+git show origin/main:third_party/blink/renderer/core/script_tools/model_context_testing.idl
+```

--- a/docs/plans/WEBMCP_IMAGE_TOOL_CONTENT_TDD_PLAN.md
+++ b/docs/plans/WEBMCP_IMAGE_TOOL_CONTENT_TDD_PLAN.md
@@ -1,0 +1,565 @@
+# WebMCP Image Tool Content TDD Plan
+
+Date: 2026-06-11
+
+## Purpose
+
+This plan prepares the next implementation pass for image input and output in
+WebMCP tools. It is intentionally test-first and end-to-end only. Do not add
+unit tests for this work unless the scope changes; the contract must be proven
+through a real page, real `document.modelContext` registration, and real
+Playwright-driven tool execution.
+
+Companion investigation:
+[`WEBMCP_IMAGE_TOOL_CONTENT_INVESTIGATION.md`](./WEBMCP_IMAGE_TOOL_CONTENT_INVESTIGATION.md).
+
+Primary external references:
+
+- [WebMCP spec](https://webmachinelearning.github.io/webmcp/)
+- [webmachinelearning/webmcp#41](https://github.com/webmachinelearning/webmcp/issues/41)
+- [webmachinelearning/webmcp#92](https://github.com/webmachinelearning/webmcp/issues/92)
+
+## Corrected API Direction
+
+This plan targets the WebMCP API, not the MCP API and not the MCPB bridge
+extensions. The implementation must use the strict `@mcp-b/webmcp-polyfill`
+runtime and the `document.modelContext` producer surface:
+
+```ts
+const tools = await document.modelContext.getTools();
+const resultJson = await document.modelContext.executeTool(tool, JSON.stringify(args));
+```
+
+Image values are direct WebMCP tool results. They are not MCP `content` blocks,
+and the E2E suite must not use an MCP client such as `window.mcpClient`.
+
+## Non-Negotiables
+
+- Use `document.modelContext` as the producer API in new tests and examples.
+  Treat `navigator.modelContext` as a compatibility alias only.
+- Prove behavior through Playwright E2E tests.
+- Run the same contract against:
+  - the polyfill/runtime path
+  - regular Chromium/Chrome without WebMCP native support, where the polyfill is
+    expected to install
+  - custom Chromium builds with native WebMCP enabled and the polyfill disabled
+- Prefer Web APIs for image conversion. Reach for dependencies only when a Web
+  API cannot do the job in browser E2E.
+- Start with direct serialized WebMCP image values:
+  `{ type: "image", data: string, mimeType: string }`.
+- Add browser-source ergonomics after the serialized contract is green.
+- Keep each TDD cycle vertical: one failing E2E behavior, minimal implementation,
+  then refactor while green.
+
+## Desired Contract
+
+### Stable Serialized Image Value
+
+The first stable image shape is a direct WebMCP tool result:
+
+```ts
+type SerializedImageValue = {
+  type: 'image';
+  data: string;
+  mimeType: string;
+};
+```
+
+`data` is base64 without a `data:` URL prefix. `mimeType` is an explicit MIME
+type such as `image/png`. This is not wrapped in an MCP `content` array.
+
+This shape should work in both directions:
+
+- tool output can return serialized image values directly
+- tool input can receive serialized image values as ordinary JSON-like arguments
+
+### Browser-Source Image Output
+
+Once serialized image blocks pass, add browser-source output forms. Proposed
+minimum set:
+
+```ts
+type BrowserImageOutput =
+  | { type: 'image'; data: string; mimeType: string }
+  | { type: 'image'; value: Blob | HTMLImageElement | HTMLCanvasElement; mimeType?: string };
+// The {type, value} source shape mirrors the Prompt API's
+// LanguageModelToolResultContent.
+```
+
+Defer `ImageBitmap`, `ImageData`, `SVGImageElement`, `HTMLVideoElement`, and
+`BufferSource` until the core path is green. The type surface can be designed so
+they fit later, but do not implement them speculatively.
+
+### Browser-Source Image Input
+
+Input should start serialized. Browser-source input is a later phase because
+callers pass arguments through JSON-string execution surfaces today:
+
+```ts
+await document.modelContext.executeTool(
+  tool,
+  JSON.stringify({
+    image: { type: 'image', data, mimeType: 'image/png' },
+  })
+);
+```
+
+Native browser object input can be explored after Chromium has a real non-string
+input path or after the spec defines one.
+
+## Test Harness Direction
+
+Reuse the existing runtime contract harness:
+
+- `e2e/runtime-contract/core.js`
+- `e2e/runtime-contract/browser-contract.js`
+- `e2e/test-app/src/runtime-contract.ts`
+- `e2e/tests/runtime-contract.helpers.ts`
+- `e2e/tests/runtime-contract-tab.spec.ts`
+- `e2e/tests/runtime-contract-native.spec.ts`
+
+Add a new focused suite rather than expanding the existing text-only contract
+files too much:
+
+- `e2e/tests/runtime-contract-image-values.spec.ts`
+
+Add image-specific helpers only when the first test needs them:
+
+- `imageToolNames`
+- `registerImageToolsInPage(page)`
+- `executeDocumentImageTool(...)`
+- `expectSerializedImageValue(...)`
+
+Keep helpers behavior-oriented. They should not mirror implementation internals.
+
+## Required Harness Cleanup Before Image Tests
+
+The current runtime contract harness still often starts from
+`navigator.modelContext`. Before adding image tests, switch new image setup to
+`document.modelContext`.
+
+Recommended approach:
+
+1. Update `installBrowserRuntimeContract` call sites to pass
+   `document.modelContext`.
+2. Update error messages from `navigator.modelContext` to
+   `document.modelContext` where the code is testing the primary producer API.
+3. Keep compatibility assertions that `navigator.modelContext` aliases
+   `document.modelContext` in native-transition tests.
+4. Do not remove existing `navigator` compatibility tests in the same change.
+
+This should be its own small green change before image behavior begins.
+
+## Browser Modes
+
+### Polyfill Mode
+
+Use the existing app import:
+
+```ts
+import { initializeWebMCPPolyfill } from '@mcp-b/webmcp-polyfill';
+
+initializeWebMCPPolyfill();
+```
+
+This mode should run on ordinary Playwright Chromium. Because regular Chromium
+does not expose native `document.modelContext`, the strict WebMCP polyfill
+installs the producer API.
+
+Command shape:
+
+```sh
+pnpm --filter mcp-e2e-tests exec playwright test \
+  tests/runtime-contract-image-values.spec.ts
+```
+
+### Chrome/Chromium With Polyfill Fallback
+
+Use the same test suite on a specific installed browser or executable path:
+
+```sh
+PLAYWRIGHT_CHROMIUM_CHANNEL=chrome pnpm --filter mcp-e2e-tests exec playwright test \
+  tests/runtime-contract-image-values.spec.ts
+```
+
+or:
+
+```sh
+PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/path/to/chrome pnpm --filter mcp-e2e-tests exec playwright test \
+  tests/runtime-contract-image-values.spec.ts
+```
+
+The expected behavior is still polyfill-backed unless native WebMCP exists and
+the global package is configured not to wrap it.
+
+### Native Custom Chromium Mode
+
+For the later C++ implementation, run the same image contract against a custom
+Chromium build with native flags enabled and the polyfill disabled for the page
+under test.
+
+Add a dedicated config during implementation:
+
+- `e2e/playwright-webmcp-image-native.config.ts`
+
+Expected command shape:
+
+```sh
+PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/path/to/chromium/out/Default/Chromium.app/Contents/MacOS/Chromium \
+PLAYWRIGHT_ENABLE_WEBMCP_FLAGS=1 \
+WEBMCP_E2E_RUNTIME=native \
+pnpm --filter mcp-e2e-tests exec playwright test \
+  --config=e2e/playwright-webmcp-image-native.config.ts
+```
+
+The native config should:
+
+- launch with `--enable-experimental-web-platform-features`
+- launch with `--enable-features=WebMCPTesting,DevToolsWebMCPSupport` if still
+  required by that Chromium revision
+- avoid importing any polyfill or bridge runtime on the image-native test page
+- fail fast if `document.modelContext.getTools` or
+  `document.modelContext.executeTool` is missing
+
+## Test Page Strategy
+
+The current `runtime-contract.html` imports `@mcp-b/global`, which is a bridge
+runtime and is not the right API surface for this WebMCP image work. Add an
+image-specific test page pair so the polyfill mode can use
+`@mcp-b/webmcp-polyfill` and native mode can avoid any runtime wrapper:
+
+- `e2e/test-app/runtime-contract-image-polyfill.html`
+- `e2e/test-app/runtime-contract-image-native.html`
+- `e2e/test-app/src/runtime-contract-image-polyfill.ts`
+- `e2e/test-app/src/runtime-contract-image-native.ts`
+
+Both pages should install the same image tools through a shared browser module:
+
+- `e2e/runtime-contract/image-contract.js`
+
+The shared module should accept a `ModelContext` argument and should never import
+`@mcp-b/global`. The polyfill page imports `@mcp-b/webmcp-polyfill` before
+calling the shared module; the native page does not.
+
+This keeps the conformance suite honest: the tests can choose the runtime by
+page URL rather than relying on runtime conditionals hidden inside the page.
+
+## Fixtures
+
+Use tiny deterministic images that are easy to assert:
+
+- `one_by_one_png`: a 1x1 PNG base64 string
+- `two_by_one_png`: a 2x1 PNG base64 string with two known pixels
+- optional later fixture: a same-origin static PNG served from
+  `e2e/test-app/public/`
+
+Store textual fixtures in code first. Add binary files only when testing
+`HTMLImageElement` loading or same-origin canvas draw behavior.
+
+The first fixture should be small enough to inline in
+`e2e/runtime-contract/image-contract.js` so tests do not depend on network timing
+or asset loading.
+
+## Vertical TDD Slices
+
+### Slice 0: Document API Harness
+
+Failing E2E behavior:
+
+- a test page registers a text tool through `document.modelContext`
+- `document.modelContext.getTools()` can discover it
+- `document.modelContext.executeTool(...)` can execute it
+
+Minimal implementation:
+
+- make the image-contract harness use `document.modelContext`
+- keep old runtime-contract pages working
+
+Acceptance:
+
+- the new image contract page reaches `data-status="ready"`
+- a text smoke tool runs through `document.modelContext.executeTool(...)`
+
+### Slice 1: Serialized Image Output Through `document.modelContext.executeTool`
+
+Failing E2E behavior:
+
+- page registers `get_serialized_png`
+- tool returns:
+
+```js
+{
+  type: "image",
+  data: ONE_BY_ONE_PNG_BASE64,
+  mimeType: "image/png"
+}
+```
+
+- Playwright discovers the registered tool with `document.modelContext.getTools()`
+- Playwright calls the tool through `document.modelContext.executeTool(tool, "{}")`
+- test parses the returned string and asserts the direct image value exactly
+  matches the fixture
+
+Minimal implementation:
+
+- preserve direct serialized image values through producer execution
+
+Acceptance:
+
+- polyfill mode passes on ordinary Playwright Chromium
+- no browser-source conversion exists yet
+
+### Slice 2: Serialized Image Input
+
+Failing E2E behavior:
+
+- page registers `describe_input_image`
+- test passes:
+
+```js
+{
+  image: { type: "image", data: ONE_BY_ONE_PNG_BASE64, mimeType: "image/png" }
+}
+```
+
+- tool returns direct JSON metadata describing the received image:
+  `{ inputType: "image", mimeType: "image/png", dataLength: N }`
+
+Minimal implementation:
+
+- ensure JSON-string arguments survive unchanged into `execute`
+- do not add binary/browser object input yet
+
+Acceptance:
+
+- invocation log records the image value shape without lossy conversion
+- returned metadata matches the fixture
+
+### Slice 3: Blob Image Output
+
+Failing E2E behavior:
+
+- page registers `get_blob_png`
+- tool creates a `Blob` from fixture bytes using Web APIs
+- tool returns `{ type: "image", blob }`
+- caller receives serialized `{ type, data, mimeType }`
+
+Minimal implementation:
+
+- use `Blob.arrayBuffer()`
+- convert bytes to base64 with browser APIs
+- infer `mimeType` from `blob.type`; require explicit `mimeType` if absent
+
+Acceptance:
+
+- no Node-only APIs in browser code
+- result equals fixture base64 and `image/png`
+
+### Slice 4: Canvas Image Output
+
+Failing E2E behavior:
+
+- page registers `get_canvas_png`
+- tool paints a deterministic canvas
+- tool returns `{ type: "image", value: canvas }`
+- caller receives a direct serialized PNG image value
+
+Minimal implementation:
+
+- use `HTMLCanvasElement.toBlob()`
+- reject null blob results with a clear tool execution error
+- default canvas output MIME to `image/png`
+
+Acceptance:
+
+- returned value is `image/png`
+- test verifies it is a valid PNG, not necessarily byte-identical across browser
+  encoders unless the fixture path is deterministic enough
+
+### Slice 5: Image Element Output
+
+Failing E2E behavior:
+
+- page loads a same-origin PNG into `<img>`
+- tool returns `{ type: "image", value: img }`
+- caller receives a direct serialized image value
+
+Minimal implementation:
+
+- draw same-origin image to a canvas
+- serialize canvas to PNG
+- reject incomplete image elements
+
+Acceptance:
+
+- same-origin image element passes
+- missing/unloaded image element produces a clear error
+
+### Slice 6: Error Semantics
+
+Failing E2E behavior:
+
+- unsupported image source fails predictably
+- tainted canvas or cross-origin image conversion fails predictably
+- missing `mimeType` for raw `data` fails if the serialized shape cannot be
+  trusted
+
+Minimal implementation:
+
+- centralize browser image normalization behind one narrow function
+- preserve existing thrown-tool error propagation behavior
+
+Acceptance:
+
+- test assertions match user-visible error class/message shape already used by
+  the runtime, not internal function names
+
+## Conformance Matrix
+
+| Behavior                                                             | Polyfill Chromium | Regular Chrome fallback | Native custom Chromium                  |
+| -------------------------------------------------------------------- | ----------------- | ----------------------- | --------------------------------------- |
+| Register via `document.modelContext.registerTool`                    | Required          | Required                | Required                                |
+| Discover image tool                                                  | Required          | Required                | Required                                |
+| `document.modelContext.executeTool` receives serialized image output | Required          | Required                | Required                                |
+| Serialized image input reaches tool `execute`                        | Required          | Required                | Required                                |
+| Blob output converts to serialized image value                       | Required          | Required                | Optional until spec text exists         |
+| Canvas output converts to serialized image value                     | Required          | Required                | Optional until spec text exists         |
+| Image element output converts to serialized image value              | Required          | Required                | Optional until spec text exists         |
+| Cross-origin/tainted conversion error                                | Required          | Required                | Required if browser-source output ships |
+
+Native optional items should be marked with explicit `test.skip` conditions tied
+to runtime capability detection, not broad browser-name skips.
+
+## Expected Implementation Areas
+
+Do not edit all of these in one pass. They are the likely files the future agent
+will touch as each failing E2E test demands it.
+
+Polyfill/runtime:
+
+- `packages/webmcp-polyfill/src/index.ts`
+- `packages/webmcp-ts-sdk/src/browser-server.ts`
+- `packages/webmcp-types/src/common.ts`
+- `packages/webmcp-types/src/tool.ts`
+- `packages/webmcp-types/src/model-context.ts`
+
+E2E:
+
+- `e2e/runtime-contract/image-contract.js`
+- `e2e/test-app/runtime-contract-image-polyfill.html`
+- `e2e/test-app/runtime-contract-image-native.html`
+- `e2e/test-app/src/runtime-contract-image-polyfill.ts`
+- `e2e/test-app/src/runtime-contract-image-native.ts`
+- `e2e/tests/runtime-contract-image-values.spec.ts`
+- `e2e/tests/runtime-contract.helpers.ts`
+- `e2e/playwright-webmcp-image-native.config.ts`
+- `e2e/package.json`
+
+Chromium later:
+
+- `third_party/blink/renderer/core/script_tools/model_context.idl`
+- `third_party/blink/renderer/core/script_tools/model_context_tool.idl`
+- `third_party/blink/renderer/core/script_tools/model_context_testing.idl`
+- `third_party/blink/renderer/core/script_tools/model_context.cc`
+- `third_party/blink/renderer/core/script_tools/model_context_testing.cc`
+- `third_party/blink/public/mojom/content_extraction/script_tools.mojom`
+- `third_party/blink/renderer/core/script_tools/model_context_test.cc`
+
+## Web API Preference
+
+Use Web APIs in browser code:
+
+- `Blob.arrayBuffer()`
+- `FileReader` only if needed for older runtime compatibility
+- `HTMLCanvasElement.toBlob()`
+- `CanvasRenderingContext2D.drawImage(...)`
+- `Uint8Array`
+- `btoa(...)` for byte-to-base64 conversion after converting bytes to a binary
+  string in chunks
+
+Avoid:
+
+- Node `Buffer` in browser-executed code
+- hand-written PNG encoders
+- custom MIME sniffing beyond simple required-field checks and `blob.type`
+
+If conversion complexity grows, isolate it behind a small `normalizeImageValue`
+module and keep the public accepted shapes narrow.
+
+## Suggested Test Helper Semantics
+
+The test helper should normalize the producer execution boundary:
+
+- discover by `document.modelContext.getTools()`
+- execute by `document.modelContext.executeTool(tool, JSON.stringify(args))`
+- parse non-null string results as direct WebMCP values
+- preserve `null`/error result behavior
+
+Example helper contract:
+
+```ts
+async function executeDocumentImageTool(page, name, args) {
+  return page.evaluate(
+    async ({ name, args }) => {
+      const tools = await document.modelContext.getTools();
+      const tool = tools.find((candidate) => candidate.name === name);
+      if (!tool) throw new Error(`Tool not found: ${name}`);
+      const result = await document.modelContext.executeTool(tool, JSON.stringify(args));
+      return result === null ? null : JSON.parse(result);
+    },
+    { name, args }
+  );
+}
+```
+
+Keep assertions in tests:
+
+```ts
+expect(result).toEqual({
+  type: 'image',
+  data: ONE_BY_ONE_PNG_BASE64,
+  mimeType: 'image/png',
+});
+```
+
+Do not test private normalization functions from Playwright.
+
+## Definition Of Done For Polyfill Phase
+
+- `runtime-contract-image-values.spec.ts` passes in ordinary Playwright
+  Chromium.
+- The same spec passes when targeting installed Chrome through
+  `PLAYWRIGHT_CHROMIUM_CHANNEL=chrome` or an executable path.
+- New image behavior uses `document.modelContext` for registration and producer
+  execution.
+- Existing text runtime-contract suites still pass.
+- No unit tests were added for image support.
+- Image output returned through `document.modelContext.executeTool` has the
+  direct serialized WebMCP value shape.
+- Unsupported browser-source image values fail with clear E2E-covered errors.
+
+## Definition Of Done For Native Chromium Phase
+
+- A clean Chromium worktree exists separate from the dirty streaming branch.
+- The same Playwright image contract runs with the polyfill disabled.
+- Native `document.modelContext` exposes the image behavior under test.
+- Native `document.modelContext.getTools()` and
+  `document.modelContext.executeTool(...)` can discover and execute the
+  image-producing tools.
+- Any optional browser-source ergonomics are either implemented natively or
+  skipped by capability detection with a linked issue.
+- The Chromium CR links to the WebMCP issue and this repo's passing conformance
+  suite.
+
+## First Implementation Prompt
+
+Use this prompt for the next coding agent:
+
+> Implement Slice 0 and Slice 1 from
+> `docs/plans/WEBMCP_IMAGE_TOOL_CONTENT_TDD_PLAN.md` using the strict
+> `@mcp-b/webmcp-polyfill` runtime. Do not use MCP clients, `@mcp-b/global`, or
+> MCP `content` arrays. Add only Playwright E2E coverage. Use
+> `document.modelContext` for registration, discovery, and execution. Make the
+> first serialized direct `{ type: "image", data, mimeType }` output test pass
+> through the polyfill runtime path, then run that E2E spec and the existing
+> runtime-contract spec.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -20,6 +20,7 @@
     "test:mcp-iframe": "playwright test tests/mcp-iframe-element.spec.ts",
     "test:native-contract:beta": "playwright test --config=playwright-chrome-beta-webmcp.config.ts tests/runtime-contract-native.spec.ts",
     "test:native-contract:default": "playwright test tests/runtime-contract-native.spec.ts",
+    "test:native-image-contract": "WEBMCP_E2E_RUNTIME=native playwright test --config=playwright-webmcp-image-native.config.ts",
     "test:native-parity": "pnpm run test:native-parity:default && pnpm run test:native-parity:beta",
     "test:native-parity:beta": "playwright test --config=playwright-chrome-beta-webmcp.config.ts",
     "test:native-parity:default": "playwright test tests/chrome-beta-webmcp.spec.ts",

--- a/e2e/playwright-webmcp-image-native.config.ts
+++ b/e2e/playwright-webmcp-image-native.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const tabTransportPort = Number.parseInt(process.env.PLAYWRIGHT_TAB_TRANSPORT_PORT ?? '4173', 10);
+const tabTransportBaseUrl = `http://localhost:${tabTransportPort}`;
+const reuseExistingServer = process.env.PLAYWRIGHT_REUSE_SERVER === '1';
+const chromiumChannel = process.env.PLAYWRIGHT_CHROMIUM_CHANNEL;
+const chromiumExecutablePath =
+  process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ?? process.env.CHROME_BIN;
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/runtime-contract-image-values.spec.ts',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: [['html'], ['list'], ...(process.env.CI ? [['github'] as const] : [])],
+  use: {
+    baseURL: tabTransportBaseUrl,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    launchOptions: {
+      ...(chromiumExecutablePath ? { executablePath: chromiumExecutablePath } : {}),
+      args: [
+        '--enable-experimental-web-platform-features',
+        '--enable-features=WebMCPTesting,DevToolsWebMCPSupport',
+      ],
+    },
+  },
+  projects: [
+    {
+      name: 'chromium-webmcp-image-native',
+      use: {
+        ...devices['Desktop Chrome'],
+        ...(chromiumChannel && !chromiumExecutablePath ? { channel: chromiumChannel } : {}),
+      },
+    },
+  ],
+  webServer: {
+    command: `pnpm --filter mcp-tab-transport-test-app exec vp dev --port ${tabTransportPort}`,
+    url: tabTransportBaseUrl,
+    reuseExistingServer,
+    timeout: 120 * 1000,
+    stdout: 'ignore',
+    stderr: 'pipe',
+  },
+});

--- a/e2e/runtime-contract/image-contract.d.ts
+++ b/e2e/runtime-contract/image-contract.d.ts
@@ -1,0 +1,44 @@
+import type { RuntimeContractController, RuntimeInvocationRecord } from './core.js';
+
+export interface ImageRuntimeContractOptions {
+  runtimeLabel?: string;
+}
+
+export interface ImageRuntimeContractToolDescriptor {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute(args: Record<string, unknown>): Promise<unknown>;
+}
+
+export interface ImageRuntimeContractDescriptors {
+  baseTools: ImageRuntimeContractToolDescriptor[];
+}
+
+export interface ImageRuntimeContractModelContext {
+  registerTool(tool: unknown, options?: { signal?: AbortSignal }): void;
+}
+
+export declare const IMAGE_TEXT_SMOKE_TOOL_NAME: string;
+export declare const GET_SERIALIZED_PNG_TOOL_NAME: string;
+export declare const GET_BLOB_PNG_TOOL_NAME: string;
+export declare const GET_CANVAS_PNG_TOOL_NAME: string;
+export declare const GET_CANVAS_UNSUPPORTED_MIME_TYPE_TOOL_NAME: string;
+export declare const GET_IMAGE_ELEMENT_PNG_TOOL_NAME: string;
+export declare const DESCRIBE_INPUT_IMAGE_TOOL_NAME: string;
+export declare const GET_UNSUPPORTED_IMAGE_SOURCE_TOOL_NAME: string;
+export declare const GET_BLOB_WITHOUT_MIME_TYPE_TOOL_NAME: string;
+export declare const GET_SERIALIZED_WITHOUT_MIME_TYPE_TOOL_NAME: string;
+export declare const ONE_BY_ONE_PNG_BASE64: string;
+export declare function createImageContractState(): {
+  ready: boolean;
+  invocations: RuntimeInvocationRecord[];
+};
+export declare function createImageToolDescriptors(
+  state: ReturnType<typeof createImageContractState>,
+  options?: ImageRuntimeContractOptions
+): ImageRuntimeContractDescriptors;
+export declare function installBrowserImageRuntimeContract(
+  modelContext: ImageRuntimeContractModelContext,
+  options?: ImageRuntimeContractOptions
+): Promise<RuntimeContractController>;

--- a/e2e/runtime-contract/image-contract.js
+++ b/e2e/runtime-contract/image-contract.js
@@ -1,0 +1,294 @@
+import { createRuntimeContractController } from './core.js';
+
+export const IMAGE_TEXT_SMOKE_TOOL_NAME = 'image_text_smoke';
+export const GET_SERIALIZED_PNG_TOOL_NAME = 'get_serialized_png';
+export const GET_BLOB_PNG_TOOL_NAME = 'get_blob_png';
+export const GET_CANVAS_PNG_TOOL_NAME = 'get_canvas_png';
+export const GET_CANVAS_UNSUPPORTED_MIME_TYPE_TOOL_NAME = 'get_canvas_unsupported_mime_type';
+export const GET_IMAGE_ELEMENT_PNG_TOOL_NAME = 'get_image_element_png';
+export const DESCRIBE_INPUT_IMAGE_TOOL_NAME = 'describe_input_image';
+export const GET_UNSUPPORTED_IMAGE_SOURCE_TOOL_NAME = 'get_unsupported_image_source';
+export const GET_BLOB_WITHOUT_MIME_TYPE_TOOL_NAME = 'get_blob_without_mime_type';
+export const GET_SERIALIZED_WITHOUT_MIME_TYPE_TOOL_NAME = 'get_serialized_without_mime_type';
+export const ONE_BY_ONE_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+function structuredCloneFallback(value) {
+  return JSON.parse(JSON.stringify(value ?? null));
+}
+
+function normalizeArguments(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return structuredCloneFallback(value);
+}
+
+function recordInvocation(state, name, args) {
+  state.invocations.push({
+    name,
+    arguments: normalizeArguments(args),
+  });
+}
+
+function base64ToBytes(base64) {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function loadImageFromBase64(base64) {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error('Image fixture failed to load'));
+    image.src = `data:image/png;base64,${base64}`;
+  });
+}
+
+function installHook(controller) {
+  if (typeof window !== 'undefined') {
+    window.__WEBMCP_E2E__ = controller;
+  }
+  globalThis.__WEBMCP_E2E__ = controller;
+  return controller;
+}
+
+export function createImageContractState() {
+  return {
+    ready: false,
+    invocations: [],
+  };
+}
+
+export function createImageToolDescriptors(state, options = {}) {
+  const runtimeLabel = options.runtimeLabel ?? 'image';
+
+  return {
+    baseTools: [
+      {
+        name: IMAGE_TEXT_SMOKE_TOOL_NAME,
+        description: 'Smoke test tool for image value contract pages.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            message: { type: 'string' },
+          },
+        },
+        async execute(args) {
+          const normalized = normalizeArguments(args);
+          const message = typeof normalized.message === 'string' ? normalized.message : '';
+          recordInvocation(state, IMAGE_TEXT_SMOKE_TOOL_NAME, normalized);
+          return {
+            message,
+            text: `image-smoke:${message}`,
+            runtime: runtimeLabel,
+          };
+        },
+      },
+      {
+        name: GET_SERIALIZED_PNG_TOOL_NAME,
+        description: 'Return a serialized PNG image value.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        async execute(args) {
+          recordInvocation(state, GET_SERIALIZED_PNG_TOOL_NAME, normalizeArguments(args));
+          return {
+            type: 'image',
+            data: ONE_BY_ONE_PNG_BASE64,
+            mimeType: 'image/png',
+          };
+        },
+      },
+      {
+        name: GET_BLOB_PNG_TOOL_NAME,
+        description: 'Return a PNG image value backed by a Blob.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        async execute(args) {
+          recordInvocation(state, GET_BLOB_PNG_TOOL_NAME, normalizeArguments(args));
+          return {
+            type: 'image',
+            value: new Blob([base64ToBytes(ONE_BY_ONE_PNG_BASE64)], {
+              type: 'image/png',
+            }),
+          };
+        },
+      },
+      {
+        name: GET_CANVAS_PNG_TOOL_NAME,
+        description: 'Return a PNG image value backed by a canvas element.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        async execute(args) {
+          recordInvocation(state, GET_CANVAS_PNG_TOOL_NAME, normalizeArguments(args));
+          const canvas = document.createElement('canvas');
+          canvas.width = 1;
+          canvas.height = 1;
+          const context = canvas.getContext('2d');
+          if (!context) {
+            throw new Error('2D canvas context is unavailable');
+          }
+          context.fillStyle = '#ff0000';
+          context.fillRect(0, 0, 1, 1);
+          return {
+            type: 'image',
+            value: canvas,
+          };
+        },
+      },
+      {
+        name: GET_CANVAS_UNSUPPORTED_MIME_TYPE_TOOL_NAME,
+        description: 'Return a canvas image value with an unsupported requested MIME type.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        async execute(args) {
+          recordInvocation(
+            state,
+            GET_CANVAS_UNSUPPORTED_MIME_TYPE_TOOL_NAME,
+            normalizeArguments(args)
+          );
+          const canvas = document.createElement('canvas');
+          canvas.width = 1;
+          canvas.height = 1;
+          const context = canvas.getContext('2d');
+          if (!context) {
+            throw new Error('2D canvas context is unavailable');
+          }
+          context.fillStyle = '#00ff00';
+          context.fillRect(0, 0, 1, 1);
+          return {
+            type: 'image',
+            value: canvas,
+            mimeType: 'image/unsupported',
+          };
+        },
+      },
+      {
+        name: GET_IMAGE_ELEMENT_PNG_TOOL_NAME,
+        description: 'Return a PNG image value backed by an image element.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        async execute(args) {
+          recordInvocation(state, GET_IMAGE_ELEMENT_PNG_TOOL_NAME, normalizeArguments(args));
+          return {
+            type: 'image',
+            value: await loadImageFromBase64(ONE_BY_ONE_PNG_BASE64),
+          };
+        },
+      },
+      {
+        name: DESCRIBE_INPUT_IMAGE_TOOL_NAME,
+        description: 'Describe a serialized input image value.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            image: {
+              type: 'object',
+            },
+          },
+          required: ['image'],
+        },
+        async execute(args) {
+          const normalized = normalizeArguments(args);
+          recordInvocation(state, DESCRIBE_INPUT_IMAGE_TOOL_NAME, normalized);
+          const image = normalized.image;
+          if (!image || typeof image !== 'object' || Array.isArray(image)) {
+            throw new Error('Expected image argument');
+          }
+          return {
+            inputType: image.type,
+            mimeType: image.mimeType,
+            dataLength: typeof image.data === 'string' ? image.data.length : 0,
+          };
+        },
+      },
+      {
+        name: GET_UNSUPPORTED_IMAGE_SOURCE_TOOL_NAME,
+        description: 'Return an unsupported image source shape.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        async execute(args) {
+          recordInvocation(state, GET_UNSUPPORTED_IMAGE_SOURCE_TOOL_NAME, normalizeArguments(args));
+          return {
+            type: 'image',
+            source: {},
+          };
+        },
+      },
+      {
+        name: GET_BLOB_WITHOUT_MIME_TYPE_TOOL_NAME,
+        description: 'Return a Blob image value without a MIME type.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        async execute(args) {
+          recordInvocation(state, GET_BLOB_WITHOUT_MIME_TYPE_TOOL_NAME, normalizeArguments(args));
+          return {
+            type: 'image',
+            value: new Blob([base64ToBytes(ONE_BY_ONE_PNG_BASE64)]),
+          };
+        },
+      },
+      {
+        name: GET_SERIALIZED_WITHOUT_MIME_TYPE_TOOL_NAME,
+        description: 'Return a serialized image value without a MIME type.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        async execute(args) {
+          recordInvocation(
+            state,
+            GET_SERIALIZED_WITHOUT_MIME_TYPE_TOOL_NAME,
+            normalizeArguments(args)
+          );
+          return {
+            type: 'image',
+            data: ONE_BY_ONE_PNG_BASE64,
+          };
+        },
+      },
+    ],
+  };
+}
+
+export async function installBrowserImageRuntimeContract(modelContext, options = {}) {
+  if (!modelContext || typeof modelContext.registerTool !== 'function') {
+    throw new Error(
+      'document.modelContext.registerTool is required for the image runtime contract'
+    );
+  }
+
+  const state = createImageContractState();
+  const descriptors = createImageToolDescriptors(state, options);
+
+  for (const tool of descriptors.baseTools) {
+    modelContext.registerTool(tool);
+  }
+  state.ready = true;
+
+  const controller = createRuntimeContractController(
+    state,
+    () => false,
+    () => false
+  );
+
+  return installHook(controller);
+}

--- a/e2e/runtime-contract/image-contract.js
+++ b/e2e/runtime-contract/image-contract.js
@@ -4,7 +4,9 @@ export const IMAGE_TEXT_SMOKE_TOOL_NAME = 'image_text_smoke';
 export const GET_SERIALIZED_PNG_TOOL_NAME = 'get_serialized_png';
 export const GET_BLOB_PNG_TOOL_NAME = 'get_blob_png';
 export const GET_CANVAS_PNG_TOOL_NAME = 'get_canvas_png';
+export const GET_CANVAS_JPEG_TOOL_NAME = 'get_canvas_jpeg';
 export const GET_CANVAS_UNSUPPORTED_MIME_TYPE_TOOL_NAME = 'get_canvas_unsupported_mime_type';
+export const GET_IMAGE_ARRAY_TOOL_NAME = 'get_image_array';
 export const GET_IMAGE_ELEMENT_PNG_TOOL_NAME = 'get_image_element_png';
 export const DESCRIBE_INPUT_IMAGE_TOOL_NAME = 'describe_input_image';
 export const GET_UNSUPPORTED_IMAGE_SOURCE_TOOL_NAME = 'get_unsupported_image_source';
@@ -38,6 +40,19 @@ function base64ToBytes(base64) {
     bytes[index] = binary.charCodeAt(index);
   }
   return bytes;
+}
+
+function createFilledCanvas(fillStyle) {
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('2D canvas context is unavailable');
+  }
+  context.fillStyle = fillStyle;
+  context.fillRect(0, 0, 1, 1);
+  return canvas;
 }
 
 function loadImageFromBase64(base64) {
@@ -131,18 +146,25 @@ export function createImageToolDescriptors(state, options = {}) {
         },
         async execute(args) {
           recordInvocation(state, GET_CANVAS_PNG_TOOL_NAME, normalizeArguments(args));
-          const canvas = document.createElement('canvas');
-          canvas.width = 1;
-          canvas.height = 1;
-          const context = canvas.getContext('2d');
-          if (!context) {
-            throw new Error('2D canvas context is unavailable');
-          }
-          context.fillStyle = '#ff0000';
-          context.fillRect(0, 0, 1, 1);
           return {
             type: 'image',
-            value: canvas,
+            value: createFilledCanvas('#ff0000'),
+          };
+        },
+      },
+      {
+        name: GET_CANVAS_JPEG_TOOL_NAME,
+        description: 'Return a canvas image value with a requested JPEG MIME type.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        async execute(args) {
+          recordInvocation(state, GET_CANVAS_JPEG_TOOL_NAME, normalizeArguments(args));
+          return {
+            type: 'image',
+            value: createFilledCanvas('#0000ff'),
+            mimeType: 'image/jpeg',
           };
         },
       },
@@ -159,20 +181,30 @@ export function createImageToolDescriptors(state, options = {}) {
             GET_CANVAS_UNSUPPORTED_MIME_TYPE_TOOL_NAME,
             normalizeArguments(args)
           );
-          const canvas = document.createElement('canvas');
-          canvas.width = 1;
-          canvas.height = 1;
-          const context = canvas.getContext('2d');
-          if (!context) {
-            throw new Error('2D canvas context is unavailable');
-          }
-          context.fillStyle = '#00ff00';
-          context.fillRect(0, 0, 1, 1);
           return {
             type: 'image',
-            value: canvas,
+            value: createFilledCanvas('#00ff00'),
             mimeType: 'image/unsupported',
           };
+        },
+      },
+      {
+        name: GET_IMAGE_ARRAY_TOOL_NAME,
+        description: 'Return an array containing an image value.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        async execute(args) {
+          recordInvocation(state, GET_IMAGE_ARRAY_TOOL_NAME, normalizeArguments(args));
+          return [
+            {
+              type: 'image',
+              value: new Blob([base64ToBytes(ONE_BY_ONE_PNG_BASE64)], {
+                type: 'image/png',
+              }),
+            },
+          ];
         },
       },
       {

--- a/e2e/test-app/package.json
+++ b/e2e/test-app/package.json
@@ -14,6 +14,7 @@
     "@mcp-b/global": "workspace:*",
     "@mcp-b/mcp-iframe": "workspace:*",
     "@mcp-b/transports": "workspace:*",
+    "@mcp-b/webmcp-polyfill": "workspace:*",
     "@mcp-b/webmcp-ts-sdk": "workspace:*",
     "@mcp-b/webmcp-types": "workspace:*",
     "@modelcontextprotocol/sdk": "catalog:",

--- a/e2e/test-app/runtime-contract-image-native.html
+++ b/e2e/test-app/runtime-contract-image-native.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Runtime Contract - Image Values Native</title>
+    <style>
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        max-width: 960px;
+        margin: 32px auto;
+        padding: 0 16px 40px;
+      }
+      .panel {
+        border: 1px solid #d0d7de;
+        border-radius: 8px;
+        padding: 16px;
+        margin-top: 16px;
+      }
+      .status {
+        padding: 10px 12px;
+        border-radius: 6px;
+        background: #f6f8fa;
+      }
+      .status.ready {
+        background: #dcfce7;
+        color: #166534;
+      }
+      .status.error {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+      pre {
+        background: #0f172a;
+        color: #e2e8f0;
+        border-radius: 8px;
+        padding: 12px;
+        overflow-x: auto;
+      }
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Runtime Contract - Image Values Native</h1>
+    <p>Image value tools registered through native <code>document.modelContext</code>.</p>
+
+    <div class="panel">
+      <h2>Runtime Status</h2>
+      <div id="runtime-status" class="status" data-status="booting">Booting runtime...</div>
+    </div>
+
+    <div class="panel">
+      <h2>Execution Status</h2>
+      <div id="client-status" class="status" data-status="connecting">
+        Discovering WebMCP tools...
+      </div>
+    </div>
+
+    <div class="panel">
+      <h2>Discovered Tools</h2>
+      <pre id="tool-list" data-count="0">[]</pre>
+    </div>
+
+    <div class="panel">
+      <h2>Recorded Invocations</h2>
+      <pre id="invocation-list" data-count="0">[]</pre>
+    </div>
+
+    <script type="module" src="/src/runtime-contract-image-native.ts"></script>
+  </body>
+</html>

--- a/e2e/test-app/runtime-contract-image-polyfill.html
+++ b/e2e/test-app/runtime-contract-image-polyfill.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Runtime Contract - Image Values Polyfill</title>
+    <style>
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        max-width: 960px;
+        margin: 32px auto;
+        padding: 0 16px 40px;
+      }
+      .panel {
+        border: 1px solid #d0d7de;
+        border-radius: 8px;
+        padding: 16px;
+        margin-top: 16px;
+      }
+      .status {
+        padding: 10px 12px;
+        border-radius: 6px;
+        background: #f6f8fa;
+      }
+      .status.ready {
+        background: #dcfce7;
+        color: #166534;
+      }
+      .status.error {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+      pre {
+        background: #0f172a;
+        color: #e2e8f0;
+        border-radius: 8px;
+        padding: 12px;
+        overflow-x: auto;
+      }
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Runtime Contract - Image Values Polyfill</h1>
+    <p>Image value tools registered through <code>document.modelContext</code>.</p>
+
+    <div class="panel">
+      <h2>Runtime Status</h2>
+      <div id="runtime-status" class="status" data-status="booting">Booting runtime...</div>
+    </div>
+
+    <div class="panel">
+      <h2>Execution Status</h2>
+      <div id="client-status" class="status" data-status="connecting">
+        Discovering WebMCP tools...
+      </div>
+    </div>
+
+    <div class="panel">
+      <h2>Discovered Tools</h2>
+      <pre id="tool-list" data-count="0">[]</pre>
+    </div>
+
+    <div class="panel">
+      <h2>Recorded Invocations</h2>
+      <pre id="invocation-list" data-count="0">[]</pre>
+    </div>
+
+    <script type="module" src="/src/runtime-contract-image-polyfill.ts"></script>
+  </body>
+</html>

--- a/e2e/test-app/src/runtime-contract-image-native.ts
+++ b/e2e/test-app/src/runtime-contract-image-native.ts
@@ -1,0 +1,77 @@
+import { installBrowserImageRuntimeContract } from '../../runtime-contract/image-contract.js';
+
+type RuntimeHook = NonNullable<Window['__WEBMCP_E2E__']>;
+
+function requireElement<T extends HTMLElement>(id: string): T {
+  const element = document.getElementById(id);
+  if (!element) {
+    throw new Error(`Required DOM element not found: ${id}`);
+  }
+  return element as T;
+}
+
+const runtimeStatusEl = requireElement<HTMLDivElement>('runtime-status');
+const clientStatusEl = requireElement<HTMLDivElement>('client-status');
+const toolListEl = requireElement<HTMLPreElement>('tool-list');
+const invocationListEl = requireElement<HTMLPreElement>('invocation-list');
+
+function setStatus(
+  element: HTMLDivElement,
+  status: 'booting' | 'ready' | 'error' | 'connecting',
+  text: string
+) {
+  element.textContent = text;
+  element.dataset.status = status;
+  element.className =
+    status === 'ready' ? 'status ready' : status === 'error' ? 'status error' : 'status';
+}
+
+function getRuntimeHook(): RuntimeHook {
+  const hook = window.__WEBMCP_E2E__;
+  if (!hook) {
+    throw new Error('Image runtime contract hook is not available');
+  }
+  return hook;
+}
+
+function renderInvocations() {
+  const hook = getRuntimeHook();
+  const invocations = hook.readInvocations();
+  invocationListEl.textContent = JSON.stringify(invocations, null, 2);
+  invocationListEl.dataset.count = String(invocations.length);
+}
+
+async function renderTools() {
+  const tools = await document.modelContext.getTools();
+  const names = tools.map((tool) => tool.name).sort();
+  toolListEl.textContent = JSON.stringify(names, null, 2);
+  toolListEl.dataset.count = String(names.length);
+}
+
+async function bootstrap() {
+  const modelContext = document.modelContext;
+  if (!modelContext) {
+    throw new Error('Native document.modelContext is unavailable');
+  }
+  if (typeof modelContext.getTools !== 'function') {
+    throw new Error('Native document.modelContext.getTools is unavailable');
+  }
+  if (typeof modelContext.executeTool !== 'function') {
+    throw new Error('Native document.modelContext.executeTool is unavailable');
+  }
+
+  await installBrowserImageRuntimeContract(modelContext, { runtimeLabel: 'image-native' });
+  setStatus(runtimeStatusEl, 'ready', 'Runtime ready');
+  renderInvocations();
+
+  setStatus(clientStatusEl, 'connecting', 'Discovering WebMCP tools...');
+  await renderTools();
+  setStatus(clientStatusEl, 'ready', 'WebMCP execution ready');
+}
+
+void bootstrap().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  setStatus(runtimeStatusEl, 'error', message);
+  setStatus(clientStatusEl, 'error', message);
+  console.error('[runtime-contract][image-native]', error);
+});

--- a/e2e/test-app/src/runtime-contract-image-polyfill.ts
+++ b/e2e/test-app/src/runtime-contract-image-polyfill.ts
@@ -1,0 +1,74 @@
+import { initializeWebMCPPolyfill } from '@mcp-b/webmcp-polyfill';
+import { installBrowserImageRuntimeContract } from '../../runtime-contract/image-contract.js';
+
+type RuntimeHook = NonNullable<Window['__WEBMCP_E2E__']>;
+
+function requireElement<T extends HTMLElement>(id: string): T {
+  const element = document.getElementById(id);
+  if (!element) {
+    throw new Error(`Required DOM element not found: ${id}`);
+  }
+  return element as T;
+}
+
+const runtimeStatusEl = requireElement<HTMLDivElement>('runtime-status');
+const clientStatusEl = requireElement<HTMLDivElement>('client-status');
+const toolListEl = requireElement<HTMLPreElement>('tool-list');
+const invocationListEl = requireElement<HTMLPreElement>('invocation-list');
+
+function setStatus(
+  element: HTMLDivElement,
+  status: 'booting' | 'ready' | 'error' | 'connecting',
+  text: string
+) {
+  element.textContent = text;
+  element.dataset.status = status;
+  element.className =
+    status === 'ready' ? 'status ready' : status === 'error' ? 'status error' : 'status';
+}
+
+function getRuntimeHook(): RuntimeHook {
+  const hook = window.__WEBMCP_E2E__;
+  if (!hook) {
+    throw new Error('Image runtime contract hook is not available');
+  }
+  return hook;
+}
+
+function renderInvocations() {
+  const hook = getRuntimeHook();
+  const invocations = hook.readInvocations();
+  invocationListEl.textContent = JSON.stringify(invocations, null, 2);
+  invocationListEl.dataset.count = String(invocations.length);
+}
+
+async function renderTools() {
+  const tools = await document.modelContext.getTools();
+  const names = tools.map((tool) => tool.name).sort();
+  toolListEl.textContent = JSON.stringify(names, null, 2);
+  toolListEl.dataset.count = String(names.length);
+}
+
+async function bootstrap() {
+  initializeWebMCPPolyfill();
+
+  const modelContext = document.modelContext;
+  if (!modelContext) {
+    throw new Error('document.modelContext is unavailable');
+  }
+
+  await installBrowserImageRuntimeContract(modelContext, { runtimeLabel: 'image-polyfill' });
+  setStatus(runtimeStatusEl, 'ready', 'Runtime ready');
+  renderInvocations();
+
+  setStatus(clientStatusEl, 'connecting', 'Discovering WebMCP tools...');
+  await renderTools();
+  setStatus(clientStatusEl, 'ready', 'WebMCP execution ready');
+}
+
+void bootstrap().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  setStatus(runtimeStatusEl, 'error', message);
+  setStatus(clientStatusEl, 'error', message);
+  console.error('[runtime-contract][image-polyfill]', error);
+});

--- a/e2e/test-app/src/webmcp-extensions.d.ts
+++ b/e2e/test-app/src/webmcp-extensions.d.ts
@@ -7,6 +7,7 @@ declare module '@mcp-b/webmcp-types' {
     listTools(): ToolListItem[];
     executeTool(name: string, args?: Record<string, unknown>): Promise<ToolResponse>;
     callTool(params: { name: string; arguments?: Record<string, unknown> }): Promise<ToolResponse>;
+    unregisterTool(name: string): void;
     createMessage(params: unknown): Promise<unknown>;
     elicitInput(params: unknown): Promise<unknown>;
     registerResource(descriptor: {

--- a/e2e/test-app/vite.config.ts
+++ b/e2e/test-app/vite.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
       input: {
         main: resolve(__dirname, 'index.html'),
         'runtime-contract': resolve(__dirname, 'runtime-contract.html'),
+        'runtime-contract-image-polyfill': resolve(
+          __dirname,
+          'runtime-contract-image-polyfill.html'
+        ),
+        'runtime-contract-image-native': resolve(__dirname, 'runtime-contract-image-native.html'),
         'runtime-contract-iframe-child': resolve(__dirname, 'runtime-contract-iframe-child.html'),
         'runtime-contract-iframe-client': resolve(__dirname, 'runtime-contract-iframe-client.html'),
         'codemode-webmcp': resolve(__dirname, 'codemode-webmcp.html'),

--- a/e2e/tests/runtime-contract-image-values.spec.ts
+++ b/e2e/tests/runtime-contract-image-values.spec.ts
@@ -1,0 +1,291 @@
+import { expect, type Page, test } from '@playwright/test';
+import {
+  DESCRIBE_INPUT_IMAGE_TOOL_NAME,
+  GET_BLOB_PNG_TOOL_NAME,
+  GET_BLOB_WITHOUT_MIME_TYPE_TOOL_NAME,
+  GET_CANVAS_PNG_TOOL_NAME,
+  GET_CANVAS_UNSUPPORTED_MIME_TYPE_TOOL_NAME,
+  GET_IMAGE_ELEMENT_PNG_TOOL_NAME,
+  GET_SERIALIZED_PNG_TOOL_NAME,
+  GET_SERIALIZED_WITHOUT_MIME_TYPE_TOOL_NAME,
+  GET_UNSUPPORTED_IMAGE_SOURCE_TOOL_NAME,
+  IMAGE_TEXT_SMOKE_TOOL_NAME,
+  ONE_BY_ONE_PNG_BASE64,
+} from '../runtime-contract/image-contract.js';
+import { waitForRuntimePage } from './runtime-contract.helpers.js';
+
+const imageRuntime = process.env.WEBMCP_E2E_RUNTIME === 'native' ? 'native' : 'polyfill';
+const imagePagePath =
+  imageRuntime === 'native'
+    ? '/runtime-contract-image-native.html'
+    : '/runtime-contract-image-polyfill.html';
+const expectedRuntimeLabel = imageRuntime === 'native' ? 'image-native' : 'image-polyfill';
+
+async function listDocumentToolNames(page: Page): Promise<string[]> {
+  return page.evaluate(async () => {
+    const tools = await document.modelContext.getTools();
+    return tools.map((tool) => tool.name).sort();
+  });
+}
+
+async function executeDocumentTool(
+  page: Page,
+  name: string,
+  args: Record<string, unknown>
+): Promise<unknown> {
+  return page.evaluate(
+    async ({ toolName, toolArgs }) => {
+      const tools = await document.modelContext.getTools();
+      const tool = tools.find((candidate) => candidate.name === toolName);
+      if (!tool) {
+        throw new Error(`Tool not found: ${toolName}`);
+      }
+
+      const result = await document.modelContext.executeTool(tool, JSON.stringify(toolArgs));
+      if (result === null) {
+        return null;
+      }
+      return JSON.parse(result) as unknown;
+    },
+    { toolName: name, toolArgs: args }
+  );
+}
+
+async function executeDocumentToolForError(
+  page: Page,
+  name: string,
+  args: Record<string, unknown>
+): Promise<string> {
+  try {
+    await executeDocumentTool(page, name, args);
+    return '';
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+function expectImageExecutionError(errorMessage: string, polyfillMessage: string) {
+  if (imageRuntime === 'native') {
+    // Native runtimes do not surface tool exception text through
+    // executeTool(); rejections map to a generic invocation-failure message.
+    expect(errorMessage.length).toBeGreaterThan(0);
+    return;
+  }
+  expect(errorMessage).toContain(polyfillMessage);
+}
+
+/**
+ * Browser-source image serialization ({type: 'image', value} with a Blob,
+ * canvas, or image element, mirroring the Prompt API content shape) is
+ * optional for native runtimes until the WebMCP spec defines it. Detect
+ * support by executing the Blob-backed tool: runtimes without support return
+ * the raw object (no string `data`) or fail.
+ */
+async function supportsBrowserSourceImages(page: Page): Promise<boolean> {
+  try {
+    const result = await executeDocumentTool(page, GET_BLOB_PNG_TOOL_NAME, {});
+    return (
+      typeof (result as { data?: unknown } | null)?.data === 'string' &&
+      (result as { data: string }).data.length > 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function skipUnlessBrowserSourceImages(page: Page) {
+  test.skip(
+    !(await supportsBrowserSourceImages(page)),
+    'Browser-source image serialization is not supported by this runtime (optional until spec text exists)'
+  );
+}
+
+function expectPngImageValue(result: unknown) {
+  expect(result).toMatchObject({
+    type: 'image',
+    mimeType: 'image/png',
+  });
+  expect(result).toHaveProperty('data', expect.any(String));
+
+  const data = (result as { data: string }).data;
+  const bytes = Buffer.from(data, 'base64');
+  expect([...bytes.subarray(0, 8)]).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
+}
+
+test.describe('Runtime Contract - Image Values', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForRuntimePage(page, imagePagePath);
+  });
+
+  test('registers image contract tools through document.modelContext', async ({ page }) => {
+    const toolNames = await listDocumentToolNames(page);
+
+    expect(toolNames).toEqual(expect.arrayContaining([IMAGE_TEXT_SMOKE_TOOL_NAME]));
+
+    const result = await executeDocumentTool(page, IMAGE_TEXT_SMOKE_TOOL_NAME, {
+      message: 'ready',
+    });
+    expect(result).toMatchObject({
+      text: 'image-smoke:ready',
+      message: 'ready',
+      runtime: expectedRuntimeLabel,
+    });
+  });
+
+  test('supports WebMCP registration lifecycle on document.modelContext', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const toolName = `lifecycle_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+      const controller = new AbortController();
+      const events: string[] = [];
+
+      document.modelContext.ontoolchange = () => {
+        events.push('handler');
+      };
+      document.modelContext.addEventListener('toolchange', () => {
+        events.push('listener');
+      });
+
+      const registration = document.modelContext.registerTool(
+        {
+          name: toolName,
+          description: 'Temporary lifecycle contract tool',
+          inputSchema: { type: 'object', properties: {} },
+          async execute() {
+            return { ok: true };
+          },
+        },
+        { signal: controller.signal }
+      );
+      // Per the WebMCP spec, registerTool() returns undefined.
+      const registerReturnsUndefined = registration === undefined;
+
+      const afterRegister = (await document.modelContext.getTools()).some(
+        (tool) => tool.name === toolName
+      );
+
+      controller.abort();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const afterAbort = (await document.modelContext.getTools()).some(
+        (tool) => tool.name === toolName
+      );
+
+      document.modelContext.ontoolchange = null;
+      return { registerReturnsUndefined, afterRegister, afterAbort, events };
+    });
+
+    expect(result.registerReturnsUndefined).toBe(true);
+    expect(result.afterRegister).toBe(true);
+    expect(result.afterAbort).toBe(false);
+    expect(result.events).toContain('handler');
+    expect(result.events).toContain('listener');
+  });
+
+  test('returns a serialized image value through document.modelContext.executeTool', async ({
+    page,
+  }) => {
+    const result = await executeDocumentTool(page, GET_SERIALIZED_PNG_TOOL_NAME, {});
+
+    expect(result).toEqual({
+      type: 'image',
+      data: ONE_BY_ONE_PNG_BASE64,
+      mimeType: 'image/png',
+    });
+  });
+
+  test('serializes a Blob-backed image value through document.modelContext.executeTool', async ({
+    page,
+  }) => {
+    await skipUnlessBrowserSourceImages(page);
+
+    const result = await executeDocumentTool(page, GET_BLOB_PNG_TOOL_NAME, {});
+
+    expect(result).toEqual({
+      type: 'image',
+      data: ONE_BY_ONE_PNG_BASE64,
+      mimeType: 'image/png',
+    });
+  });
+
+  test('serializes a canvas-backed image value through document.modelContext.executeTool', async ({
+    page,
+  }) => {
+    await skipUnlessBrowserSourceImages(page);
+
+    const result = await executeDocumentTool(page, GET_CANVAS_PNG_TOOL_NAME, {});
+
+    expectPngImageValue(result);
+  });
+
+  test('reports the actual encoded MIME type for unsupported canvas MIME requests', async ({
+    page,
+  }) => {
+    await skipUnlessBrowserSourceImages(page);
+
+    const result = await executeDocumentTool(page, GET_CANVAS_UNSUPPORTED_MIME_TYPE_TOOL_NAME, {});
+
+    expectPngImageValue(result);
+  });
+
+  test('serializes an image-element-backed image value through document.modelContext.executeTool', async ({
+    page,
+  }) => {
+    await skipUnlessBrowserSourceImages(page);
+
+    const result = await executeDocumentTool(page, GET_IMAGE_ELEMENT_PNG_TOOL_NAME, {});
+
+    expectPngImageValue(result);
+  });
+
+  test('passes serialized image values into tool execution unchanged', async ({ page }) => {
+    const result = await executeDocumentTool(page, DESCRIBE_INPUT_IMAGE_TOOL_NAME, {
+      image: {
+        type: 'image',
+        data: ONE_BY_ONE_PNG_BASE64,
+        mimeType: 'image/png',
+      },
+    });
+
+    expect(result).toEqual({
+      inputType: 'image',
+      mimeType: 'image/png',
+      dataLength: ONE_BY_ONE_PNG_BASE64.length,
+    });
+  });
+
+  test('rejects unsupported image source values with a clear execution error', async ({ page }) => {
+    await skipUnlessBrowserSourceImages(page);
+
+    const errorMessage = await executeDocumentToolForError(
+      page,
+      GET_UNSUPPORTED_IMAGE_SOURCE_TOOL_NAME,
+      {}
+    );
+
+    expectImageExecutionError(errorMessage, 'Image output value must include');
+  });
+
+  test('rejects Blob-backed image values without a MIME type', async ({ page }) => {
+    await skipUnlessBrowserSourceImages(page);
+
+    const errorMessage = await executeDocumentToolForError(
+      page,
+      GET_BLOB_WITHOUT_MIME_TYPE_TOOL_NAME,
+      {}
+    );
+
+    expectImageExecutionError(errorMessage, 'Image Blob output requires a mimeType or Blob.type');
+  });
+
+  test('rejects serialized image values without a MIME type', async ({ page }) => {
+    await skipUnlessBrowserSourceImages(page);
+
+    const errorMessage = await executeDocumentToolForError(
+      page,
+      GET_SERIALIZED_WITHOUT_MIME_TYPE_TOOL_NAME,
+      {}
+    );
+
+    expectImageExecutionError(errorMessage, 'Image output value must include data and mimeType');
+  });
+});

--- a/e2e/tests/runtime-contract-image-values.spec.ts
+++ b/e2e/tests/runtime-contract-image-values.spec.ts
@@ -3,8 +3,10 @@ import {
   DESCRIBE_INPUT_IMAGE_TOOL_NAME,
   GET_BLOB_PNG_TOOL_NAME,
   GET_BLOB_WITHOUT_MIME_TYPE_TOOL_NAME,
+  GET_CANVAS_JPEG_TOOL_NAME,
   GET_CANVAS_PNG_TOOL_NAME,
   GET_CANVAS_UNSUPPORTED_MIME_TYPE_TOOL_NAME,
+  GET_IMAGE_ARRAY_TOOL_NAME,
   GET_IMAGE_ELEMENT_PNG_TOOL_NAME,
   GET_SERIALIZED_PNG_TOOL_NAME,
   GET_SERIALIZED_WITHOUT_MIME_TYPE_TOOL_NAME,
@@ -217,6 +219,22 @@ test.describe('Runtime Contract - Image Values', () => {
     expectPngImageValue(result);
   });
 
+  test('honors a supported requested MIME type for canvas-backed image values', async ({
+    page,
+  }) => {
+    await skipUnlessBrowserSourceImages(page);
+
+    const result = await executeDocumentTool(page, GET_CANVAS_JPEG_TOOL_NAME, {});
+
+    expect(result).toMatchObject({
+      type: 'image',
+      mimeType: 'image/jpeg',
+    });
+    const data = (result as { data: string }).data;
+    const bytes = Buffer.from(data, 'base64');
+    expect([...bytes.subarray(0, 3)]).toEqual([255, 216, 255]);
+  });
+
   test('reports the actual encoded MIME type for unsupported canvas MIME requests', async ({
     page,
   }) => {
@@ -251,6 +269,17 @@ test.describe('Runtime Contract - Image Values', () => {
       mimeType: 'image/png',
       dataLength: ONE_BY_ONE_PNG_BASE64.length,
     });
+  });
+
+  test('serializes only top-level image values, not values nested in arrays', async ({ page }) => {
+    const result = await executeDocumentTool(page, GET_IMAGE_ARRAY_TOOL_NAME, {});
+
+    // Image detection applies to the top-level result value only; nested
+    // values go through ordinary JSON serialization (a Blob serializes to
+    // an empty object). This holds whether or not the runtime supports
+    // browser-source image serialization.
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual([{ type: 'image', value: {} }]);
   });
 
   test('rejects unsupported image source values with a clear execution error', async ({ page }) => {

--- a/e2e/types/globals.d.ts
+++ b/e2e/types/globals.d.ts
@@ -8,6 +8,7 @@ declare module '@mcp-b/webmcp-types' {
     listTools(): ToolListItem[];
     callTool(params: { name: string; arguments?: Record<string, unknown> }): Promise<ToolResponse>;
     executeTool(name: string, args?: Record<string, unknown>): Promise<ToolResponse>;
+    unregisterTool(name: string): void;
     createMessage(params: unknown): Promise<unknown>;
     elicitInput(params: unknown): Promise<unknown>;
   }

--- a/packages/webmcp-polyfill/README.md
+++ b/packages/webmcp-polyfill/README.md
@@ -32,7 +32,7 @@ Important:
 
 - `document.modelContext` is the canonical install location. `navigator.modelContext` is kept as a backward-compatible alias that returns the same instance and logs a one-time deprecation warning on first access. The upstream WebMCP draft moved the getter from Navigator to Document on May 27, 2026 ([webmachinelearning/webmcp#184](https://github.com/webmachinelearning/webmcp/pull/184)) and Chrome 150 deprecates `navigator.modelContext`. The polyfill will remove the Navigator alias in the next major version.
 - `document.modelContext` in this package does not provide `listTools()` or `callTool(...)`; producer discovery/execution uses `getTools()` and `executeTool(...)`.
-- For list/execute test flows, use `navigator.modelContextTesting` (when `installTestingShim` is enabled).
+- Producer discovery/execution uses `document.modelContext.getTools()` and `document.modelContext.executeTool(...)`. `navigator.modelContextTesting` remains available only as an optional compatibility shim for older tests.
 - `provideContext()` and `clearContext()` were removed from the upstream WebMCP spec on March 5, 2026 and are not exposed by this polyfill.
 - `unregisterTool(name)` was removed from the WebMCP draft on April 23, 2026 in favor of `AbortSignal`-driven unregistration. The polyfill keeps it functional with a one-time deprecation warning; it will be removed in the next major version.
 
@@ -75,7 +75,7 @@ document.modelContext.registerTool({
   inputSchema: { type: 'object', properties: {} },
   async execute() {
     return {
-      content: [{ type: 'text', text: document.title }],
+      title: document.title,
     };
   },
 });
@@ -122,7 +122,8 @@ document.modelContext.registerTool({
     // Inferred type:
     // { query: string; limit?: number }
     return {
-      content: [{ type: 'text', text: `Searching for ${args.query} (${args.limit ?? 10})` }],
+      query: args.query,
+      limit: args.limit ?? 10,
     };
   },
 });
@@ -176,7 +177,7 @@ document.modelContext.registerTool(
     description: 'Search docs',
     inputSchema: { type: 'object', properties: {} },
     async execute() {
-      return { content: [{ type: 'text', text: 'ok' }] };
+      return { ok: true };
     },
   },
   { signal: ac.signal }
@@ -194,19 +195,25 @@ ac.abort();
 
 ## Listing and Executing Tools
 
-In `@mcp-b/webmcp-polyfill`, listing and execution helpers are exposed on
-`navigator.modelContextTesting` (not `document.modelContext`) when the testing shim is enabled.
+In `@mcp-b/webmcp-polyfill`, producer discovery and execution are exposed on
+`document.modelContext`.
 
 ```ts
 import { initializeWebMCPPolyfill } from '@mcp-b/webmcp-polyfill';
 
-initializeWebMCPPolyfill({ installTestingShim: true });
+initializeWebMCPPolyfill();
 
-const tools = navigator.modelContextTesting?.listTools();
-const result = await navigator.modelContextTesting?.executeTool(
-  'search',
+const tools = await document.modelContext.getTools();
+const searchTool = tools.find((tool) => tool.name === 'search');
+if (!searchTool) {
+  throw new Error('search tool is not registered');
+}
+
+const resultJson = await document.modelContext.executeTool(
+  searchTool,
   JSON.stringify({ query: 'webmcp' })
 );
+const result = resultJson === null ? null : JSON.parse(resultJson);
 
 void tools;
 void result;
@@ -214,6 +221,48 @@ void result;
 
 If you want `callTool(...)` / extension-style runtime methods on `document.modelContext`, use
 `@mcp-b/global`.
+
+## Direct WebMCP Image Values
+
+Tool handlers may return image values directly. This is a WebMCP value shape, not
+an MCP `content` array.
+
+```ts
+document.modelContext.registerTool({
+  name: 'get_product_image',
+  description: 'Return the product image rendered on the page',
+  inputSchema: { type: 'object', properties: {} },
+  async execute() {
+    const image = document.querySelector<HTMLImageElement>('#product-image');
+    if (!image) {
+      throw new Error('Product image is not available');
+    }
+
+    return { type: 'image', value: image };
+  },
+});
+
+const tools = await document.modelContext.getTools();
+const tool = tools.find((candidate) => candidate.name === 'get_product_image');
+if (!tool) {
+  throw new Error('get_product_image is not registered');
+}
+
+const resultJson = await document.modelContext.executeTool(tool, '{}');
+const image = resultJson === null ? null : JSON.parse(resultJson);
+```
+
+Accepted direct image output values:
+
+- `{ type: 'image', data, mimeType }` — already-serialized base64 image data
+- `{ type: 'image', value, mimeType? }` — a `Blob` (`mimeType` defaults to
+  `blob.type`), an `HTMLCanvasElement`, or a loaded same-origin
+  `HTMLImageElement` (element output defaults to `image/png`)
+
+The `{type, value}` source shape mirrors the Prompt API's
+`LanguageModelToolResultContent`. Serialized values require a non-empty
+`mimeType`. Blob values must provide either `mimeType` or `Blob.type`.
+Unsupported image sources reject the tool execution with a clear error.
 
 ## Input Schema Support
 

--- a/packages/webmcp-polyfill/src/index.ts
+++ b/packages/webmcp-polyfill/src/index.ts
@@ -20,6 +20,7 @@ const TOOL_INVOCATION_FAILED_MESSAGE =
   'Tool was executed but the invocation failed. For example, the script function threw an error';
 const TOOL_CANCELLED_MESSAGE = 'Tool was cancelled';
 const DEFAULT_INPUT_SCHEMA: InputSchema = { type: 'object', properties: {} };
+const DEFAULT_IMAGE_MIME_TYPE = 'image/png';
 const STANDARD_JSON_SCHEMA_TARGETS = ['draft-2020-12', 'draft-07'] as const;
 /** WebMCP §4.2 tool name: ASCII alnum, underscore, hyphen, period; 1–128 code points. */
 const VALID_TOOL_NAME_RE = /^[A-Za-z0-9_\-.]{1,128}$/u;
@@ -268,7 +269,8 @@ class StrictWebMCPContext extends EventTarget {
       if (normalizeResult) {
         return toSerializedTestingResult(normalizeToolResponse(rawResult));
       }
-      const serialized = JSON.stringify(rawResult);
+      const webMCPResult = await normalizeWebMCPExecutionResult(rawResult);
+      const serialized = JSON.stringify(webMCPResult);
       return serialized === undefined ? null : serialized;
     } catch (error) {
       const detail =
@@ -832,6 +834,158 @@ function serializeTextContent(value: unknown): string {
   } catch {
     return String(value);
   }
+}
+
+interface SerializedImageValue {
+  type: 'image';
+  data: string;
+  mimeType: string;
+}
+
+function isBlobValue(value: unknown): value is Blob {
+  return typeof Blob !== 'undefined' && value instanceof Blob;
+}
+
+function isCanvasElement(value: unknown): value is HTMLCanvasElement {
+  return typeof HTMLCanvasElement !== 'undefined' && value instanceof HTMLCanvasElement;
+}
+
+function isImageElement(value: unknown): value is HTMLImageElement {
+  return typeof HTMLImageElement !== 'undefined' && value instanceof HTMLImageElement;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  const chunkSize = 0x8000;
+  let binary = '';
+
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+
+  return btoa(binary);
+}
+
+function getImageMimeType(value: Record<string, unknown>): string | undefined {
+  // Mirrors native IDL dictionary conversion: the member is absent when
+  // undefined, and any other value stringifies.
+  const mimeType = value.mimeType;
+  if (mimeType === undefined) {
+    return undefined;
+  }
+
+  return String(mimeType).trim() || undefined;
+}
+
+async function blobToSerializedImage(
+  blob: Blob,
+  explicitMimeType?: string
+): Promise<SerializedImageValue> {
+  const mimeType = explicitMimeType || blob.type;
+  if (!mimeType) {
+    throw new TypeError('Image Blob output requires a mimeType or Blob.type');
+  }
+
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  return {
+    type: 'image',
+    data: bytesToBase64(bytes),
+    mimeType,
+  };
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, mimeType: string): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    try {
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          reject(new Error('Canvas image serialization returned no Blob'));
+          return;
+        }
+        resolve(blob);
+      }, mimeType);
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function canvasToSerializedImage(
+  canvas: HTMLCanvasElement,
+  mimeType = DEFAULT_IMAGE_MIME_TYPE
+): Promise<SerializedImageValue> {
+  const blob = await canvasToBlob(canvas, mimeType);
+  return blobToSerializedImage(blob, blob.type || DEFAULT_IMAGE_MIME_TYPE);
+}
+
+async function imageElementToSerializedImage(
+  image: HTMLImageElement,
+  mimeType = DEFAULT_IMAGE_MIME_TYPE
+): Promise<SerializedImageValue> {
+  if (typeof image.decode === 'function') {
+    await image.decode();
+  }
+
+  if (!image.complete || image.naturalWidth <= 0 || image.naturalHeight <= 0) {
+    throw new Error('Image element output must be loaded before serialization');
+  }
+
+  const canvas = image.ownerDocument.createElement('canvas');
+  canvas.width = image.naturalWidth;
+  canvas.height = image.naturalHeight;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('2D canvas context is unavailable for image serialization');
+  }
+  context.drawImage(image, 0, 0);
+  return canvasToSerializedImage(canvas, mimeType);
+}
+
+async function normalizeWebMCPImageValue(value: Record<string, unknown>): Promise<unknown> {
+  // The accepted input shapes mirror the native implementation: the
+  // serialized MCP-style {type, data, mimeType} form passes through, and the
+  // Prompt-API-style {type, value, mimeType?} form carries a live browser
+  // source to serialize.
+  const data = value.data;
+  const mimeType = getImageMimeType(value);
+
+  if (data !== undefined) {
+    if (!mimeType) {
+      throw new TypeError('Image output value must include data and mimeType');
+    }
+    return {
+      type: 'image',
+      data: String(data),
+      mimeType,
+    } satisfies SerializedImageValue;
+  }
+
+  const source = value.value;
+  if (source === undefined) {
+    throw new TypeError(
+      'Image output value must include data and mimeType, or a Blob, HTMLCanvasElement, or ' +
+        'HTMLImageElement value'
+    );
+  }
+
+  if (isBlobValue(source)) {
+    return blobToSerializedImage(source, mimeType);
+  }
+  if (isCanvasElement(source)) {
+    return canvasToSerializedImage(source, mimeType ?? DEFAULT_IMAGE_MIME_TYPE);
+  }
+  if (isImageElement(source)) {
+    return imageElementToSerializedImage(source, mimeType ?? DEFAULT_IMAGE_MIME_TYPE);
+  }
+
+  throw new TypeError('Image output value must be a Blob, HTMLCanvasElement, or HTMLImageElement');
+}
+
+async function normalizeWebMCPExecutionResult(value: unknown): Promise<unknown> {
+  if (isPlainObject(value) && value.type === 'image') {
+    return normalizeWebMCPImageValue(value);
+  }
+
+  return value;
 }
 
 function normalizeToolResponse(value: unknown): ToolResponse {

--- a/packages/webmcp-types/README.md
+++ b/packages/webmcp-types/README.md
@@ -19,6 +19,7 @@ This package is the type-safety source of truth for WebMCP.
 - Deprecated global `Navigator` augmentation for backward-compatible `navigator.modelContext`
 - Strongly typed tool descriptors and tool responses
 - Literal JSON Schema inference for tool args and `structuredContent`
+- Direct WebMCP image value types for serialized and browser-backed images
 - Name-aware helper types for typed tool registries
 - Runtime-agnostic: works with native implementations, polyfills, or adapters
 
@@ -99,12 +100,9 @@ document.modelContext.registerTool({
   async execute(args) {
     // args is inferred as: { query: string; limit?: number }
     return {
-      content: [{ type: 'text', text: `Searching for ${args.query}` }],
-      structuredContent: {
-        // inferred from outputSchema
-        total: 1,
-        items: [args.query],
-      },
+      // inferred from outputSchema
+      total: 1,
+      items: [args.query],
     };
   },
 });
@@ -159,6 +157,36 @@ This catches enum/type mismatches at compile time.
 ### 6. Explicit typing is still available
 
 You can always provide explicit generic args/results with `ToolDescriptor<TArgs, TResult, TName>` when schema inference is not enough for your use case.
+
+## Direct WebMCP Image Values
+
+`WebMCPImageValue` describes image values returned directly from WebMCP tool
+handlers. These are not MCP `content` blocks.
+
+```ts
+import type { ToolDescriptor, WebMCPImageValue } from '@mcp-b/webmcp-types';
+
+const getImageTool: ToolDescriptor<Record<string, never>, WebMCPImageValue> = {
+  name: 'get_product_image',
+  description: 'Return a product image',
+  inputSchema: { type: 'object', properties: {} },
+  async execute() {
+    const image = document.querySelector<HTMLImageElement>('#product-image');
+    if (!image) {
+      throw new Error('Product image is not available');
+    }
+
+    return { type: 'image', value: image };
+  },
+};
+```
+
+Supported direct image value types:
+
+- `SerializedImageValue` — `{ type: 'image', data, mimeType }`
+- `SourceImageValue` — `{ type: 'image', value, mimeType? }` where `value` is a
+  `Blob`, `HTMLImageElement`, or `HTMLCanvasElement` (the `{type, value}` shape
+  mirrors the Prompt API's `LanguageModelToolResultContent`)
 
 ## Name-Aware Typed Context (Advanced)
 
@@ -219,6 +247,9 @@ void result;
 | `InferArgsFromInputSchema`           | Derive args shape from a schema type                         |
 | `ToolResultFromOutputSchema`         | Derive `structuredContent` type from output schema           |
 | `TypedModelContext`                  | Name-aware typed `callTool`/`listTools` for known registries |
+| `WebMCPImageValue`                   | Direct WebMCP image output value union                       |
+| `SerializedImageValue`               | Direct serialized base64 image output value                  |
+| `SourceImageValue`                   | Direct Blob/element-backed image output value                |
 | `CallToolResult`                     | Tool response type                                           |
 | `ContentBlock` / `LooseContentBlock` | Strict and pragmatic content block typing                    |
 | `ModelContextClient`                 | Tool execution client (`requestUserInteraction`)             |

--- a/packages/webmcp-types/src/common.ts
+++ b/packages/webmcp-types/src/common.ts
@@ -69,6 +69,62 @@ export interface InputSchema {
 }
 
 // ============================================================================
+// WebMCP Image Values
+// ============================================================================
+
+/**
+ * Serialized image value returned directly from a WebMCP tool.
+ *
+ * `data` is base64 without a `data:` URL prefix.
+ */
+export interface SerializedImageValue {
+  /**
+   * Discriminator for image values.
+   */
+  type: 'image';
+
+  /**
+   * Base64 payload.
+   */
+  data: string;
+
+  /**
+   * MIME type for the encoded image.
+   */
+  mimeType: string;
+}
+
+/**
+ * Browser-sourced image value accepted by the WebMCP polyfill.
+ *
+ * The `{type, value}` shape mirrors the Prompt API's
+ * `LanguageModelToolResultContent`; the browser serializes `value` to the
+ * `{type, data, mimeType}` wire form before the agent sees it.
+ */
+export interface SourceImageValue {
+  /**
+   * Discriminator for image values.
+   */
+  type: 'image';
+
+  /**
+   * Image source to serialize. For a Blob, `blob.type` is used when
+   * `mimeType` is omitted; elements are rasterized (default `image/png`).
+   */
+  value: Blob | HTMLImageElement | HTMLCanvasElement;
+
+  /**
+   * Optional MIME type override for the serialized image.
+   */
+  mimeType?: string;
+}
+
+/**
+ * Image value shape for direct WebMCP tool output.
+ */
+export type WebMCPImageValue = SerializedImageValue | SourceImageValue;
+
+// ============================================================================
 // Content Types (MCP spec shapes, defined inline)
 // ============================================================================
 

--- a/packages/webmcp-types/src/index.test-d.ts
+++ b/packages/webmcp-types/src/index.test-d.ts
@@ -1,5 +1,11 @@
 import { expectTypeOf, test } from 'vitest';
-import type { CallToolResult, InputSchema } from './common.js';
+import type {
+  CallToolResult,
+  InputSchema,
+  SerializedImageValue,
+  SourceImageValue,
+  WebMCPImageValue,
+} from './common.js';
 import type {
   LooseContentBlock,
   MaybePromise,
@@ -14,7 +20,7 @@ import type {
   ModelContextWithExtensions,
   ToolCallEvent,
 } from './index.js';
-import type { ToolDescriptor, ToolListItem } from './tool.js';
+import type { ToolDescriptor, ToolExecuteResult, ToolListItem } from './tool.js';
 
 // === Producer API ===
 test('ModelContext.registerTool accepts ToolDescriptor and returns void', () => {
@@ -52,6 +58,39 @@ test('ModelContext.executeTool uses registered tool objects and JSON-string inpu
   expectTypeOf<ModelContext['executeTool']>().parameter(0).toEqualTypeOf<ModelContextToolInfo>();
   expectTypeOf<ModelContext['executeTool']>().parameter(1).toEqualTypeOf<string>();
   expectTypeOf<ModelContext['executeTool']>().returns.toEqualTypeOf<Promise<string | null>>();
+});
+
+test('WebMCP image values describe direct serialized and browser-source output forms', () => {
+  expectTypeOf<SerializedImageValue>().toMatchObjectType<{
+    type: 'image';
+    data: string;
+    mimeType: string;
+  }>();
+  expectTypeOf<SourceImageValue>().toMatchObjectType<{
+    type: 'image';
+    value: Blob | HTMLImageElement | HTMLCanvasElement;
+    mimeType?: string;
+  }>();
+  expectTypeOf<WebMCPImageValue>().toEqualTypeOf<SerializedImageValue | SourceImageValue>();
+});
+
+test('ToolDescriptor can return direct WebMCP image values without content blocks', () => {
+  const tool: ToolDescriptor<Record<string, never>, WebMCPImageValue> = {
+    name: 'image_tool',
+    description: 'Return an image',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    execute: async () => ({
+      type: 'image',
+      value: new Blob([], { type: 'image/png' }),
+    }),
+  };
+
+  expectTypeOf(tool.execute).returns.toEqualTypeOf<
+    MaybePromise<ToolExecuteResult<WebMCPImageValue>>
+  >();
 });
 
 test('ModelContext does not expose legacy unregisterTool on the strict core surface', () => {

--- a/packages/webmcp-types/src/index.ts
+++ b/packages/webmcp-types/src/index.ts
@@ -21,9 +21,12 @@ export type {
   RegistrationHandle,
   ResourceContents,
   ResourceLink,
+  SerializedImageValue,
+  SourceImageValue,
   TextContent,
   TextResourceContents,
   ToolResponse,
+  WebMCPImageValue,
 } from './common.js';
 export type {
   InferArgsFromInputSchema,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,6 +286,9 @@ importers:
       '@mcp-b/transports':
         specifier: workspace:*
         version: link:../../packages/transports
+      '@mcp-b/webmcp-polyfill':
+        specifier: workspace:*
+        version: link:../../packages/webmcp-polyfill
       '@mcp-b/webmcp-ts-sdk':
         specifier: workspace:*
         version: link:../../packages/webmcp-ts-sdk


### PR DESCRIPTION
## Summary

Splits the WebMCP image-value feature work out of local `main` onto its own branch. Tools registered on `document.modelContext` can return direct image values, either as serialized `{ type: "image", data, mimeType }` payloads or browser-source `{ type: "image", value, mimeType? }` payloads backed by `Blob`, `HTMLCanvasElement`, or `HTMLImageElement`.

This also adds the matching `@mcp-b/webmcp-types` image value types and a focused Playwright runtime contract for the polyfill/native image-value behavior.

## Why

This is unrelated feature work and should not be mixed into the release-prep commits currently sitting on local `main`. The implementation follows the image/tool-result direction discussed in WebMCP: [webmachinelearning/webmcp#41](https://github.com/webmachinelearning/webmcp/issues/41) and [webmachinelearning/webmcp#86](https://github.com/webmachinelearning/webmcp/issues/86).

## Validation

- `pnpm --filter @mcp-b/webmcp-types typecheck`
- `pnpm --filter @mcp-b/webmcp-polyfill typecheck`
- `pnpm --filter mcp-e2e-tests exec playwright test tests/runtime-contract-image-values.spec.ts`

Note: the focused e2e run requires local workspace package builds first in a fresh worktree because the test app imports built package entry points.
