### PR TITLE
fix(release): add repository URL for trusted publishing

### DIFF
--- a/packages/smart-dom-reader/mcp-server/package.json
+++ b/packages/smart-dom-reader/mcp-server/package.json
@@ -4,6 +4,8 @@
   "description": "MCP server for smart-dom-reader backed by Playwright",
   "license": "MIT",
   "repository": {
+    "type": "git",
+    "url": "git+https://github.com/WebMCP-org/npm-packages.git",
     "directory": "packages/smart-dom-reader/mcp-server"
   },
   "bin": {


### PR DESCRIPTION
## Why

The v5 release run published `@mcp-b/smart-dom-reader@5.0.0` through npm trusted publishing, then npm denied `@mcp-b/smart-dom-reader-server@5.0.0`. The nested package only declared `repository.directory`; npm requires `repository.url` to match the GitHub repository used by the OIDC workflow.

- Failed release: https://github.com/WebMCP-org/npm-packages/actions/runs/32554171490
- npm trusted publishing requirements: https://docs.npmjs.com/trusted-publishers/

## What changed

Added the same repository `type` and `url` metadata already used by every other publishable workspace. No workflow credentials or long-lived npm token were added.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `vp check`
- `pnpm test:unit`
- `pnpm release:check`

No changeset: this repairs publication of the already-versioned, still-unpublished `5.0.0` package.