### PR TITLE
fix(*): align declarative WebMCP with upstream WPT

### DIFF
--- a/.changeset/wise-forms-conform.md
+++ b/.changeset/wise-forms-conform.md
@@ -1,0 +1,9 @@
+---
+'@mcp-b/webmcp-polyfill': patch
+'@mcp-b/webmcp-ts-sdk': patch
+---
+
+Align declarative form execution with Chromium and the upstream Web Platform
+Tests. Autosubmit now preserves native event ordering, opaque documents report
+their effective origin, and the composed runtime forwards behavior-only form
+registration changes.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -176,19 +176,10 @@ jobs:
       - name: Print Chromium Snapshot version
         run: '"${{ steps.chromium_snapshot.outputs.chrome-path }}" --version'
 
-      - name: Run declarative WPT against the polyfill
-        working-directory: .reference/wpt
+      - name: Run WebMCP WPT against the polyfill
         env:
           CHROME_BIN: ${{ steps.chrome_canary.outputs.chrome-path }}
-          POLYFILL_SCRIPT: ${{ github.workspace }}/packages/webmcp-polyfill/dist/index.iife.js
-        run: >-
-          ./wpt run --channel canary --binary "$CHROME_BIN" --yes --install-webdriver
-          --headless --no-enable-experimental --test-types testharness
-          --binary-arg=--no-sandbox
-          --binary-arg=--disable-features=WebMCP,WebMCPTesting
-          --inject-script "$POLYFILL_SCRIPT"
-          --no-pause-after-test --processes 1 --no-manifest-download
-          --include /webmcp/declarative/ chrome
+        run: pnpm test:wpt
 
       - name: Run Native Runtime Contract (Chrome Canary)
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -127,6 +127,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Checkout Web Platform Tests
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: web-platform-tests/wpt
+          ref: c7fdee80f3f17b4e9813964916afdfd57ace863f
+          path: .reference/wpt
+          sparse-checkout: |
+            common
+            docs
+            resources
+            tools
+            webmcp
+
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
@@ -151,6 +164,19 @@ jobs:
 
       - name: Print Chrome Canary version
         run: '"${{ steps.chrome_canary.outputs.chrome-path }}" --version'
+
+      - name: Run declarative WPT against the polyfill
+        working-directory: .reference/wpt
+        env:
+          CHROME_BIN: ${{ steps.chrome_canary.outputs.chrome-path }}
+          POLYFILL_SCRIPT: ${{ github.workspace }}/packages/webmcp-polyfill/dist/index.iife.js
+        run: >-
+          ./wpt run --channel canary --binary "$CHROME_BIN" --yes --install-webdriver
+          --headless --no-enable-experimental
+          --binary-arg=--disable-features=WebMCP,WebMCPTesting
+          --inject-script "$POLYFILL_SCRIPT"
+          --no-pause-after-test --processes 1 --no-manifest-download
+          --include /webmcp/declarative/ chrome
 
       - name: Run Native Runtime Contract (Chrome Canary)
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -172,7 +172,7 @@ jobs:
           POLYFILL_SCRIPT: ${{ github.workspace }}/packages/webmcp-polyfill/dist/index.iife.js
         run: >-
           ./wpt run --channel canary --binary "$CHROME_BIN" --yes --install-webdriver
-          --headless --no-enable-experimental
+          --headless --no-enable-experimental --test-types testharness
           --binary-arg=--disable-features=WebMCP,WebMCPTesting
           --inject-script "$POLYFILL_SCRIPT"
           --no-pause-after-test --processes 1 --no-manifest-download

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -173,6 +173,7 @@ jobs:
         run: >-
           ./wpt run --channel canary --binary "$CHROME_BIN" --yes --install-webdriver
           --headless --no-enable-experimental --test-types testharness
+          --binary-arg=--no-sandbox
           --binary-arg=--disable-features=WebMCP,WebMCPTesting
           --inject-script "$POLYFILL_SCRIPT"
           --no-pause-after-test --processes 1 --no-manifest-download

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -162,8 +162,19 @@ jobs:
           chrome-version: canary
           install-dependencies: true
 
+      # Branded Chrome blocks --load-extension; native extension E2E needs unbranded Chromium.
+      - name: Setup Chromium Snapshot
+        id: chromium_snapshot
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd
+        with:
+          chrome-version: latest
+          install-dependencies: true
+
       - name: Print Chrome Canary version
         run: '"${{ steps.chrome_canary.outputs.chrome-path }}" --version'
+
+      - name: Print Chromium Snapshot version
+        run: '"${{ steps.chromium_snapshot.outputs.chrome-path }}" --version'
 
       - name: Run declarative WPT against the polyfill
         working-directory: .reference/wpt
@@ -191,6 +202,12 @@ jobs:
           CHROME_BIN: ${{ steps.chrome_canary.outputs.chrome-path }}
           PLAYWRIGHT_NATIVE_SHOWCASE_EXECUTABLE_PATH: ${{ steps.chrome_canary.outputs.chrome-path }}
         run: pnpm --filter mcp-e2e-tests run test:native-showcase
+
+      - name: Run Native Extension Frame Integration (Chromium Snapshot)
+        env:
+          PLAYWRIGHT_EXTENSION_CHROMIUM_EXECUTABLE_PATH: ${{ steps.chromium_snapshot.outputs.chrome-path }}
+          PLAYWRIGHT_EXTENSION_ENABLE_WEBMCP_FLAGS: '1'
+        run: pnpm --filter @mcp-b/webmcp-extension test:e2e
 
       - name: Upload Parity Playwright Report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ vp check              # Check without fixing (CI)
 pnpm check-all        # All checks (typecheck + lint)
 pnpm test:unit        # Unit tests only
 pnpm test:e2e         # E2E tests only
+pnpm test:wpt         # Pinned upstream WebMCP WPT (requires Chrome Canary)
 vp test run           # Run tests in current package
 vp pack               # Build current library package
 pnpm changeset        # Create a changeset for versioning
@@ -56,13 +57,14 @@ the Diataxis framework.
 
 ## Key Files
 
-| File                                                               | Purpose                                              |
-| ------------------------------------------------------------------ | ---------------------------------------------------- |
-| [CONTRIBUTING.md](./CONTRIBUTING.md)                               | Code quality requirements, commit format, PR process |
-| [.agents/skills/release/SKILL.md](.agents/skills/release/SKILL.md) | Publishing workflow and troubleshooting              |
-| [docs/TESTING.md](./docs/TESTING.md)                               | Testing documentation                                |
-| [pnpm-workspace.yaml](./pnpm-workspace.yaml)                       | Workspace packages and dependency catalog            |
-| [vite.config.ts](./vite.config.ts)                                 | Lint, format, staged, and task config (Vite+)        |
+| File                                                                                                   | Purpose                                              |
+| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| [CONTRIBUTING.md](./CONTRIBUTING.md)                                                                   | Code quality requirements, commit format, PR process |
+| [.agents/skills/release/SKILL.md](.agents/skills/release/SKILL.md)                                     | Publishing workflow and troubleshooting              |
+| [docs/TESTING.md](./docs/TESTING.md)                                                                   | Testing documentation                                |
+| [packages/global/WEBMCP-CONFORMANCE-REFERENCES.md](./packages/global/WEBMCP-CONFORMANCE-REFERENCES.md) | WebMCP spec, WPT, and Chromium source index          |
+| [pnpm-workspace.yaml](./pnpm-workspace.yaml)                                                           | Workspace packages and dependency catalog            |
+| [vite.config.ts](./vite.config.ts)                                                                     | Lint, format, staged, and task config (Vite+)        |
 
 ## Quick Reference
 
@@ -151,12 +153,39 @@ Repo scopes: `root`, `deps`, `release`, `ci`, `docs`, `*`
 
 ## Reference Repos (`.reference/`)
 
-The `.reference/` directory (gitignored) holds shallow clones of upstream repos we track for sync. These are NOT dependencies — they are for human/AI reference when syncing with upstream changes.
+The `.reference/` directory (gitignored) holds shallow clones of upstream repos
+we track for sync. They are not runtime dependencies. Most are human/AI
+references; `wpt/` is also the pinned upstream conformance suite used by CI.
 
