### PR TITLE
fix(global): support immutable native WebMCP contexts

### DIFF
--- a/.changeset/sour-insects-build.md
+++ b/.changeset/sour-insects-build.md
@@ -1,0 +1,6 @@
+---
+'@mcp-b/webmcp-ts-sdk': patch
+'@mcp-b/global': patch
+---
+
+Handle legacy native WebMCP contexts that omit EventTarget methods or expose immutable modelContext properties.

--- a/packages/global/src/global.test.ts
+++ b/packages/global/src/global.test.ts
@@ -95,6 +95,29 @@ describe('global adapter', () => {
     expect(typeof getModelContext().listTools).toBe('function');
   });
 
+  it('leaves a non-configurable native modelContext untouched', () => {
+    const nativeContext = createNativeModelContextStub();
+    const previousNavigatorContext = navigator.modelContext;
+    setDocumentModelContext(nativeContext);
+    const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+    const descriptorSpy = vi
+      .spyOn(Object, 'getOwnPropertyDescriptor')
+      .mockImplementation((target, key) => {
+        const descriptor = getOwnPropertyDescriptor(target, key);
+        return target === document && key === 'modelContext' && descriptor
+          ? { ...descriptor, configurable: false }
+          : descriptor;
+      });
+
+    try {
+      expect(initializeWebModelContext()).toBeUndefined();
+      expect(document.modelContext).toBe(nativeContext);
+      expect(navigator.modelContext).toBe(previousNavigatorContext);
+    } finally {
+      descriptorSpy.mockRestore();
+    }
+  });
+
   it('leaves the native surface untouched when transport selection fails', () => {
     const nativeContext = createNativeModelContextStub();
     setDocumentModelContext(nativeContext);
@@ -342,7 +365,7 @@ describe('global adapter', () => {
     });
   });
 
-  it('backfills tools from a native document modelContext using getTools and executeTool', async () => {
+  it('backfills tools from a legacy native context without EventTarget methods', async () => {
     const nativeTool = {
       name: 'standard_native_tool',
       description: 'registered before wrapper init through the standard API',
@@ -367,9 +390,6 @@ describe('global adapter', () => {
       registerTool: () => {},
       getTools,
       executeTool,
-      addEventListener: () => {},
-      removeEventListener: () => {},
-      dispatchEvent: () => true,
     };
 
     setDocumentModelContext(nativeContext);

--- a/packages/global/src/global.ts
+++ b/packages/global/src/global.ts
@@ -23,6 +23,11 @@ function readCurrentModelContext(): ModelContext | undefined {
   return document.modelContext ?? navigator.modelContext;
 }
 
+function canReplaceModelContext(target: Document | Navigator): boolean {
+  const descriptor = Object.getOwnPropertyDescriptor(target, 'modelContext');
+  return descriptor ? descriptor.configurable === true : Object.isExtensible(target);
+}
+
 function replaceDocumentModelContext(value: unknown): void {
   Object.defineProperty(document, 'modelContext', {
     configurable: true,
@@ -132,6 +137,12 @@ export function initializeWebModelContext(options?: WebModelContextInitOptions):
   const native = readCurrentModelContext();
   if (!native) {
     throw new Error('modelContext is not available');
+  }
+
+  // Some browser hosts expose a frozen native context through non-configurable
+  // own properties. It is already usable and cannot legally be wrapped.
+  if (!canReplaceModelContext(document) || !canReplaceModelContext(navigator)) {
+    return;
   }
 
   // 3. Resolve transport before mutating either browser surface.

--- a/packages/webmcp-ts-sdk/src/browser-server.ts
+++ b/packages/webmcp-ts-sdk/src/browser-server.ts
@@ -191,7 +191,11 @@ export class BrowserMcpServer extends EventTarget implements ModelContextWithExt
     });
     this.native = native;
     this.ownerDocument = globalThis.document ?? null;
-    if (native) {
+    if (
+      native &&
+      typeof native.addEventListener === 'function' &&
+      typeof native.removeEventListener === 'function'
+    ) {
       this.nativeToolChangeListener = () => {
         if (this.closed) return;
         this.nativeToolChangeQueue = this.nativeToolChangeQueue.then(async () => {


### PR DESCRIPTION
## Why

The Codex in-app browser exposes a working native modelContext as a frozen own property, but its compatibility surface does not implement EventTarget. The v5 global bundle assumed both event methods and replaceable properties, so auto-initialization failed before page tools could continue normally.

The current WebMCP draft defines ModelContext as an EventTarget and document.modelContext as SameObject: https://webmachinelearning.github.io/webmcp/#model-context-container. This patch remains aligned with that standard while degrading safely for older host-provided compatibility surfaces.

## What changed

- Subscribe to native toolchange events only when both listener methods exist.
- Preserve native modelContext properties when the host marks them non-configurable.
- Cover both replaceable legacy contexts and immutable host contexts with regression tests.
- Add a patch changeset for @mcp-b/webmcp-ts-sdk and @mcp-b/global; the fixed release group will produce the 5.0.1 train.

## Verification

- pnpm build
- pnpm typecheck
- vp check
- pnpm test:unit
- pnpm release:check
- In-app browser: native registration, discovery, and execution pass with no console warnings or errors.