-| Directory          | Upstream                                                                                      | Tracked By            |
-| ------------------ | --------------------------------------------------------------------------------------------- | --------------------- |
-| `standard-schema/` | [standard-schema/standard-schema](https://github.com/standard-schema/standard-schema)         | `@mcp-b/webmcp-types` |
-| `typescript-sdk/`  | [anthropics/anthropic-sdk-typescript](https://github.com/anthropics/anthropic-sdk-typescript) | General reference     |
+| Directory          | Upstream                                                                                      | Purpose                                     |
+| ------------------ | --------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `standard-schema/` | [standard-schema/standard-schema](https://github.com/standard-schema/standard-schema)         | `@mcp-b/webmcp-types` reference             |
+| `typescript-sdk/`  | [anthropics/anthropic-sdk-typescript](https://github.com/anthropics/anthropic-sdk-typescript) | General SDK reference                       |
+| `webmcp/`          | [webmachinelearning/webmcp](https://github.com/webmachinelearning/webmcp)                     | WebMCP draft and explainer source           |
+| `wpt/`             | [web-platform-tests/wpt](https://github.com/web-platform-tests/wpt)                           | Executable WebMCP conformance, pinned in CI |
+
+### WebMCP Standards and Conformance
+
+For changes to browser-facing WebMCP behavior:
+
+1. Read the relevant draft or explainer in `.reference/webmcp/`.
+2. Inspect `.reference/wpt/webmcp/` for executable upstream behavior. WPT is a
+   cross-browser standards suite, not a Chromium-only test repository.
+3. Consult Blink's `third_party/blink/renderer/core/script_tools/` only for
+   Chromium-specific implementation details or extensions.
+
+The pinned WPT revision and CI job live in
+[`.github/workflows/e2e.yml`](./.github/workflows/e2e.yml). Test selection and
+the shared local/CI runner live in
+[`scripts/run-webmcp-wpt.mjs`](./scripts/run-webmcp-wpt.mjs). The WPT lane builds
+the standalone polyfill, disables native WebMCP, injects the bundle, and runs
+the declarative suite plus an explicit page-local imperative allowlist.
+Frame-tree, origin-policy, and navigation WPT are excluded because they require
+native coverage. When changing covered behavior, run the shared conformance
+suite and replay the WPT lane with
+`CHROME_BIN=/path/to/chrome-canary pnpm test:wpt`. Update the WPT pin
+deliberately and review the upstream diff first. See
+[`docs/TESTING.md`](./docs/TESTING.md) for the test matrix.
 
 ## Before Committing
 

--- a/apps/documentation-website/docs.json
+++ b/apps/documentation-website/docs.json
@@ -65,7 +65,7 @@
           "href": "https://github.com/WebMCP-org/examples"
         },
         {
-          "anchor": "W3C Spec",
+          "anchor": "Community Group Draft",
           "icon": "book",
           "href": "https://webmachinelearning.github.io/webmcp/"
         }
@@ -139,6 +139,13 @@
           {
             "group": "Tooling",
             "pages": [
+              {
+                "group": "@mcp-b/webmcp-extension",
+                "pages": [
+                  "packages/webmcp-extension/overview",
+                  "packages/webmcp-extension/reference"
+                ]
+              },
               {
                 "group": "@mcp-b/webmcp-local-relay",
                 "pages": [

--- a/apps/documentation-website/how-to/test-native-and-polyfill.mdx
+++ b/apps/documentation-website/how-to/test-native-and-polyfill.mdx
@@ -23,12 +23,14 @@ The monorepo provides several testing lanes organized by runtime:
 
 | Runtime                | Canonical caller                                | Command                                                       |
 | ---------------------- | ----------------------------------------------- | ------------------------------------------------------------- |
+| Strict polyfill        | `document.modelContext`                         | `pnpm --filter @mcp-b/webmcp-polyfill test:conformance`       |
+| Composed global        | `document.modelContext`                         | `pnpm --filter @mcp-b/global test:conformance:global`         |
 | Tab and iframe         | SDK `Client` over MCP-B transports              | `pnpm --filter mcp-e2e-tests test:runtime-contract:transport` |
 | `<mcp-iframe>` element | SDK `Client` + `IframeParentTransport`          | `pnpm --filter mcp-e2e-tests test:mcp-iframe`                 |
 | Native Chrome          | `getTools()` + feature-detected `executeTool()` | `pnpm --filter mcp-e2e-tests test:native-contract:default`    |
 | Local relay            | SDK `Client` over stdio                         | `pnpm --filter @mcp-b/webmcp-local-relay test:e2e`            |
 
-Every canonical E2E suite proves the same six assertions against the real runtime:
+Each runtime-contract E2E suite proves the same six assertions against the real runtime:
 
 1. Initial discovery returns the expected tools
 2. A successful call returns the expected payload
@@ -37,9 +39,18 @@ Every canonical E2E suite proves the same six assertions against the real runtim
 5. Unregistration removes the tool and later calls fail
 6. Runtime-thrown tool errors propagate to the caller
 
-## Run the canonical polyfill tests
+## Run the polyfill tests
 
-The polyfill tests use Playwright with a real browser. They exercise `@mcp-b/global` running in a page, discovered and called through the SDK `Client` and `TabClientTransport`.
+Run the shared browser conformance suite against the strict polyfill and the
+composed global runtime:
+
+```bash title="Run browser conformance"
+pnpm --filter @mcp-b/webmcp-polyfill test:conformance
+pnpm --filter @mcp-b/global test:conformance:global
+```
+
+Then run the transport contract to exercise `@mcp-b/global` through an SDK
+`Client` and `TabClientTransport`:
 
 ```bash title="Run transport contracts"
 # Tab and iframe transport contracts only
@@ -50,6 +61,10 @@ pnpm test:e2e
 ```
 
 These tests use the shared fixture in `e2e/runtime-contract/` which registers a deterministic tool set: `echo`, `sum`, `dynamic_tool`, and `always_fail`.
+
+CI also injects the built standalone polyfill into the upstream
+[declarative Web Platform Tests](https://github.com/web-platform-tests/wpt/tree/master/webmcp/declarative).
+The workflow pins a WPT revision so upstream behavior changes require review.
 
 ## Run the native Chromium tests
 
@@ -143,6 +158,7 @@ cd e2e && pnpm test:chrome-beta:webmcp:headed
 | If you are...                             | Use this lane                                      |
 | ----------------------------------------- | -------------------------------------------------- |
 | Building tools with `@mcp-b/global`       | `test:runtime-contract:transport`                  |
+| Validating declarative polyfill behavior  | `@mcp-b/webmcp-polyfill test:conformance`          |
 | Validating against the native browser API | `test:native-contract:default`                     |
 | Testing the local relay end-to-end        | `pnpm --filter @mcp-b/webmcp-local-relay test:e2e` |
 | Running the full canonical gate           | `pnpm test:e2e`                                    |

--- a/apps/documentation-website/how-to/test-native-and-polyfill.mdx
+++ b/apps/documentation-website/how-to/test-native-and-polyfill.mdx
@@ -29,6 +29,7 @@ The monorepo provides several testing lanes organized by runtime:
 | `<mcp-iframe>` element | SDK `Client` + `IframeParentTransport`          | `pnpm --filter mcp-e2e-tests test:mcp-iframe`                 |
 | Native Chrome          | `getTools()` + feature-detected `executeTool()` | `pnpm --filter mcp-e2e-tests test:native-contract:default`    |
 | Local relay            | SDK `Client` over stdio                         | `pnpm --filter @mcp-b/webmcp-local-relay test:e2e`            |
+| Extension template     | SDK `Client` from an isolated content script    | `pnpm --filter @mcp-b/webmcp-extension test:e2e`              |
 
 Each runtime-contract E2E suite proves the same six assertions against the real runtime:
 
@@ -56,7 +57,7 @@ Then run the transport contract to exercise `@mcp-b/global` through an SDK
 # Tab and iframe transport contracts only
 pnpm --filter mcp-e2e-tests test:runtime-contract:transport
 
-# Full E2E gate, including native Chrome and the relay
+# Local E2E umbrella, including native Chrome, relay, and extension packages
 pnpm test:e2e
 ```
 
@@ -126,7 +127,8 @@ pnpm --filter mcp-e2e-tests test:integration:runtime-api
 pnpm --filter mcp-e2e-tests test:integration:frameworks
 ```
 
-These lanes are useful for broader compatibility checks but are not the canonical E2E gate.
+These lanes provide broader compatibility checks outside the local `pnpm test:e2e` umbrella. CI
+also runs the framework lane.
 
 ## Debug failing tests
 
@@ -161,7 +163,7 @@ cd e2e && pnpm test:chrome-beta:webmcp:headed
 | Validating declarative polyfill behavior  | `@mcp-b/webmcp-polyfill test:conformance`          |
 | Validating against the native browser API | `test:native-contract:default`                     |
 | Testing the local relay end-to-end        | `pnpm --filter @mcp-b/webmcp-local-relay test:e2e` |
-| Running the full canonical gate           | `pnpm test:e2e`                                    |
+| Running the local zero-mock E2E umbrella  | `pnpm test:e2e`                                    |
 
 ## Related pages
 

--- a/apps/documentation-website/packages/index.mdx
+++ b/apps/documentation-website/packages/index.mdx
@@ -62,7 +62,7 @@ Cross-package concepts stay in [Explanation](/explanation/index). Task-oriented 
     href="/packages/webmcp-extension/overview"
   >
     Chromium MV3 template and isolated-world client helper for installing WebMCP and calling page
-    tools from an extension.
+    tools, including declarative forms, from an extension.
   </Card>
   <Card
     title="@mcp-b/webmcp-local-relay"

--- a/apps/documentation-website/packages/index.mdx
+++ b/apps/documentation-website/packages/index.mdx
@@ -57,6 +57,14 @@ Cross-package concepts stay in [Explanation](/explanation/index). Task-oriented 
 
 <CardGroup cols={2}>
   <Card
+    title="@mcp-b/webmcp-extension"
+    icon="boxes-stacked"
+    href="/packages/webmcp-extension/overview"
+  >
+    Chromium MV3 template and isolated-world client helper for installing WebMCP and calling page
+    tools from an extension.
+  </Card>
+  <Card
     title="@mcp-b/webmcp-local-relay"
     icon="boxes-stacked"
     href="/packages/webmcp-local-relay/overview"

--- a/apps/documentation-website/packages/webmcp-extension/overview.mdx
+++ b/apps/documentation-website/packages/webmcp-extension/overview.mdx
@@ -36,8 +36,11 @@ polyfilled declarative runtime. Both tool types use the same `listTools()` and
 The extension does not scan forms itself. `@mcp-b/global` owns the page runtime,
 including its [declarative support and compatibility boundary](/reference/webmcp/declarative-api).
 
-The shipped template targets top-level pages only. It does not inject into
-child frames.
+The shipped content scripts target top-level pages only. Native Chrome still
+exposes imperative and declarative tools from same-origin child documents
+through frame-tree discovery. The polyfilled path remains scoped to the top
+document. The [reference page](/packages/webmcp-extension/reference#document-tree-scope)
+lists the cross-origin and navigation boundaries.
 
 ## Security boundary
 

--- a/apps/documentation-website/packages/webmcp-extension/overview.mdx
+++ b/apps/documentation-website/packages/webmcp-extension/overview.mdx
@@ -1,0 +1,67 @@
+---
+title: '@mcp-b/webmcp-extension overview'
+description: 'When to use the Chromium extension template and how it separates page runtime installation from isolated client code.'
+keywords:
+  ['@mcp-b/webmcp-extension', 'overview', 'chrome extension', 'manifest v3', 'content script']
+icon: 'chrome'
+---
+
+`@mcp-b/webmcp-extension` provides a Chromium MV3 template and a client helper
+for extension-owned WebMCP integration. A MAIN-world content script installs
+the runtime, page code uses `document.modelContext` normally, and an isolated
+content script receives the official MCP `Client`.
+
+## When to use this package
+
+- You want an extension to install WebMCP on matching pages.
+- You want page runtime installation separated from isolated client code.
+- You want to discover and call page tools through the official MCP client API.
+
+## When not to use this package
+
+- Your page can install its own runtime. Use [`@mcp-b/global`](/packages/global/overview).
+- You need a background worker or Chrome runtime-port server. This package's
+  template connects an isolated content script to the current page.
+
+## Where it sits in the package graph
+
+The MAIN-world entry imports `@mcp-b/global`. The isolated entry calls
+`connectWebMCPClient()`, which connects an MCP client to that page. The package
+does not replace or wrap the website API: site code still registers tools with
+`document.modelContext`.
+
+The shipped template targets top-level pages only. It does not inject into
+child frames.
+
+## Security boundary
+
+MAIN-world code shares the website's JavaScript environment. Keep extension
+secrets, credentials, and privileged Chrome APIs out of that bundle. Treat page
+tool metadata, arguments, and results as untrusted. Authorize privileged
+actions from trusted extension state, never from page-provided values alone.
+
+For the broader threat model, see [Security and human control](/explanation/design/security-and-human-in-the-loop).
+
+## First step
+
+Start with the included template, then narrow its manifest match patterns to
+the sites your extension supports. The [reference page](/packages/webmcp-extension/reference)
+documents the manifest, build shape, exported helper, and security constraints.
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Reference" icon="book-open" href="/packages/webmcp-extension/reference">
+    Manifest structure, world boundaries, client helper, and template build.
+  </Card>
+  <Card title="@mcp-b/global overview" icon="globe" href="/packages/global/overview">
+    Runtime installed by the MAIN-world entry.
+  </Card>
+  <Card
+    title="Security and human control"
+    icon="shield-halved"
+    href="/explanation/design/security-and-human-in-the-loop"
+  >
+    Security principles for page tools and agent access.
+  </Card>
+</CardGroup>

--- a/apps/documentation-website/packages/webmcp-extension/overview.mdx
+++ b/apps/documentation-website/packages/webmcp-extension/overview.mdx
@@ -8,14 +8,15 @@ icon: 'chrome'
 
 `@mcp-b/webmcp-extension` provides a Chromium MV3 template and a client helper
 for extension-owned WebMCP integration. A MAIN-world content script installs
-the runtime, page code uses `document.modelContext` normally, and an isolated
-content script receives the official MCP `Client`.
+the runtime, page code uses `document.modelContext` or declarative HTML forms,
+and an isolated content script receives the official MCP `Client`.
 
 ## When to use this package
 
 - You want an extension to install WebMCP on matching pages.
 - You want page runtime installation separated from isolated client code.
-- You want to discover and call page tools through the official MCP client API.
+- You want to discover and call imperative and declarative page tools through
+  the official MCP client API.
 
 ## When not to use this package
 
@@ -28,7 +29,12 @@ content script receives the official MCP `Client`.
 The MAIN-world entry imports `@mcp-b/global`. The isolated entry calls
 `connectWebMCPClient()`, which connects an MCP client to that page. The package
 does not replace or wrap the website API: site code still registers tools with
-`document.modelContext`.
+`document.modelContext`, and annotated forms become tools through the native or
+polyfilled declarative runtime. Both tool types use the same `listTools()` and
+`callTool()` methods from the isolated content script.
+
+The extension does not scan forms itself. `@mcp-b/global` owns the page runtime,
+including its [declarative support and compatibility boundary](/reference/webmcp/declarative-api).
 
 The shipped template targets top-level pages only. It does not inject into
 child frames.
@@ -56,6 +62,9 @@ documents the manifest, build shape, exported helper, and security constraints.
   </Card>
   <Card title="@mcp-b/global overview" icon="globe" href="/packages/global/overview">
     Runtime installed by the MAIN-world entry.
+  </Card>
+  <Card title="Declarative API" icon="file-code" href="/reference/webmcp/declarative-api">
+    Annotated forms, browser behavior, and polyfill compatibility.
   </Card>
   <Card
     title="Security and human control"

--- a/apps/documentation-website/packages/webmcp-extension/reference.mdx
+++ b/apps/documentation-website/packages/webmcp-extension/reference.mdx
@@ -116,6 +116,34 @@ The extension package adds no separate DOM scanner or declarative client API.
 See the [declarative API reference](/reference/webmcp/declarative-api) for the
 upstream behavior and the polyfill's documented compatibility boundary.
 
+## Document-tree scope
+
+The template injects its MAIN-world runtime and isolated client into top-level
+pages only. Native Chrome's `getTools()` still includes tools owned by
+same-origin active documents in the same frame tree. The extension client can
+therefore list and call both JavaScript and declarative form tools from
+same-origin child documents without child-frame injection.
+
+The polyfilled path discovers only the top document. Cross-origin imperative
+tools require `allow="tools"`, child registration with `exposedTo`, and a
+caller-supplied `fromOrigins` list. The extension client does not supply that
+list. Declarative forms currently have no equivalent cross-origin exposure
+attribute. See the [WebMCP standard API](/reference/webmcp/standard-api) and
+Chrome's [cross-origin iframe guidance](https://developer.chrome.com/docs/ai/webmcp/imperative-api#cross-origin-iframes).
+
+MCP tool names are global within one client connection. Use unique names across
+the frame tree.
+
+## Navigation results
+
+Chrome resolves `executeTool()` with `null` when a tool triggers navigation.
+The extension client reports that call as interrupted. It does not preserve the
+call across document navigation or read JSON-LD from the destination document.
+For a declarative tool that must return a result without navigation, cancel the
+submission and use `SubmitEvent.respondWith()`. The upstream
+[declarative explainer](https://github.com/webmachinelearning/webmcp/blob/main/declarative-api-explainer.md#getting-the-form-response-to-the-agent)
+tracks the unresolved cross-document response design.
+
 ## Isolated content-script entry
 
 ```typescript title="src/content-script.ts"
@@ -192,7 +220,8 @@ imports at runtime.
 </Warning>
 
 - Narrow the manifest match patterns before publishing.
-- The template targets top-level pages and does not inject into child frames.
+- The template injects into top-level pages only. Native Chrome can still
+  discover same-origin child-document tools.
 - Add icons and Chrome Web Store listing metadata before publishing.
 
 For the broader threat model, see [Security and human control](/explanation/design/security-and-human-in-the-loop).

--- a/apps/documentation-website/packages/webmcp-extension/reference.mdx
+++ b/apps/documentation-website/packages/webmcp-extension/reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: '@mcp-b/webmcp-extension'
-description: 'Reference for the Chromium MV3 extension template, isolated-world client helper, build entries, and security boundary.'
+description: 'Reference for the Chromium MV3 extension template, imperative and declarative page tools, isolated client helper, and security boundary.'
 keywords:
   [
     '@mcp-b/webmcp-extension',
@@ -9,13 +9,16 @@ keywords:
     'manifest v3',
     'content script',
     'MAIN world',
+    'declarative WebMCP',
+    'toolname',
   ]
 icon: 'chrome'
 ---
 
 `@mcp-b/webmcp-extension` installs WebMCP from a Chromium extension and
-connects an isolated content script to the page's tools. It returns the
-official MCP `Client`; websites continue to use `document.modelContext`.
+connects an isolated content script to the page's imperative and declarative
+tools. It returns the official MCP `Client`; websites continue to use
+`document.modelContext` and annotated HTML forms.
 
 ```text title="Package metadata"
 npm: @mcp-b/webmcp-extension
@@ -87,6 +90,31 @@ await document.modelContext.registerTool({
 
 See the [WebMCP standard API](/reference/webmcp/standard-api) for a page-facing
 quick reference and a link to the authoritative Community Group draft.
+
+## Declarative form tools
+
+The MAIN-world runtime also discovers annotated forms:
+
+```html title="Page form"
+<form
+  toolname="extension_declarative"
+  tooldescription="Submit a value through an annotated form."
+  toolautosubmit
+>
+  <input name="value" toolparamdescription="Value to submit" required />
+  <button type="submit">Submit</button>
+</form>
+```
+
+`@mcp-b/global` adopts native declarative behavior when available and installs
+the polyfilled form runtime otherwise. Form tools and JavaScript registrations
+both appear in the isolated client's `listTools()` result and run through
+`callTool()`. `listChanged.tools` reports form additions, definition changes,
+and removals.
+
+The extension package adds no separate DOM scanner or declarative client API.
+See the [declarative API reference](/reference/webmcp/declarative-api) for the
+upstream behavior and the polyfill's documented compatibility boundary.
 
 ## Isolated content-script entry
 
@@ -175,3 +203,4 @@ For the broader threat model, see [Security and human control](/explanation/desi
 - [@mcp-b/global reference](/packages/global/reference)
 - [@mcp-b/transports reference](/packages/transports/reference)
 - [WebMCP standard API](/reference/webmcp/standard-api)
+- [WebMCP declarative API](/reference/webmcp/declarative-api)

--- a/apps/documentation-website/packages/webmcp-extension/reference.mdx
+++ b/apps/documentation-website/packages/webmcp-extension/reference.mdx
@@ -1,0 +1,177 @@
+---
+title: '@mcp-b/webmcp-extension'
+description: 'Reference for the Chromium MV3 extension template, isolated-world client helper, build entries, and security boundary.'
+keywords:
+  [
+    '@mcp-b/webmcp-extension',
+    'connectWebMCPClient',
+    'chrome extension',
+    'manifest v3',
+    'content script',
+    'MAIN world',
+  ]
+icon: 'chrome'
+---
+
+`@mcp-b/webmcp-extension` installs WebMCP from a Chromium extension and
+connects an isolated content script to the page's tools. It returns the
+official MCP `Client`; websites continue to use `document.modelContext`.
+
+```text title="Package metadata"
+npm: @mcp-b/webmcp-extension
+export: @mcp-b/webmcp-extension/content-script
+license: MIT
+node: >= 20
+```
+
+## Installation
+
+```bash title="Install packages"
+pnpm add @mcp-b/global @mcp-b/webmcp-extension
+```
+
+## Extension layout
+
+The template declares two static `document_start` content scripts. Chrome 111
+or newer is required for `world: "MAIN"`.
+
+| Entry                    | World    | Responsibility                                  |
+| ------------------------ | -------- | ----------------------------------------------- |
+| `main-world.iife.js`     | `MAIN`   | Install `@mcp-b/global` in the page environment |
+| `content-script.iife.js` | Isolated | Connect the MCP client and consume page tools   |
+
+```json title="manifest.json"
+{
+  "manifest_version": 3,
+  "name": "My WebMCP Extension",
+  "version": "1.0.0",
+  "minimum_chrome_version": "111",
+  "content_scripts": [
+    {
+      "matches": ["https://*/*", "http://localhost/*", "http://127.0.0.1/*"],
+      "js": ["main-world.iife.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
+      "matches": ["https://*/*", "http://localhost/*", "http://127.0.0.1/*"],
+      "js": ["content-script.iife.js"],
+      "run_at": "document_start"
+    }
+  ]
+}
+```
+
+The template omits `all_frames`, extension API permissions, a background
+worker, and `web_accessible_resources`. It targets matching top-level pages.
+
+## MAIN-world entry
+
+The MAIN-world bundle only installs the runtime:
+
+```typescript title="src/main-world.ts"
+import '@mcp-b/global';
+```
+
+Website code uses the native-shaped page API directly:
+
+```typescript title="Page code"
+await document.modelContext.registerTool({
+  name: 'get_cart',
+  description: 'Read the current shopping cart.',
+  execute: () => ({
+    content: [{ type: 'text', text: JSON.stringify(readCart()) }],
+  }),
+});
+```
+
+See the [WebMCP standard API](/reference/webmcp/standard-api) for a page-facing
+quick reference and a link to the authoritative Community Group draft.
+
+## Isolated content-script entry
+
+```typescript title="src/content-script.ts"
+import { connectWebMCPClient } from '@mcp-b/webmcp-extension/content-script';
+
+const client = await connectWebMCPClient({
+  name: 'my-extension',
+  version: '1.0.0',
+});
+
+const { tools } = await client.listTools();
+const result = await client.callTool({
+  name: 'get_cart',
+  arguments: {},
+});
+
+await client.close();
+```
+
+`client` is the official `Client` from `@modelcontextprotocol/client`, not a
+package-specific wrapper.
+
+## `connectWebMCPClient()`
+
+```typescript title="Signature"
+connectWebMCPClient(
+  clientInfo?: Implementation,
+  clientOptions?: ClientOptions
+): Promise<Client>
+```
+
+| Parameter       | Default                                                 | Description                                       |
+| --------------- | ------------------------------------------------------- | ------------------------------------------------- |
+| `clientInfo`    | `{ name: '@mcp-b/webmcp-extension', version: '1.0.0' }` | MCP client identity                               |
+| `clientOptions` | `{}`                                                    | Official MCP `ClientOptions` passed to the client |
+
+The helper:
+
+1. Creates the official MCP `Client` with automatic protocol version negotiation.
+2. Applies the supplied `ClientOptions`.
+3. Connects a `TabClientTransport` with `targetOrigin` set to `window.location.origin`.
+4. Resolves with the connected client.
+
+Use the returned client's `listTools()`, `callTool()`, and `close()` methods.
+The second argument also accepts official client features such as
+`listChanged.tools`; the template uses it to follow tools registered after page
+hydration.
+
+## Template build
+
+The published package includes a copyable `template` directory. Its build
+requires Node 22.12 or newer.
+
+```bash title="Build the template"
+cp -R node_modules/@mcp-b/webmcp-extension/template my-webmcp-extension
+cd my-webmcp-extension
+pnpm install
+pnpm build
+```
+
+Load the generated `dist/` directory as an unpacked extension. The Vite+ config
+bundles both entries as self-contained, minified IIFEs targeting Chrome 111 and
+copies `manifest.json` into `dist/`. Content scripts cannot load bare npm
+imports at runtime.
+
+## Security and scope
+
+<Warning>
+  MAIN-world code shares the website's JavaScript environment. Keep secrets, credentials, and
+  privileged Chrome API calls out of the MAIN-world bundle. The client pins messages to
+  `window.location.origin`, but this routing check is not authentication. Same-page code can observe
+  or forge the channel. Treat page tool metadata, arguments, and results as untrusted. Authorize
+  privileged actions from trusted extension state, never from page-provided values alone.
+</Warning>
+
+- Narrow the manifest match patterns before publishing.
+- The template targets top-level pages and does not inject into child frames.
+- Add icons and Chrome Web Store listing metadata before publishing.
+
+For the broader threat model, see [Security and human control](/explanation/design/security-and-human-in-the-loop).
+
+## Related pages
+
+- [@mcp-b/webmcp-extension overview](/packages/webmcp-extension/overview)
+- [@mcp-b/global reference](/packages/global/reference)
+- [@mcp-b/transports reference](/packages/transports/reference)
+- [WebMCP standard API](/reference/webmcp/standard-api)

--- a/apps/documentation-website/packages/webmcp-polyfill/overview.mdx
+++ b/apps/documentation-website/packages/webmcp-polyfill/overview.mdx
@@ -10,7 +10,7 @@ icon: 'puzzle-piece'
 ## When to use this package
 
 - You want the standard `registerTool` and `getTools` APIs, plus a feature-detectable Chrome-compatible `executeTool` extension, in browsers today.
-- You are building a site or reusable library that wants to stay close to the W3C surface.
+- You are building a site or reusable library that wants to stay close to the Community Group draft surface.
 - You want to pair runtime behavior with [`@mcp-b/webmcp-types`](/packages/webmcp-types/overview) for type inference.
 
 ## When not to use this package

--- a/apps/documentation-website/packages/webmcp-polyfill/reference.mdx
+++ b/apps/documentation-website/packages/webmcp-polyfill/reference.mdx
@@ -172,14 +172,16 @@ validation and calls `requestSubmit()`. Agent-triggered submit events expose
 `SubmitEvent.agentInvoked` and `SubmitEvent.respondWith()`; `toolactivated`
 fires on `window` after the controls are filled.
 
-Removing a declarative form unregisters its tool. Changes that alter its
-generated tool replace the registration. Resetting, removing, or replacing a
-registration cancels a pending invocation. Tool names must be unique; duplicate
-names expose one form.
+Removing a declarative form unregisters its tool. Changes to its registration
+attributes or generated schema replace the registration. Resetting, removing,
+or replacing a registration cancels a pending invocation. Tool names must be
+unique; duplicate names expose one form.
 
 Chrome's [declarative API documentation](https://developer.chrome.com/docs/ai/webmcp/declarative-api)
 defines the current compatibility target. This package covers the tested subset
-described above. The Community Group draft's
+described above. CI runs the upstream
+[declarative Web Platform Tests](https://github.com/web-platform-tests/wpt/tree/master/webmcp/declarative)
+against the standalone polyfill. The Community Group draft's
 [declarative section](https://webmachinelearning.github.io/webmcp/#declarative-webmcp)
 is still incomplete.
 

--- a/apps/documentation-website/reference/webmcp/declarative-api.mdx
+++ b/apps/documentation-website/reference/webmcp/declarative-api.mdx
@@ -43,6 +43,9 @@ a stable compatibility contract.
 implements the tested local-document subset and documents its native-only gaps.
 React users can write these attributes directly after importing
 [`@mcp-b/react-webmcp`](/packages/react-webmcp/reference#declarative-form-attributes).
+Extensions can install the same runtime in the MAIN world with
+[`@mcp-b/webmcp-extension`](/packages/webmcp-extension/overview), then discover
+and call form tools from an isolated MCP client.
 
 For imperative JavaScript registration, use
 [`document.modelContext.registerTool()`](/reference/webmcp/standard-api).

--- a/apps/documentation-website/reference/webmcp/declarative-api.mdx
+++ b/apps/documentation-website/reference/webmcp/declarative-api.mdx
@@ -39,6 +39,11 @@ for proposal status. The upstream
 record the current executable compatibility cases. Do not treat this example as
 a stable compatibility contract.
 
+Native `getTools()` includes declarative forms from same-origin active documents
+in the current frame tree. Declarative HTML currently has no equivalent to the
+imperative API's `exposedTo` option, so a form cannot opt into cross-origin
+discovery. The MCP-B polyfill observes only its owning document.
+
 [`@mcp-b/webmcp-polyfill`](/packages/webmcp-polyfill/reference#declarative-forms)
 implements the tested local-document subset and documents its native-only gaps.
 React users can write these attributes directly after importing

--- a/apps/documentation-website/reference/webmcp/declarative-api.mdx
+++ b/apps/documentation-website/reference/webmcp/declarative-api.mdx
@@ -34,8 +34,10 @@ behavior, and iframe model are still evolving. Use Chrome's
 for current browser behavior. Track the Community Group
 [declarative draft section](https://webmachinelearning.github.io/webmcp/#declarative-webmcp)
 and [declarative explainer](https://github.com/webmachinelearning/webmcp/blob/main/declarative-api-explainer.md)
-for proposal status. Do not treat this example as a stable compatibility
-contract.
+for proposal status. The upstream
+[declarative Web Platform Tests](https://github.com/web-platform-tests/wpt/tree/master/webmcp/declarative)
+record the current executable compatibility cases. Do not treat this example as
+a stable compatibility contract.
 
 [`@mcp-b/webmcp-polyfill`](/packages/webmcp-polyfill/reference#declarative-forms)
 implements the tested local-document subset and documents its native-only gaps.

--- a/apps/documentation-website/reference/webmcp/standard-api.mdx
+++ b/apps/documentation-website/reference/webmcp/standard-api.mdx
@@ -49,15 +49,17 @@ its rejection.
 Registration options are `signal`, which unregisters the tool when aborted,
 and `exposedTo`, an array of origins in the current document tree to which the
 tool may be exposed. `getTools()` accepts `fromOrigins` to include tools from
-specified origins; without it, discovery is same-origin.
+specified origins. Without it, discovery includes same-origin active documents
+throughout the current top-level frame tree.
 
 `getTools()` returns `RegisteredTool` values. They contain `name`, optional
 `title`, `description`, serialized `inputSchema`, `window`, `origin`, and
 optional annotations. They do not expose the original `execute` callback.
 
 The API is available only in secure contexts. The `tools` Permissions Policy
-defaults to `self`; cross-origin discovery still requires explicit exposure and
-policy delegation.
+defaults to `self`. Cross-origin discovery requires policy delegation with
+`allow="tools"`, owner exposure through `exposedTo`, and caller opt-in through
+`fromOrigins`.
 
 ## Chrome execution extension
 

--- a/conformance/declarative-forms-conformance.shared.ts
+++ b/conformance/declarative-forms-conformance.shared.ts
@@ -308,6 +308,36 @@ export function runDeclarativeFormConformanceSuite(
       );
     });
 
+    it('dispatches autosubmit before announcing tool activation', async () => {
+      const name = `declarative_autosubmit_order_${String(Date.now())}`;
+      toolNames.add(name);
+      document.body.insertAdjacentHTML(
+        'beforeend',
+        `<form ${FIXTURE_ATTRIBUTE} toolname="${name}" tooldescription="Autosubmit order" toolautosubmit></form>`
+      );
+      const form = document.querySelector<HTMLFormElement>(
+        `form[${FIXTURE_ATTRIBUTE}][toolname="${name}"]`
+      );
+      if (!form) throw new Error('Expected autosubmit-order declarative form fixture');
+      const events: string[] = [];
+      form.addEventListener('submit', (event) => {
+        events.push('submit');
+        event.preventDefault();
+        event.respondWith(Promise.resolve());
+      });
+      window.addEventListener(
+        'toolactivated',
+        (event) => {
+          if (Reflect.get(event, 'toolName') === name) events.push('activated');
+        },
+        { once: true }
+      );
+
+      await executeTool(await waitForTool(name), {});
+
+      expect(events).toEqual(['submit', 'activated']);
+    });
+
     it('honors native validation, novalidate, and formnovalidate during autosubmit', async () => {
       for (const validationBypass of ['novalidate', 'formnovalidate'] as const) {
         const name = `declarative_${validationBypass}_${String(Date.now())}`;
@@ -649,6 +679,27 @@ export function runDeclarativeFormConformanceSuite(
       await waitForToolRemoval(name);
       second.setAttribute('tooldescription', 'Restored form');
       expect(await waitForTool(name)).toMatchObject({ description: 'Restored form' });
+    });
+
+    it('emits a tool change when toolautosubmit is added', async () => {
+      const name = `declarative_autosubmit_change_${String(Date.now())}`;
+      toolNames.add(name);
+      document.body.insertAdjacentHTML(
+        'beforeend',
+        `<form ${FIXTURE_ATTRIBUTE} toolname="${name}" tooldescription="Autosubmit change"></form>`
+      );
+      const form = document.querySelector<HTMLFormElement>(
+        `form[${FIXTURE_ATTRIBUTE}][toolname="${name}"]`
+      );
+      if (!form) throw new Error('Expected autosubmit-change declarative form fixture');
+      await waitForTool(name);
+      const changed = new Promise((resolve) => {
+        document.modelContext.addEventListener('toolchange', resolve, { once: true });
+      });
+
+      form.setAttribute('toolautosubmit', '');
+
+      await changed;
     });
 
     it('rejects invalid input transactionally before changing any control', async () => {

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -43,6 +43,7 @@ pnpm --filter @mcp-b/global test:conformance:global
 # Runtime-specific canonical E2E packages
 pnpm --filter @mcp-b/webmcp-local-relay test:e2e
 pnpm --filter @mcp-b/transports test:e2e
+pnpm --filter @mcp-b/webmcp-extension test:e2e
 
 # Tarball validation
 pnpm test:e2e:tarball:global
@@ -55,13 +56,14 @@ Notes:
 
 ## Runtime Coverage Matrix
 
-| Runtime             | Canonical caller                          | Real runtime boundary under test                    | Command                                                    |
-| ------------------- | ----------------------------------------- | --------------------------------------------------- | ---------------------------------------------------------- |
-| Tab / global        | SDK `Client` + `TabClientTransport`       | Browser page running `@mcp-b/global`                | `pnpm --filter mcp-e2e-tests test:runtime-contract`        |
-| Iframe              | SDK `Client` + `IframeParentTransport`    | Parent/iframe runtime boundary                      | `pnpm --filter mcp-e2e-tests test:runtime-contract`        |
-| Native Chromium     | `document.modelContext`                   | Chrome 152+ with WebMCP flags in CI                 | `pnpm --filter mcp-e2e-tests test:native-contract:default` |
-| Local relay         | SDK `Client` over stdio                   | Real relay server + real browser runtime            | `pnpm --filter @mcp-b/webmcp-local-relay test:e2e`         |
-| Extension transport | SDK `Client` + `ExtensionClientTransport` | Real MV3 extension using `ExtensionServerTransport` | `pnpm --filter @mcp-b/transports test:e2e`                 |
+| Runtime             | Canonical caller                           | Real runtime boundary under test                    | Command                                                    |
+| ------------------- | ------------------------------------------ | --------------------------------------------------- | ---------------------------------------------------------- |
+| Tab / global        | SDK `Client` + `TabClientTransport`        | Browser page running `@mcp-b/global`                | `pnpm --filter mcp-e2e-tests test:runtime-contract`        |
+| Iframe              | SDK `Client` + `IframeParentTransport`     | Parent/iframe runtime boundary                      | `pnpm --filter mcp-e2e-tests test:runtime-contract`        |
+| Native Chromium     | `document.modelContext`                    | Chrome 152+ with WebMCP flags in CI                 | `pnpm --filter mcp-e2e-tests test:native-contract:default` |
+| Local relay         | SDK `Client` over stdio                    | Real relay server + real browser runtime            | `pnpm --filter @mcp-b/webmcp-local-relay test:e2e`         |
+| Extension transport | SDK `Client` + `ExtensionClientTransport`  | Real MV3 extension using `ExtensionServerTransport` | `pnpm --filter @mcp-b/transports test:e2e`                 |
+| Extension template  | SDK `Client` in an isolated content script | MAIN-world runtime injected by a real MV3 extension | `pnpm --filter @mcp-b/webmcp-extension test:e2e`           |
 
 ## Canonical E2E Assertions
 
@@ -120,13 +122,13 @@ The canonical runtime gate lives in `.github/workflows/e2e.yml`.
 
 The workflow runs:
 
-1. `pnpm test:e2e`
-2. The pinned upstream declarative Web Platform Tests against the standalone polyfill
-3. Native contract on Chrome Canary with WebMCP flags
-4. Native showcase integration coverage on Chrome Canary
-5. Tarball validation for `@mcp-b/global`
+1. Tab, iframe, local-relay, framework, and `@mcp-b/global` tarball E2E coverage
+2. Extension transport and extension-template E2E coverage
+3. The pinned upstream declarative Web Platform Tests against the standalone polyfill
+4. Native contract and showcase integration coverage on Chrome Canary
 
-`pnpm test` at the repo root includes this gate by default.
+`pnpm test` runs unit tests plus the local zero-mock `pnpm test:e2e` umbrella. CI adds the
+framework, tarball, upstream WPT, and Chrome Canary lanes listed above.
 
 The upstream declarative suite lives in
 [`webmcp/declarative`](https://github.com/web-platform-tests/wpt/tree/master/webmcp/declarative).

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -40,6 +40,9 @@ pnpm --filter mcp-e2e-tests test:native-showcase
 pnpm --filter @mcp-b/webmcp-polyfill test:conformance
 pnpm --filter @mcp-b/global test:conformance:global
 
+# Pinned upstream WebMCP WPT (requires .reference/wpt and Chrome Canary)
+CHROME_BIN=/path/to/chrome-canary pnpm test:wpt
+
 # Runtime-specific canonical E2E packages
 pnpm --filter @mcp-b/webmcp-local-relay test:e2e
 pnpm --filter @mcp-b/transports test:e2e
@@ -124,18 +127,20 @@ The workflow runs:
 
 1. Tab, iframe, local-relay, framework, and `@mcp-b/global` tarball E2E coverage
 2. Extension transport and extension-template E2E coverage
-3. The pinned upstream declarative Web Platform Tests against the standalone polyfill
+3. The pinned upstream WebMCP Web Platform Tests against the standalone polyfill
 4. Native contract and showcase integration coverage on Chrome Canary
 
 `pnpm test` runs unit tests plus the local zero-mock `pnpm test:e2e` umbrella. CI adds the
 framework, tarball, upstream WPT, and Chrome Canary lanes listed above.
 
-The upstream declarative suite lives in
-[`webmcp/declarative`](https://github.com/web-platform-tests/wpt/tree/master/webmcp/declarative).
-The workflow pins its WPT revision and injects
-`packages/webmcp-polyfill/dist/index.iife.js` with native WebMCP disabled. The
-shared repository suite adds MCP-B-specific polyfill, global, and native
-integration coverage.
+The upstream suite lives in
+[`webmcp`](https://github.com/web-platform-tests/wpt/tree/master/webmcp). The
+workflow pins its WPT revision and injects
+`packages/webmcp-polyfill/dist/index.iife.js` with native WebMCP disabled. It
+runs every declarative test plus an explicit allowlist of imperative tests for
+the page-local surface. Frame-tree, origin-policy, and navigation WPT are
+excluded because they require native browser behavior. The shared repository
+suite adds MCP-B-specific polyfill, global, and native integration coverage.
 
 ## Extension Transport Testing
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -36,6 +36,10 @@ pnpm --filter mcp-e2e-tests test:integration:frameworks
 pnpm --filter mcp-e2e-tests test:native-contract:default
 pnpm --filter mcp-e2e-tests test:native-showcase
 
+# Shared WebMCP conformance lanes
+pnpm --filter @mcp-b/webmcp-polyfill test:conformance
+pnpm --filter @mcp-b/global test:conformance:global
+
 # Runtime-specific canonical E2E packages
 pnpm --filter @mcp-b/webmcp-local-relay test:e2e
 pnpm --filter @mcp-b/transports test:e2e
@@ -117,11 +121,19 @@ The canonical runtime gate lives in `.github/workflows/e2e.yml`.
 The workflow runs:
 
 1. `pnpm test:e2e`
-2. Native contract on Chrome Canary with WebMCP flags
-3. Native showcase integration coverage on Chrome Canary
-4. Tarball validation for `@mcp-b/global`
+2. The pinned upstream declarative Web Platform Tests against the standalone polyfill
+3. Native contract on Chrome Canary with WebMCP flags
+4. Native showcase integration coverage on Chrome Canary
+5. Tarball validation for `@mcp-b/global`
 
 `pnpm test` at the repo root includes this gate by default.
+
+The upstream declarative suite lives in
+[`webmcp/declarative`](https://github.com/web-platform-tests/wpt/tree/master/webmcp/declarative).
+The workflow pins its WPT revision and injects
+`packages/webmcp-polyfill/dist/index.iife.js` with native WebMCP disabled. The
+shared repository suite adds MCP-B-specific polyfill, global, and native
+integration coverage.
 
 ## Extension Transport Testing
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -56,14 +56,14 @@ Notes:
 
 ## Runtime Coverage Matrix
 
-| Runtime             | Canonical caller                           | Real runtime boundary under test                    | Command                                                    |
-| ------------------- | ------------------------------------------ | --------------------------------------------------- | ---------------------------------------------------------- |
-| Tab / global        | SDK `Client` + `TabClientTransport`        | Browser page running `@mcp-b/global`                | `pnpm --filter mcp-e2e-tests test:runtime-contract`        |
-| Iframe              | SDK `Client` + `IframeParentTransport`     | Parent/iframe runtime boundary                      | `pnpm --filter mcp-e2e-tests test:runtime-contract`        |
-| Native Chromium     | `document.modelContext`                    | Chrome 152+ with WebMCP flags in CI                 | `pnpm --filter mcp-e2e-tests test:native-contract:default` |
-| Local relay         | SDK `Client` over stdio                    | Real relay server + real browser runtime            | `pnpm --filter @mcp-b/webmcp-local-relay test:e2e`         |
-| Extension transport | SDK `Client` + `ExtensionClientTransport`  | Real MV3 extension using `ExtensionServerTransport` | `pnpm --filter @mcp-b/transports test:e2e`                 |
-| Extension template  | SDK `Client` in an isolated content script | MAIN-world runtime injected by a real MV3 extension | `pnpm --filter @mcp-b/webmcp-extension test:e2e`           |
+| Runtime             | Canonical caller                           | Real runtime boundary under test                         | Command                                                    |
+| ------------------- | ------------------------------------------ | -------------------------------------------------------- | ---------------------------------------------------------- |
+| Tab / global        | SDK `Client` + `TabClientTransport`        | Browser page running `@mcp-b/global`                     | `pnpm --filter mcp-e2e-tests test:runtime-contract`        |
+| Iframe              | SDK `Client` + `IframeParentTransport`     | Parent/iframe runtime boundary                           | `pnpm --filter mcp-e2e-tests test:runtime-contract`        |
+| Native Chromium     | `document.modelContext`                    | Chrome 152+ with WebMCP flags in CI                      | `pnpm --filter mcp-e2e-tests test:native-contract:default` |
+| Local relay         | SDK `Client` over stdio                    | Real relay server + real browser runtime                 | `pnpm --filter @mcp-b/webmcp-local-relay test:e2e`         |
+| Extension transport | SDK `Client` + `ExtensionClientTransport`  | Real MV3 extension using `ExtensionServerTransport`      | `pnpm --filter @mcp-b/transports test:e2e`                 |
+| Extension template  | SDK `Client` in an isolated content script | Imperative and declarative tools in a real MV3 extension | `pnpm --filter @mcp-b/webmcp-extension test:e2e`           |
 
 ## Canonical E2E Assertions
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:unit:coverage": "pnpm test:unit:packages:coverage && pnpm test:hooks:coverage",
     "test:unit:packages": "pnpm -r --filter '!@mcp-b/example-*' --filter '!@mcp-b/landing-page' --filter '!mcp-e2e-tests' --filter '!mcp-tab-transport-test-app' --filter '!usewebmcp' --filter '!@mcp-b/react-webmcp' run test",
     "test:unit:packages:coverage": "pnpm -r --filter '!@mcp-b/example-*' --filter '!@mcp-b/landing-page' --filter '!mcp-e2e-tests' --filter '!mcp-tab-transport-test-app' --filter '!usewebmcp' --filter '!@mcp-b/react-webmcp' run test -- --coverage",
+    "test:wpt": "pnpm --filter @mcp-b/webmcp-polyfill build && node ./scripts/run-webmcp-wpt.mjs",
     "typecheck": "pnpm -r --filter '!@mcp-b/example-*' --filter '!@mcp-b/landing-page' run typecheck",
     "validate:docs": "pnpm --filter @mcp-b/documentation-website validate",
     "validate:publish": "node ./scripts/validate-publish.js"

--- a/packages/global/WEBMCP-CONFORMANCE-REFERENCES.md
+++ b/packages/global/WEBMCP-CONFORMANCE-REFERENCES.md
@@ -2,17 +2,18 @@
 
 This file is the canonical link index for WebMCP discussions and Chromium implementation/source references used by `@mcp-b/global`.
 
-Goal: keep one place to track standards decisions and implementation details before adding full conformance tests.
+Goal: keep one place to track standards decisions, implementation details, and executable conformance coverage.
 
-## W3C WebMCP Spec and Docs
+## WebMCP Community Group Draft and Docs
 
 - WebMCP repository: https://github.com/webmachinelearning/webmcp
 - Rendered spec: https://webmachinelearning.github.io/webmcp/
 - Spec source (`index.bs`): https://github.com/webmachinelearning/webmcp/blob/main/index.bs
-- Proposal doc: https://github.com/webmachinelearning/webmcp/blob/main/docs/proposal.md
-- Explainer: https://github.com/webmachinelearning/webmcp/blob/main/docs/explainer.md
+- Repository explainer: https://github.com/webmachinelearning/webmcp/blob/main/README.md
+- Declarative API explainer: https://github.com/webmachinelearning/webmcp/blob/main/declarative-api-explainer.md
+- Declarative Web Platform Tests: https://github.com/web-platform-tests/wpt/tree/master/webmcp/declarative
 
-## W3C Discussions / Issues
+## Community Group Discussions / Issues
 
 - Elicitation discussion (WebMCP vs MCP behavior): https://github.com/webmachinelearning/webmcp/issues/21
 - Consumer API for in-page agents: https://github.com/webmachinelearning/webmcp/issues/51
@@ -71,7 +72,6 @@ Goal: keep one place to track standards decisions and implementation details bef
 
 - [ ] Cross-document `getTools({ fromOrigins })` exposure and Permissions Policy behavior
 - [ ] Event conformance for standard `toolchange` dispatch timing
-- [ ] Native-vs-polyfill parity matrix (Chromium native + shimmed consumer API)
 - [ ] Optional Chromium `executeTool` behavior without treating it as standard API
 
 ## Runtime Conformance Matrix (Implemented)
@@ -80,6 +80,8 @@ Goal: keep one place to track standards decisions and implementation details bef
 - Global runtime entry: `packages/global/conformance/global-runtime.e2e.test.ts`
 - Polyfill runtime entry: `packages/webmcp-polyfill/conformance/polyfill-runtime.e2e.test.ts`
 - Native Chromium runtime entry: `conformance/native-runtime.e2e.test.ts`
+- Shared declarative suite: `conformance/declarative-forms-conformance.shared.ts`
+- Pinned upstream declarative WPT lane: `.github/workflows/e2e.yml`
 
 Current MCP-B alignment note:
 

--- a/packages/global/WEBMCP-CONFORMANCE-REFERENCES.md
+++ b/packages/global/WEBMCP-CONFORMANCE-REFERENCES.md
@@ -11,6 +11,7 @@ Goal: keep one place to track standards decisions, implementation details, and e
 - Spec source (`index.bs`): https://github.com/webmachinelearning/webmcp/blob/main/index.bs
 - Repository explainer: https://github.com/webmachinelearning/webmcp/blob/main/README.md
 - Declarative API explainer: https://github.com/webmachinelearning/webmcp/blob/main/declarative-api-explainer.md
+- WebMCP Web Platform Tests: https://github.com/web-platform-tests/wpt/tree/master/webmcp
 - Declarative Web Platform Tests: https://github.com/web-platform-tests/wpt/tree/master/webmcp/declarative
 
 ## Community Group Discussions / Issues
@@ -81,7 +82,9 @@ Goal: keep one place to track standards decisions, implementation details, and e
 - Polyfill runtime entry: `packages/webmcp-polyfill/conformance/polyfill-runtime.e2e.test.ts`
 - Native Chromium runtime entry: `conformance/native-runtime.e2e.test.ts`
 - Shared declarative suite: `conformance/declarative-forms-conformance.shared.ts`
-- Pinned upstream declarative WPT lane: `.github/workflows/e2e.yml`
+- Pinned upstream declarative and page-local imperative WPT:
+  - Selection and runner: `scripts/run-webmcp-wpt.mjs`
+  - CI revision and job: `.github/workflows/e2e.yml`
 
 Current MCP-B alignment note:
 
@@ -95,6 +98,8 @@ Current MCP-B alignment note:
 
 Run commands:
 
+- Pinned upstream WebMCP WPT against the standalone polyfill:
+  - `CHROME_BIN="/path/to/chrome-canary" pnpm test:wpt`
 - WebMCP polyfill runtime (non-native Chromium):
   - `pnpm --filter @mcp-b/webmcp-polyfill run test:conformance`
 - Global runtime (non-native Chromium):

--- a/packages/webmcp-extension/README.md
+++ b/packages/webmcp-extension/README.md
@@ -1,8 +1,12 @@
 # `@mcp-b/webmcp-extension`
 
-Install WebMCP from a Chromium extension, then discover and call the page's tools from an isolated content script.
+Install WebMCP from a Chromium extension, then discover and call the page's
+imperative and declarative tools from an isolated content script.
 
-The page API stays native-shaped: websites register tools with `document.modelContext`. The extension-side helper returns the official MCP `Client`, with its normal `listTools()`, `callTool()`, and `close()` methods.
+The page API stays native-shaped: websites register JavaScript tools with
+`document.modelContext` or declare form tools in HTML. The extension-side helper
+returns the official MCP `Client`, with its normal `listTools()`, `callTool()`,
+and `close()` methods.
 
 ## Install
 
@@ -54,6 +58,26 @@ await document.modelContext.registerTool({
   }),
 });
 ```
+
+Annotated forms use the same extension connection:
+
+```html
+<form
+  toolname="extension_declarative"
+  tooldescription="Submit a value through an annotated form."
+  toolautosubmit
+>
+  <input name="value" toolparamdescription="Value to submit" required />
+  <button type="submit">Submit</button>
+</form>
+```
+
+`@mcp-b/global` uses native declarative support when available and installs the
+polyfilled form runtime otherwise. Imperative registrations and annotated forms
+both appear in `client.listTools()` and run through `client.callTool()`. The
+extension adds no separate DOM scanner or declarative client API. See the
+[declarative API reference](https://docs.mcp-b.ai/reference/webmcp/declarative-api)
+for the evolving browser behavior and polyfill compatibility boundary.
 
 Connect from the isolated content script and use the standard client API:
 
@@ -107,4 +131,10 @@ Load `dist/` as an unpacked extension from `chrome://extensions`.
 pnpm --filter @mcp-b/webmcp-extension test:e2e
 ```
 
-The test smoke-builds the copyable template with its own config, then loads its manifest and runtime as a real unpacked MV3 extension in Playwright's bundled Chromium. It covers document-start injection, strict page CSP, isolated-world discovery and calls, list-change handling, tool errors, dynamic registration and removal, top-frame scoping, navigation, and BFCache restoration. See Playwright's [Chrome extension testing guide](https://playwright.dev/docs/chrome-extensions).
+The test smoke-builds the copyable template with its own config, then loads its
+manifest and runtime as a real unpacked MV3 extension in Playwright's bundled
+Chromium. It covers document-start injection, strict page CSP, imperative and
+declarative discovery and calls, `toolautosubmit`, `respondWith()`, list-change
+handling, tool errors, dynamic registration and removal, top-frame scoping,
+navigation, and BFCache restoration. See Playwright's
+[Chrome extension testing guide](https://playwright.dev/docs/chrome-extensions).

--- a/packages/webmcp-extension/README.md
+++ b/packages/webmcp-extension/README.md
@@ -79,6 +79,11 @@ extension adds no separate DOM scanner or declarative client API. See the
 [declarative API reference](https://docs.mcp-b.ai/reference/webmcp/declarative-api)
 for the evolving browser behavior and polyfill compatibility boundary.
 
+Native Chrome also includes imperative and declarative tools owned by
+same-origin child documents in the top-level client's tool list. This uses the
+browser's frame-tree discovery; the extension does not inject into those child
+frames. The polyfilled path remains scoped to the top document.
+
 Connect from the isolated content script and use the standard client API:
 
 ```ts
@@ -123,7 +128,16 @@ Load `dist/` as an unpacked extension from `chrome://extensions`.
 - The template needs no extension API permissions, background worker, or `web_accessible_resources` declaration. Its match patterns declare the page access it needs.
 - Narrow the manifest match patterns to the sites your extension actually supports before publishing it.
 - Add icons and the remaining Chrome Web Store listing metadata before publishing; the included manifest is a runnable development baseline.
-- The template intentionally targets top-level pages. It does not inject into child frames.
+- The template injects into top-level pages only. Native Chrome still discovers
+  same-origin child-document tools through `getTools()`.
+- Cross-origin imperative tools require `allow="tools"`, `exposedTo`, and an
+  explicit `fromOrigins` request. The extension client does not make that
+  request. Declarative tools currently have no cross-origin exposure attribute.
+- Native Chrome resolves `executeTool()` with `null` when a tool navigates. The
+  extension client reports that as an interrupted MCP call and does not carry
+  calls across navigation or read JSON-LD from the destination document. Use
+  `SubmitEvent.respondWith()` when a declarative tool must return a result
+  without navigation.
 
 ## Test
 
@@ -136,5 +150,6 @@ manifest and runtime as a real unpacked MV3 extension in Playwright's bundled
 Chromium. It covers document-start injection, strict page CSP, imperative and
 declarative discovery and calls, `toolautosubmit`, `respondWith()`, list-change
 handling, tool errors, dynamic registration and removal, top-frame scoping,
-navigation, and BFCache restoration. See Playwright's
+navigation, and BFCache restoration. A native Chromium lane also covers
+same-origin child-document imperative and declarative tools. See Playwright's
 [Chrome extension testing guide](https://playwright.dev/docs/chrome-extensions).

--- a/packages/webmcp-extension/e2e/extension-runtime.e2e.test.ts
+++ b/packages/webmcp-extension/e2e/extension-runtime.e2e.test.ts
@@ -9,6 +9,8 @@ import { chromium, type BrowserContext, type Page } from 'playwright';
 
 const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const extensionDirectory = resolve(packageDirectory, 'e2e/dist/extension');
+const chromiumExecutablePath = process.env.PLAYWRIGHT_EXTENSION_CHROMIUM_EXECUTABLE_PATH;
+const enableNativeWebMCP = process.env.PLAYWRIGHT_EXTENSION_ENABLE_WEBMCP_FLAGS === '1';
 
 const pageHtml = `<!doctype html>
 <html>
@@ -16,6 +18,7 @@ const pageHtml = `<!doctype html>
     <meta charset="utf-8">
     <title>WebMCP extension fixture</title>
     <script nonce="webmcp-e2e">
+      window.__webmcpPageWorld = true;
       Promise.resolve().then(async () => {
         if (!document.modelContext) throw new Error('document.modelContext was not injected');
         let dynamicController;
@@ -100,7 +103,7 @@ const pageHtml = `<!doctype html>
       <input name="value" toolparamdescription="Value to submit" required>
       <button type="submit">Submit</button>
     </form>
-    <iframe src="/child" title="Uninjected child frame"></iframe>
+    <iframe src="/child" title="Same-origin child frame"></iframe>
   </body>
 </html>`;
 
@@ -109,10 +112,57 @@ const childHtml = `<!doctype html>
   <head>
     <meta charset="utf-8">
     <script nonce="webmcp-e2e">
-      document.documentElement.dataset.webmcpChildReady = 'true';
+      Promise.resolve().then(async () => {
+        if (!document.modelContext) {
+          document.documentElement.dataset.webmcpChildMode = 'unavailable';
+          document.documentElement.dataset.webmcpChildReady = 'true';
+          return;
+        }
+
+        await document.modelContext.registerTool({
+          name: 'extension_child_script',
+          description: 'Echo a value from a same-origin child document.',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value']
+          },
+          execute({ value }) {
+            document.documentElement.dataset.webmcpChildScriptInvoked = value;
+            return { content: [{ type: 'text', text: 'child-script:' + value }] };
+          }
+        });
+        document.addEventListener('submit', (event) => {
+          const form = event.target;
+          if (
+            !(form instanceof HTMLFormElement) ||
+            form.getAttribute('toolname') !== 'extension_child_declarative'
+          ) {
+            return;
+          }
+          event.preventDefault();
+          const value = String(new FormData(form).get('value'));
+          document.documentElement.dataset.webmcpChildDeclarativeInvoked = value;
+          event.respondWith(Promise.resolve('child-form:' + value));
+        });
+        document.documentElement.dataset.webmcpChildMode = 'native';
+        document.documentElement.dataset.webmcpChildReady = 'true';
+      }).catch((error) => {
+        document.documentElement.dataset.webmcpChildError = String(error?.message ?? error);
+      });
     </script>
   </head>
-  <body>Child frame</body>
+  <body>
+    Child frame
+    <form
+      toolname="extension_child_declarative"
+      tooldescription="Submit a value from a same-origin child document."
+      toolautosubmit
+    >
+      <input name="value" toolparamdescription="Value to submit" required>
+      <button type="submit">Submit</button>
+    </form>
+  </body>
 </html>`;
 
 let server: Server;
@@ -149,13 +199,21 @@ async function launchExtension(): Promise<{
   const userDataDirectory = mkdtempSync(resolve(tmpdir(), 'webmcp-extension-e2e-'));
   try {
     const context = await chromium.launchPersistentContext(userDataDirectory, {
-      channel: process.env.PLAYWRIGHT_EXTENSION_CHROMIUM_CHANNEL ?? 'chromium',
+      ...(chromiumExecutablePath
+        ? { executablePath: chromiumExecutablePath }
+        : { channel: process.env.PLAYWRIGHT_EXTENSION_CHROMIUM_CHANNEL ?? 'chromium' }),
       headless: process.env.PLAYWRIGHT_EXTENSION_HEADLESS !== 'false',
       // Playwright disables BFCache by default; this suite exercises extension restore behavior.
       ignoreDefaultArgs: ['--disable-back-forward-cache'],
       args: [
         `--disable-extensions-except=${extensionDirectory}`,
         `--load-extension=${extensionDirectory}`,
+        ...(enableNativeWebMCP
+          ? [
+              '--enable-experimental-web-platform-features',
+              '--enable-features=WebMCPTesting,DevToolsWebMCPSupport',
+            ]
+          : []),
       ],
     });
     return { context, userDataDirectory };
@@ -187,6 +245,8 @@ describe('WebMCP extension template', () => {
           assert.deepStrictEqual(
             {
               contentError: outcome.webmcpExtensionError,
+              childDeclarativeResult: outcome.webmcpExtensionChildDeclarativeResult,
+              childScriptResult: outcome.webmcpExtensionChildScriptResult,
               declarativeInvocation: outcome.webmcpDeclarativeInvoked,
               declarativeResult: outcome.webmcpExtensionDeclarativeResult,
               dynamicResult: outcome.webmcpExtensionDynamicResult,
@@ -203,6 +263,8 @@ describe('WebMCP extension template', () => {
             },
             {
               contentError: undefined,
+              childDeclarativeResult: enableNativeWebMCP ? `child-form:${pathname}` : undefined,
+              childScriptResult: enableNativeWebMCP ? `child-script:${pathname}` : undefined,
               declarativeInvocation: pathname,
               declarativeResult: `submitted:${pathname}`,
               dynamicResult: `dynamic:${pathname}`,
@@ -215,16 +277,32 @@ describe('WebMCP extension template', () => {
               result: `echo:${pathname}`,
               sawDynamic: 'true',
               sawDynamicRemoval: 'true',
-              tools: 'extension_declarative,extension_echo,extension_fail,extension_set_dynamic',
+              tools: enableNativeWebMCP
+                ? 'extension_child_declarative,extension_child_script,extension_declarative,extension_echo,extension_fail,extension_set_dynamic'
+                : 'extension_declarative,extension_echo,extension_fail,extension_set_dynamic',
             }
           );
 
           const child = page.frames().find((frame) => frame.url() === `${origin}/child`);
           assert.ok(child, 'child frame did not load');
-          await child.waitForFunction(() => document.documentElement.dataset.webmcpChildReady);
           assert.deepStrictEqual(
-            await child.evaluate(() => ({ ...document.documentElement.dataset })),
-            { webmcpChildReady: 'true' }
+            await child.evaluate(() => {
+              const { dataset } = document.documentElement;
+              return {
+                declarativeInvocation: dataset.webmcpChildDeclarativeInvoked,
+                error: dataset.webmcpChildError,
+                mode: dataset.webmcpChildMode,
+                ready: dataset.webmcpChildReady,
+                scriptInvocation: dataset.webmcpChildScriptInvoked,
+              };
+            }),
+            {
+              declarativeInvocation: enableNativeWebMCP ? pathname : undefined,
+              error: undefined,
+              mode: enableNativeWebMCP ? 'native' : 'unavailable',
+              ready: 'true',
+              scriptInvocation: enableNativeWebMCP ? pathname : undefined,
+            }
           );
         }
 

--- a/packages/webmcp-extension/e2e/extension/content-script.ts
+++ b/packages/webmcp-extension/e2e/extension/content-script.ts
@@ -8,6 +8,22 @@ async function waitForDocument(): Promise<void> {
   });
 }
 
+async function waitForPageTools(): Promise<void> {
+  await waitForDocument();
+  await new Promise<void>((resolve, reject) => {
+    const check = () => {
+      const { dataset } = document.documentElement;
+      if (!dataset.webmcpPageReady && !dataset.webmcpPageError) return;
+      observer.disconnect();
+      if (dataset.webmcpPageError) reject(new Error(dataset.webmcpPageError));
+      else resolve();
+    };
+    const observer = new MutationObserver(check);
+    observer.observe(document.documentElement, { attributes: true });
+    check();
+  });
+}
+
 function readText(result: CallToolResult, toolName: string): string {
   const text = result.content.find((item) => item.type === 'text');
   if (!text || text.type !== 'text') throw new Error(`${toolName} returned no text`);
@@ -19,7 +35,7 @@ async function run(): Promise<void> {
     !Reflect.has(document, 'modelContext')
   );
 
-  await waitForDocument();
+  await waitForPageTools();
   let sawDynamicTool = false;
   let resolveDynamicRemoval!: () => void;
   let rejectDynamicRemoval!: (reason: unknown) => void;

--- a/packages/webmcp-extension/e2e/extension/content-script.ts
+++ b/packages/webmcp-extension/e2e/extension/content-script.ts
@@ -1,5 +1,5 @@
 import { connectWebMCPClient } from '@mcp-b/webmcp-extension/content-script';
-import type { CallToolResult } from '@modelcontextprotocol/client';
+import type { CallToolResult, Client } from '@modelcontextprotocol/client';
 
 async function waitForDocument(): Promise<void> {
   if (document.readyState !== 'loading') return;
@@ -30,12 +30,60 @@ function readText(result: CallToolResult, toolName: string): string {
   return text.text;
 }
 
-async function run(): Promise<void> {
-  document.documentElement.dataset.webmcpIsolatedWorld = String(
-    !Reflect.has(document, 'modelContext')
+async function callChildToolsWhenNative(client: Client): Promise<void> {
+  const frame = document.querySelector('iframe');
+  if (!frame) throw new Error('Child frame was not found');
+
+  const deadline = performance.now() + 5_000;
+  let childDataset: DOMStringMap | undefined;
+  while (performance.now() < deadline) {
+    childDataset = frame.contentDocument?.documentElement?.dataset;
+    if (childDataset?.webmcpChildError) throw new Error(childDataset.webmcpChildError);
+    if (childDataset?.webmcpChildReady) break;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  if (!childDataset?.webmcpChildReady) throw new Error('Child frame did not become ready');
+
+  const mode = childDataset.webmcpChildMode;
+  if (!mode) throw new Error('Child frame did not report its WebMCP mode');
+  if (mode !== 'native') return;
+
+  const childToolNames = ['extension_child_declarative', 'extension_child_script'];
+  let toolNames: string[] = [];
+  const toolDeadline = performance.now() + 5_000;
+  while (performance.now() < toolDeadline) {
+    toolNames = (await client.listTools()).tools.map(({ name }) => name);
+    if (childToolNames.every((name) => toolNames.includes(name))) break;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  if (!childToolNames.every((name) => toolNames.includes(name))) {
+    throw new Error('Native child-frame tools were not exposed to the extension client');
+  }
+
+  const scriptResult = await client.callTool({
+    name: 'extension_child_script',
+    arguments: { value: window.location.pathname },
+  });
+  document.documentElement.dataset.webmcpExtensionChildScriptResult = readText(
+    scriptResult,
+    'extension_child_script'
   );
 
+  const declarativeResult = await client.callTool({
+    name: 'extension_child_declarative',
+    arguments: { value: window.location.pathname },
+  });
+  document.documentElement.dataset.webmcpExtensionChildDeclarativeResult = readText(
+    declarativeResult,
+    'extension_child_declarative'
+  );
+}
+
+async function run(): Promise<void> {
   await waitForPageTools();
+  document.documentElement.dataset.webmcpIsolatedWorld = String(
+    !Reflect.has(window, '__webmcpPageWorld')
+  );
   let sawDynamicTool = false;
   let resolveDynamicRemoval!: () => void;
   let rejectDynamicRemoval!: (reason: unknown) => void;
@@ -64,6 +112,8 @@ async function run(): Promise<void> {
       },
     },
   });
+
+  await callChildToolsWhenNative(client);
 
   window.addEventListener('pageshow', (event) => {
     if (!event.persisted) return;

--- a/packages/webmcp-extension/template/README.md
+++ b/packages/webmcp-extension/template/README.md
@@ -13,6 +13,11 @@ Load `dist/` from `chrome://extensions` with **Developer mode** → **Load unpac
 - `src/content-script.ts` stays isolated, logs current tools, and follows later tool-list changes.
 - `manifest.json` declares site access. Narrow its match patterns before publishing.
 
+The client receives both JavaScript tools registered through
+`document.modelContext` and declarative tools generated from annotated forms.
+`@mcp-b/global` owns native or polyfilled form discovery; the isolated content
+script uses the same `listTools()` and `callTool()` methods for both tool types.
+
 Call a page tool from `src/content-script.ts` with the returned client:
 
 ```ts

--- a/packages/webmcp-extension/template/README.md
+++ b/packages/webmcp-extension/template/README.md
@@ -17,6 +17,8 @@ The client receives both JavaScript tools registered through
 `document.modelContext` and declarative tools generated from annotated forms.
 `@mcp-b/global` owns native or polyfilled form discovery; the isolated content
 script uses the same `listTools()` and `callTool()` methods for both tool types.
+Native Chrome also exposes both tool types from same-origin child documents.
+The polyfilled fallback is scoped to the top document.
 
 Call a page tool from `src/content-script.ts` with the returned client:
 

--- a/packages/webmcp-local-relay/src/relay.e2e.test.ts
+++ b/packages/webmcp-local-relay/src/relay.e2e.test.ts
@@ -13,6 +13,7 @@ import type { RuntimeContractController } from '../../../e2e/runtime-contract/co
 import { sanitizeName } from './naming.js';
 
 const TEST_TOOL_NAME = 'sum';
+const DECLARATIVE_TOOL_NAME = 'webmcp_zero_config_declarative_e2e';
 const PACKAGE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const REPO_ROOT = resolve(PACKAGE_DIR, '../..');
 const CLI_ENTRY_PATH = resolve(PACKAGE_DIR, 'dist/cli.mjs');
@@ -74,12 +75,14 @@ declare global {
   }
 }
 
+const GLOBAL_RUNTIME_CASE: RuntimeCase = {
+  mode: 'global',
+  scriptRoute: '/runtime/global.iife.js',
+  scriptPath: GLOBAL_RUNTIME_PATH,
+};
+
 const RUNTIME_CASES: RuntimeCase[] = [
-  {
-    mode: 'global',
-    scriptRoute: '/runtime/global.iife.js',
-    scriptPath: GLOBAL_RUNTIME_PATH,
-  },
+  GLOBAL_RUNTIME_CASE,
   {
     mode: 'polyfill-testing',
     scriptRoute: '/runtime/webmcp-polyfill.iife.js',
@@ -344,6 +347,20 @@ function buildHostPageHtml(options: {
 }): string {
   const { widgetOrigin, relayPort, runtimeScriptRoute, runtimeContractRoute, runtimeMode } =
     options;
+  const declarativeFixture = `<script>
+      document.addEventListener('submit', (event) => {
+        const form = event.target;
+        if (!(form instanceof HTMLFormElement) || form.getAttribute('toolname') !== '${DECLARATIVE_TOOL_NAME}') return;
+        event.preventDefault();
+        const value = String(new FormData(form).get('value'));
+        document.documentElement.dataset.webmcpDeclarativeInvoked = value;
+        event.respondWith(Promise.resolve({ content: [{ type: 'text', text: 'submitted:' + value }] }));
+      });
+    </script>
+    <form toolname="${DECLARATIVE_TOOL_NAME}" tooldescription="Submit through the zero-configuration relay." toolautosubmit>
+      <input name="value" toolparamdescription="Value to submit" required />
+      <button type="submit">Submit</button>
+    </form>`;
 
   return `<!doctype html>
 <html lang="en">
@@ -353,6 +370,7 @@ function buildHostPageHtml(options: {
   </head>
   <body>
     <h1>WebMCP Relay E2E Host</h1>
+    ${declarativeFixture}
     <div id="status" data-state="booting">booting</div>
     <script src="${runtimeScriptRoute}"></script>
     <script type="module">
@@ -378,7 +396,6 @@ function buildHostPageHtml(options: {
     </script>
     <script
       src="${widgetOrigin}/embed.js"
-      data-relay-host="127.0.0.1"
       data-relay-port="${String(relayPort)}"
     ></script>
   </body>
@@ -564,15 +581,7 @@ async function setupE2EHarness(options: {
 
     const stdioTransport = new StdioClientTransport({
       command: process.execPath,
-      args: [
-        CLI_ENTRY_PATH,
-        '--host',
-        '127.0.0.1',
-        '--port',
-        String(relayPort),
-        '--widget-origin',
-        host.origin,
-      ],
+      args: [CLI_ENTRY_PATH, '--port', String(relayPort)],
       cwd: PACKAGE_DIR,
       stderr: 'pipe',
     });
@@ -637,6 +646,45 @@ async function setupE2EHarness(options: {
 }
 
 describe('relay e2e (real browser assets)', () => {
+  it('invokes a declarative form with the default origin policy', async () => {
+    let widgetServer: StartedHttpServer | null = null;
+    let harness: E2EHarness | null = null;
+
+    try {
+      const relayPort = await getOpenPort();
+      widgetServer = await startWidgetAssetServer();
+      harness = await setupE2EHarness({
+        runtimeCase: GLOBAL_RUNTIME_CASE,
+        relayPort,
+        widgetOrigin: widgetServer.origin,
+        clientName: 'webmcp-local-relay-e2e-client-default-origin-declarative',
+      });
+
+      const toolName = sanitizeName(DECLARATIVE_TOOL_NAME);
+      await waitForValue(async () => {
+        const toolList = await harness?.client.listTools();
+        return toolList?.tools.some((tool) => tool.name === toolName) ? true : undefined;
+      }, 20_000);
+
+      const result = await harness.client.callTool({
+        name: toolName,
+        arguments: { value: 'zero-config' },
+      });
+
+      expect(firstContentText(result)).toBe('submitted:zero-config');
+      await expect
+        .poll(() =>
+          harness?.page.evaluate(() => document.documentElement.dataset.webmcpDeclarativeInvoked)
+        )
+        .toBe('zero-config');
+    } catch (error) {
+      throw formatE2EError('default-origin declarative', error, harness);
+    } finally {
+      await harness?.cleanup();
+      await stopHttpServer(widgetServer?.server ?? null);
+    }
+  });
+
   it('uses async document discovery, current descriptor identity, and document toolchange', async () => {
     let widgetServer: StartedHttpServer | null = null;
     let harness: E2EHarness | null = null;

--- a/packages/webmcp-polyfill/README.md
+++ b/packages/webmcp-polyfill/README.md
@@ -68,8 +68,10 @@ submit it. With `toolautosubmit`, the polyfill validates the form and calls
 `requestSubmit()`. Agent submissions expose `SubmitEvent.agentInvoked` and
 `SubmitEvent.respondWith()`.
 
-The implementation tracks the subset of current Chromium behavior covered by
-the package's browser conformance suite. See Chrome's
+CI checks the standalone polyfill against the upstream
+[declarative Web Platform Tests](https://github.com/web-platform-tests/wpt/tree/master/webmcp/declarative).
+Repository-specific browser tests cover the polyfill and composed MCP-B runtime.
+See Chrome's
 [declarative API documentation](https://developer.chrome.com/docs/ai/webmcp/declarative-api)
 for the evolving API. The Community Group draft's
 [declarative section](https://webmachinelearning.github.io/webmcp/#declarative-webmcp)

--- a/packages/webmcp-polyfill/src/declarative-forms.ts
+++ b/packages/webmcp-polyfill/src/declarative-forms.ts
@@ -684,11 +684,14 @@ function waitForSubmission(
     registration.cancelPending = cancel;
     Reflect.apply(EventTarget.prototype.addEventListener, form, ['invalid', onInvalid, true]);
 
-    if (!autosubmit) submitter?.focus();
-    window.dispatchEvent(agentEvent('toolactivated', toolName));
-    if (!autosubmit) return;
+    if (!autosubmit) {
+      submitter?.focus();
+      window.dispatchEvent(agentEvent('toolactivated', toolName));
+      return;
+    }
     try {
       requestFormSubmit(form, submitter);
+      window.dispatchEvent(agentEvent('toolactivated', toolName));
     } catch (error) {
       cancel(error);
     }

--- a/packages/webmcp-polyfill/src/index.ts
+++ b/packages/webmcp-polyfill/src/index.ts
@@ -52,6 +52,12 @@ const installedProperties: InstalledProperty[] = [];
 let installedContext: StrictWebMCPContext | null = null;
 let cleanupDeclarativeForms: (() => void) | null = null;
 
+function currentOrigin(): string {
+  return typeof globalThis.origin === 'string'
+    ? globalThis.origin
+    : (globalThis.location?.origin ?? '');
+}
+
 function installProperty(target: object, key: PropertyKey, descriptor: PropertyDescriptor): void {
   const previous = Object.getOwnPropertyDescriptor(target, key);
   try {
@@ -174,7 +180,7 @@ class StrictWebMCPContext extends EventTarget implements ModelContext {
       }
     }
     validateExecutableOrigin(tool.origin);
-    if (tool.window !== globalThis.window || tool.origin !== (globalThis.location?.origin ?? '')) {
+    if (tool.window !== globalThis.window || tool.origin !== currentOrigin()) {
       throw createUnknownError(`Tool not found: ${tool.name}`);
     }
     return this.invokeToolByName(tool.name, inputArgsJson, options);
@@ -208,7 +214,7 @@ class StrictWebMCPContext extends EventTarget implements ModelContext {
         ...(tool[REGISTERED_INPUT_SCHEMA_SYMBOL] !== undefined
           ? { inputSchema: tool[REGISTERED_INPUT_SCHEMA_SYMBOL] }
           : {}),
-        origin: globalThis.location?.origin ?? '',
+        origin: currentOrigin(),
         window: globalThis.window,
         ...(tool.annotations ? { annotations: toWebMcpAnnotations(tool.annotations) } : {}),
       }))

--- a/packages/webmcp-ts-sdk/src/browser-server.test.ts
+++ b/packages/webmcp-ts-sdk/src/browser-server.test.ts
@@ -116,7 +116,11 @@ describe('BrowserMcpServer', () => {
       ontoolchange: null,
       registerTool() {
         registrationCount += 1;
-        return registrationCount === 1 ? accepted : Promise.reject(nativeFailure);
+        return registrationCount === 1
+          ? accepted.then(() => {
+              native.dispatchEvent(new Event('toolchange'));
+            })
+          : Promise.reject(nativeFailure);
       },
       async getTools() {
         return nativeTools;
@@ -142,9 +146,10 @@ describe('BrowserMcpServer', () => {
     expect(server.listTools().map(({ name }) => name)).toEqual(['accepted']);
     expect(order).toEqual(['toolchange', 'resolved']);
 
+    // Native events remain authoritative when getTools() reuses descriptor objects.
     native.dispatchEvent(new Event('toolchange'));
     await server.syncNativeTools();
-    expect(order).toEqual(['toolchange', 'resolved']);
+    await expect.poll(() => order).toEqual(['toolchange', 'resolved', 'toolchange']);
 
     await expect(
       server.registerTool({

--- a/packages/webmcp-ts-sdk/src/browser-server.ts
+++ b/packages/webmcp-ts-sdk/src/browser-server.ts
@@ -165,6 +165,7 @@ export class BrowserMcpServer extends EventTarget implements ModelContextWithExt
   private readonly pendingTools = new Map<string, AbortController>();
   private readonly removingNativeTools = new Set<string>();
   private nativeSyncQueue: Promise<void> = Promise.resolve();
+  private nativeToolChangeQueue: Promise<void> = Promise.resolve();
   private nativeToolChangeListener: EventListener | undefined;
   private closed = false;
   private closePromise: Promise<void> | undefined;
@@ -189,13 +190,14 @@ export class BrowserMcpServer extends EventTarget implements ModelContextWithExt
     if (native) {
       this.nativeToolChangeListener = () => {
         if (this.closed) return;
-        void this.queueNativeToolSync()
-          .then(async (changed) => {
-            if (changed) await this.notifyProducerToolsChanged();
-          })
-          .catch((error: unknown) => {
+        this.nativeToolChangeQueue = this.nativeToolChangeQueue.then(async () => {
+          try {
+            await this.queueNativeToolSync();
+          } catch (error) {
             console.warn('[BrowserMcpServer] Native WebMCP tool reconciliation failed:', error);
-          });
+          }
+          await this.notifyProducerToolsChanged();
+        });
       };
       native.addEventListener('toolchange', this.nativeToolChangeListener);
     }
@@ -221,11 +223,9 @@ export class BrowserMcpServer extends EventTarget implements ModelContextWithExt
 
   private async notifyProducerToolsChanged(): Promise<void> {
     if (this.closed) return;
-    // ponytail: the platform does not expose its WebMCP task source; a timer
-    // preserves task (rather than microtask) ordering for local registrations.
+    // Preserve task ordering because WebMCP does not expose its platform task source.
     await new Promise((resolve) => setTimeout(resolve, 0));
-    if (this.closed) return;
-    this.dispatchEvent(new Event('toolchange'));
+    if (!this.closed) this.dispatchEvent(new Event('toolchange'));
   }
 
   private getNativeStandardToolsApi(): NativeStandardToolsApi | undefined {
@@ -417,7 +417,8 @@ export class BrowserMcpServer extends EventTarget implements ModelContextWithExt
       registered.abortListener = abort;
     }
     if (this.tools.get(tool.name) === registered) {
-      await this.notifyProducerToolsChanged();
+      if (this.native) await this.nativeToolChangeQueue;
+      else await this.notifyProducerToolsChanged();
     }
     if (this.closed) throw createInvalidStateError('BrowserMcpServer is closed');
     options.signal?.throwIfAborted();
@@ -432,7 +433,7 @@ export class BrowserMcpServer extends EventTarget implements ModelContextWithExt
       this.tools.delete(name);
       this.nativeBackfilledTools.delete(name);
       registered.mcpHandle?.remove();
-      if (options?.notify ?? true) {
+      if ((options?.notify ?? true) && !this.native) {
         void this.notifyProducerToolsChanged();
       }
     }
@@ -440,14 +441,14 @@ export class BrowserMcpServer extends EventTarget implements ModelContextWithExt
   }
 
   syncNativeTools(): Promise<void> {
-    return this.queueNativeToolSync().then(() => undefined);
+    return this.queueNativeToolSync();
   }
 
-  private queueNativeToolSync(): Promise<boolean> {
+  private queueNativeToolSync(): Promise<void> {
     const sync = this.nativeSyncQueue.then(async () => {
-      if (this.closed) return false;
+      if (this.closed) return;
       const native = this.getNativeStandardToolsApi();
-      return native ? this.backfillNativeStandardTools(native) : false;
+      if (native) await this.backfillNativeStandardTools(native);
     });
     this.nativeSyncQueue = sync.then(
       () => undefined,
@@ -456,10 +457,9 @@ export class BrowserMcpServer extends EventTarget implements ModelContextWithExt
     return sync;
   }
 
-  private async backfillNativeStandardTools(native: NativeStandardToolsApi): Promise<boolean> {
+  private async backfillNativeStandardTools(native: NativeStandardToolsApi): Promise<void> {
     const tools = await native.getTools();
-    if (this.closed) return false;
-    let changed = false;
+    if (this.closed) return;
     const nextTools = new Map<string, NativeBackfilledTool>();
     const nativeNames = new Set(tools.map(({ name }) => name));
     for (const name of this.removingNativeTools) {
@@ -508,7 +508,6 @@ export class BrowserMcpServer extends EventTarget implements ModelContextWithExt
       const next = nextTools.get(name);
       if (!next || next.fingerprint !== current.fingerprint) {
         this.removeTool(name, { skipNative: true, notify: false });
-        changed = true;
         continue;
       }
       this.nativeBackfilledTools.set(name, next);
@@ -538,7 +537,6 @@ export class BrowserMcpServer extends EventTarget implements ModelContextWithExt
         const normalized = this.validateToolDescriptor(tool);
         this.tools.set(tool.name, this.registerToolInMcp(tool, normalized, execute));
         this.nativeBackfilledTools.set(name, next);
-        changed = true;
       } catch (error) {
         console.warn(
           `[BrowserMcpServer] Native tool "${name}" was not exposed over MCP because its schema could not be compiled:`,
@@ -546,7 +544,6 @@ export class BrowserMcpServer extends EventTarget implements ModelContextWithExt
         );
       }
     }
-    return changed;
   }
 
   registerResource(descriptor: ResourceDescriptor): RegistrationHandle {

--- a/scripts/run-webmcp-wpt.mjs
+++ b/scripts/run-webmcp-wpt.mjs
@@ -1,0 +1,81 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const wptDirectory = resolve(root, '.reference/wpt');
+const runner = resolve(wptDirectory, 'wpt');
+const polyfill = resolve(root, 'packages/webmcp-polyfill/dist/index.iife.js');
+const chrome = process.env.CHROME_BIN;
+
+if (!chrome) {
+  throw new Error('CHROME_BIN must point to a Chrome Canary executable');
+}
+if (!existsSync(runner)) {
+  throw new Error(
+    'Missing .reference/wpt; check out web-platform-tests/wpt at the revision pinned in .github/workflows/e2e.yml'
+  );
+}
+if (!existsSync(polyfill)) {
+  throw new Error('Missing built polyfill bundle');
+}
+
+// ponytail: page-local allowlist; add frame/origin tests only with browser-level coordination.
+// Mixed exposedTo tests stay out because valid nonempty exposure is intentionally native-only.
+const imperativeTests = [
+  'document-domain-enabled.https.html',
+  'duplicate_tool_registration.https.html',
+  'executeTool-abort.https.html',
+  'executeTool-error-window-onerror.https.html',
+  'executeTool-invalid-dictionary.https.html',
+  'getTools-imperative-annotations.https.html',
+  'getTools-imperative-schema.https.html',
+  'getTools.https.html',
+  'model_context.https.html',
+  'non-secure.html',
+  'object-arguments.https.html',
+  'opaque-origin-tools.https.html',
+  'register-tool-title.https.html',
+  'register_tool_invalid_json_schema.https.html',
+  'register_tool_name_validation.https.html',
+  'register_tool_no_schema.https.html',
+  'register_tool_signal.https.html',
+  'register_tool_toolchange.https.html',
+  'register_tool_with_empty_annotation.https.html',
+  'register_tool_with_schema.https.html',
+];
+const includes = ['/webmcp/declarative/'].concat(
+  imperativeTests.map((test) => `/webmcp/imperative/${test}`)
+);
+
+const result = spawnSync(
+  runner,
+  [
+    'run',
+    '--channel',
+    'canary',
+    '--binary',
+    chrome,
+    '--yes',
+    '--install-webdriver',
+    '--headless',
+    '--no-enable-experimental',
+    '--test-types',
+    'testharness',
+    '--binary-arg=--no-sandbox',
+    '--binary-arg=--disable-features=WebMCP,WebMCPTesting',
+    '--inject-script',
+    polyfill,
+    '--no-pause-after-test',
+    '--processes',
+    '1',
+    '--no-manifest-download',
+    ...includes.flatMap((path) => ['--include', path]),
+    'chrome',
+  ],
+  { cwd: wptDirectory, stdio: 'inherit' }
+);
+
+if (result.error) throw result.error;
+process.exitCode = result.status ?? 1;


### PR DESCRIPTION
## Why

This is a conformance follow-up to [#278](https://github.com/WebMCP-org/npm-packages/pull/278). Declarative forms had repository coverage, but upstream Web Platform Tests were not part of the merge gate. The audit found three observable mismatches: autosubmit event order, opaque-origin reporting, and composed-runtime propagation for behavior-only form mutations.

First-party references:

- [WebMCP declarative explainer](https://github.com/webmachinelearning/webmcp/blob/main/declarative-api-explainer.md)
- [WebMCP Community Group Draft](https://webmachinelearning.github.io/webmcp/)
- [Chrome declarative API documentation](https://developer.chrome.com/docs/ai/webmcp/declarative-api)
- [Chrome imperative iframe documentation](https://developer.chrome.com/docs/ai/webmcp/imperative-api#cross-origin-iframes)
- [Pinned WebMCP WPT revision](https://github.com/web-platform-tests/wpt/tree/c7fdee80f3f17b4e9813964916afdfd57ace863f/webmcp)

## What changed

- Match Chromium autosubmit ordering by submitting before `toolactivated`.
- Report the effective origin in opaque documents.
- Treat native `modelContext` `toolchange` events as authoritative in `BrowserMcpServer`, reconciling before forwarding without metadata heuristics or duplicate wrapper events.
- Add MCP-B regressions for autosubmit order and `toolautosubmit` mutation propagation.
- Pin and inject the standalone polyfill into upstream WebMCP WPT in CI.
- Share one `pnpm test:wpt` runner between local development and CI, covering every declarative WPT plus 20 page-local imperative WPT files.
- Keep frame-tree, origin-policy, and navigation WPT out of the injected-polyfill lane because they require native browser ownership.
- Add WPT, the WebMCP draft, and Chromium-source routing guidance to `AGENTS.md` and the testing references.
- Exercise a declarative form through the real local-relay iframe with the default loopback host and wildcard page-origin policy; the test overrides only the port for process isolation.
- Document the MV3 extension package from its shipped manifest, client API, build, top-frame scope, and trust boundary.
- Document that declarative forms and imperative registrations reach the extension through the same MCP client list/call path while `@mcp-b/global` remains responsible for native or polyfilled form discovery.
- Prove that native same-origin child-document imperative and declarative tools list and execute through the isolated extension MCP client without child-frame injection.
- Document the native frame-tree, cross-origin opt-in, polyfill, and navigation-result boundaries.
- Correct the docs' local-versus-CI test boundaries and label the upstream document as a Community Group Draft.
- Add patch changesets for the polyfill and TypeScript SDK fixed group.

## Verification

- Manual upstream declarative WPT on native Chrome Canary: 15/15 subtests.
- Injected-polyfill WebMCP WPT: 32/32 files, including all 12 declarative files and 20 page-local imperative files.
- Shared browser conformance: strict polyfill 24/24, composed global 24/24, native Canary 24/24 (17 declarative and 7 core tests in each run).
- Local relay real-browser E2E: 10/10, including default-policy declarative discovery and invocation.
- Real unpacked MV3 extension-template E2E in bundled Chromium, including declarative discovery and invocation, `toolautosubmit`, and `respondWith()`.
- Real unpacked MV3 extension-template E2E in current unbranded Chromium, including same-origin child-document imperative and declarative listing and execution.
- Mintlify validation and broken-link checks.
- `pnpm build`, `pnpm typecheck`, `vp check`, and `pnpm test:unit`.
- Tab and iframe transport runtime contracts: 10/10.
