### PR TITLE
docs(docs): add Codex site tools compatibility guide

### DIFF
--- a/.agents/skills/docs-authoring/SKILL.md
+++ b/.agents/skills/docs-authoring/SKILL.md
@@ -30,10 +30,10 @@ pages, groups, and hierarchy. Read it first.
 | **Explanation**   | `explanation/`                   | Understanding-oriented |
 
 Every package gets an `overview` page and a `reference` page under
-`packages/<name>/`. The `reference/webmcp/` pages route proposal details to
-upstream sources and sit in the same tab.
+`packages/<name>/`. The `reference/webmcp/` pages route proposal and platform
+details to upstream sources and sit in the same tab.
 `explanation/design/spec-status-and-limitations` keeps its legacy URL but is a
-reference directory in the **WebMCP proposal** navigation group.
+reference directory in the **WebMCP platforms and agents** navigation group.
 
 ### Key files
 
@@ -104,6 +104,7 @@ If a concept is covered on multiple pages, one page owns it. All others link to 
 | WebMCP vs MCP                     | Chrome's external `compare-mcp` guide                             |
 | WebMCP API sources                | `reference/webmcp/standard-api`                                   |
 | Declarative API                   | `reference/webmcp/declarative-api`                                |
+| Codex site tools compatibility    | `reference/webmcp/codex-site-tools`                               |
 | WebMCP and MCP-B extensions       | `explanation/strict-core-vs-mcp-b-extensions`                     |
 | Runtime layering / initialization | `explanation/architecture/runtime-layering`                       |
 | Transports and bridges            | `explanation/architecture/transports-and-bridges`                 |
@@ -241,13 +242,14 @@ This is critical. WebMCP is an active **Web Machine Learning Community Group pro
 | Declarative API       | https://developer.chrome.com/docs/ai/webmcp/declarative-api   |
 | Use cases             | https://developer.chrome.com/docs/ai/webmcp/use-cases         |
 | Best practices        | https://developer.chrome.com/docs/ai/webmcp/best-practices    |
+| Build tools           | https://developer.chrome.com/docs/ai/webmcp/build-tools       |
 | WebMCP and MCP        | https://developer.chrome.com/docs/ai/webmcp/compare-mcp       |
 | Evaluation            | https://developer.chrome.com/docs/ai/webmcp/evals             |
 | Secure tools          | https://developer.chrome.com/docs/ai/webmcp/secure-tools      |
 | Chrome DevTools panel | https://developer.chrome.com/docs/devtools/application/webmcp |
 | Chrome DevTools MCP   | https://github.com/ChromeDevTools/chrome-devtools-mcp         |
 
-**Chrome team tools and demos:**
+**Chrome-linked experimental tools and demos:**
 
 | Topic                                           | URL                                                                                                 | Local clone                                  |
 | ----------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------- |
@@ -255,7 +257,15 @@ This is critical. WebMCP is an active **Web Machine Learning Community Group pro
 | Tool Inspector source                           | https://github.com/beaufortfrancois/model-context-tool-inspector                                    | `webmcp-tools/model-context-tool-inspector/` |
 | webmcp-tools repo (demos + utilities)           | https://github.com/GoogleChromeLabs/webmcp-tools                                                    | `webmcp-tools/`                              |
 | Live WebMCP explainer                           | https://googlechromelabs.github.io/webmcp-tools/demos/explainer/                                    | `webmcp-tools/demos/explainer/`              |
-| Awesome WebMCP list                             | `webmcp-tools/AWESOME_WEBMCP.md`                                                                    | `webmcp-tools/AWESOME_WEBMCP.md`             |
+| Awesome WebMCP list                             | https://github.com/GoogleChromeLabs/webmcp-tools/blob/main/AWESOME_WEBMCP.md                        | `webmcp-tools/AWESOME_WEBMCP.md`             |
+
+**OpenAI product documentation (link to these, don't re-document):**
+
+| Topic                    | URL                                                                                      |
+| ------------------------ | ---------------------------------------------------------------------------------------- |
+| Codex site tools         | https://learn.chatgpt.com/docs/webmcp                                                    |
+| ChatGPT built-in browser | https://learn.chatgpt.com/docs/browser                                                   |
+| Site tools Help Center   | https://help.openai.com/en/articles/20001423-using-site-tools-in-the-chatgpt-desktop-app |
 
 **Rules for proposal vs. package content:**
 
@@ -269,14 +279,16 @@ This is critical. WebMCP is an active **Web Machine Learning Community Group pro
 - When showing the proposal working, prefer the Chrome team's [live explainer](https://googlechromelabs.github.io/webmcp-tools/demos/explainer/) or an individual demo from `GoogleChromeLabs/webmcp-tools` rather than recreating it.
 - Security model documentation should summarize our approach but link to the draft's [security and privacy considerations](https://webmachinelearning.github.io/webmcp/#security-and-privacy-considerations) and Chrome's [secure tools guidance](https://developer.chrome.com/docs/ai/webmcp/secure-tools) for the full threat model.
 - When mentioning native Chrome support, link to the [Model Context Tool Inspector](https://chromewebstore.google.com/detail/webmcp-model-context-tool/gbpdfapgefenggkahomfgkhfehlcenpd) extension recommended by Chrome's WebMCP documentation. Do not describe it as an officially supported Google product.
+- When documenting Codex site tools, link to OpenAI for availability, setup, security, and current limitations. Keep our page dated and limited to independently observed compatibility differences. Do not treat those observations as permanent product behavior or generalize them to Chrome, Codex CLI, or the Codex IDE extension.
 
 **Page-specific guidance:**
 
-| Our page                               | What to keep                                     | What to defer upstream                                                                          |
-| -------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
-| `reference/webmcp/standard-api.mdx`    | Upstream source map and MCP-B package boundary   | API tables, signatures, dictionaries, and algorithms → Community Group draft                    |
-| `reference/webmcp/declarative-api.mdx` | Upstream source map and MCP-B coverage links     | Attributes, events, schema synthesis, and browser behavior → Chrome and Community Group sources |
-| `explanation/what-is-webmcp.mdx`       | High-level "what and why", ecosystem positioning | Detailed API walkthrough → link to the Community Group draft                                    |
+| Our page                                | What to keep                                     | What to defer upstream                                                                          |
+| --------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `reference/webmcp/standard-api.mdx`     | Upstream source map and MCP-B package boundary   | API tables, signatures, dictionaries, and algorithms → Community Group draft                    |
+| `reference/webmcp/declarative-api.mdx`  | Upstream source map and MCP-B coverage links     | Attributes, events, schema synthesis, and browser behavior → Chrome and Community Group sources |
+| `reference/webmcp/codex-site-tools.mdx` | Dated compatibility observations and source map  | Availability, setup, product security, and supported features → OpenAI                          |
+| `explanation/what-is-webmcp.mdx`        | High-level "what and why", ecosystem positioning | Detailed API walkthrough → link to the Community Group draft                                    |
 
 ### What we own (document fully)
 

--- a/apps/documentation-website/docs.json
+++ b/apps/documentation-website/docs.json
@@ -189,11 +189,12 @@
             "pages": ["packages/index"]
           },
           {
-            "group": "WebMCP proposal",
+            "group": "WebMCP platforms and agents",
             "pages": [
               "explanation/design/spec-status-and-limitations",
               "reference/webmcp/standard-api",
-              "reference/webmcp/declarative-api"
+              "reference/webmcp/declarative-api",
+              "reference/webmcp/codex-site-tools"
             ]
           },
           {

--- a/apps/documentation-website/explanation/design/spec-status-and-limitations.mdx
+++ b/apps/documentation-website/explanation/design/spec-status-and-limitations.mdx
@@ -27,44 +27,57 @@ Check the implementation source when making a release decision.
 
 ## Chrome developer documentation
 
-| Resource                                                                       | Use it for                                            |
-| ------------------------------------------------------------------------------ | ----------------------------------------------------- |
-| [WebMCP overview](https://developer.chrome.com/docs/ai/webmcp)                 | Chrome setup, availability, and limitations           |
-| [Imperative API](https://developer.chrome.com/docs/ai/webmcp/imperative-api)   | JavaScript registration, discovery, and execution     |
-| [Declarative API](https://developer.chrome.com/docs/ai/webmcp/declarative-api) | Form attributes, submission, events, and focus states |
-| [User journeys](https://developer.chrome.com/docs/ai/webmcp/use-cases)         | Candidate tasks and tool boundaries                   |
-| [Best practices](https://developer.chrome.com/docs/ai/webmcp/best-practices)   | Tool names, schemas, outputs, and lifecycle design    |
-| [Tool security](https://developer.chrome.com/docs/ai/webmcp/secure-tools)      | Guidance for sites that expose tools                  |
-| [Agent security](https://developer.chrome.com/docs/agents/security)            | Guidance for agents that consume tools                |
-| [WebMCP and MCP](https://developer.chrome.com/docs/ai/webmcp/compare-mcp)      | Browser API and client-server protocol differences    |
+| Resource                                                                                     | Use it for                                            |
+| -------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| [WebMCP and AI agents](https://developer.chrome.com/docs/ai/agents)                          | Chrome's WebMCP and agent resource hub                |
+| [WebMCP overview](https://developer.chrome.com/docs/ai/webmcp)                               | Chrome setup, availability, and limitations           |
+| [Imperative API](https://developer.chrome.com/docs/ai/webmcp/imperative-api)                 | JavaScript registration, discovery, and execution     |
+| [Declarative API](https://developer.chrome.com/docs/ai/webmcp/declarative-api)               | Form attributes, submission, events, and focus states |
+| [User journeys](https://developer.chrome.com/docs/ai/webmcp/use-cases)                       | Candidate tasks and tool boundaries                   |
+| [Best practices](https://developer.chrome.com/docs/ai/webmcp/best-practices)                 | Tool names, schemas, outputs, and lifecycle design    |
+| [Build tools around user workflows](https://developer.chrome.com/docs/ai/webmcp/build-tools) | User goals, initial state, recovery, and evaluation   |
+| [Tool security](https://developer.chrome.com/docs/ai/webmcp/secure-tools)                    | Guidance for sites that expose tools                  |
+| [Agent security](https://developer.chrome.com/docs/agents/security)                          | Guidance for agents that consume tools                |
+| [WebMCP and MCP](https://developer.chrome.com/docs/ai/webmcp/compare-mcp)                    | Browser API and client-server protocol differences    |
+
+## Codex and ChatGPT
+
+| Resource                                                                                                       | Use it for                                                     |
+| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [OpenAI site tools documentation](https://learn.chatgpt.com/docs/webmcp)                                       | Current Codex and ChatGPT Work support in the built-in browser |
+| [Codex site tools compatibility](/reference/webmcp/codex-site-tools)                                           | Dated observations compared with the Community Group draft     |
+| [OpenAI WebMCP case study](https://developers.openai.com/blog/automating-repetitive-work-at-openai-with-codex) | Runme's browser-side tools in a Codex workflow                 |
 
 ## Inspection and testing tools
 
-| Resource                                                                                                                            | Use it for                                              |
-| ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| [Chrome DevTools WebMCP panel](https://developer.chrome.com/docs/devtools/application/webmcp)                                       | Inspecting schemas, invoking tools, and reviewing calls |
-| [Model Context Tool Inspector](https://chromewebstore.google.com/detail/webmcp-model-context-tool/gbpdfapgefenggkahomfgkhfehlcenpd) | Manual and model-assisted tool inspection               |
-| [Chrome DevTools MCP WebMCP tools](https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/docs/tool-reference.md#webmcp)   | Letting a coding agent inspect and invoke page tools    |
-| [Lighthouse registered tools audit](https://developer.chrome.com/docs/lighthouse/agentic-browsing/registered-webmcp-tools)          | Listing tools discovered on a page                      |
-| [Lighthouse schema validity audit](https://developer.chrome.com/docs/lighthouse/agentic-browsing/webmcp-schema-validity)            | Finding declarative schema problems                     |
-| [WebMCP eval guidance](https://developer.chrome.com/docs/ai/webmcp/evals)                                                           | Designing deterministic tests and model evaluations     |
-| [WebMCP Evals](https://github.com/GoogleChromeLabs/webmcp-tools/tree/main/webmcp-evals)                                             | Running experimental model evaluations                  |
-| [GoogleChromeLabs WebMCP tools](https://github.com/GoogleChromeLabs/webmcp-tools)                                                   | Experimental utilities, eval tooling, and demos         |
+| Resource                                                                                                                            | Use it for                                                                           |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [Chrome DevTools WebMCP panel](https://developer.chrome.com/docs/devtools/application/webmcp)                                       | Manual inspection and invocation; use the MCP reference below for coding-agent setup |
+| [Model Context Tool Inspector](https://chromewebstore.google.com/detail/webmcp-model-context-tool/gbpdfapgefenggkahomfgkhfehlcenpd) | Manual and model-assisted tool inspection                                            |
+| [Chrome DevTools MCP WebMCP tools](https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/docs/tool-reference.md#webmcp)   | Letting a coding agent inspect and invoke page tools                                 |
+| [Lighthouse registered tools audit](https://developer.chrome.com/docs/lighthouse/agentic-browsing/registered-webmcp-tools)          | Listing tools discovered on a page                                                   |
+| [Lighthouse schema validity audit](https://developer.chrome.com/docs/lighthouse/agentic-browsing/webmcp-schema-validity)            | Finding declarative schema problems                                                  |
+| [Lighthouse agentic browsing requirements](https://developer.chrome.com/docs/lighthouse/agentic-browsing/scoring)                   | Category availability, prerequisites, and scoring model                              |
+| [WebMCP eval guidance](https://developer.chrome.com/docs/ai/webmcp/evals)                                                           | Designing deterministic tests and model evaluations                                  |
+| [WebMCP Evals](https://github.com/GoogleChromeLabs/webmcp-tools/blob/main/webmcp-evals/README.md)                                   | Deterministic smoke tests and experimental model evaluations                         |
+| [GoogleChromeLabs WebMCP tools](https://github.com/GoogleChromeLabs/webmcp-tools)                                                   | Experimental utilities, eval tooling, and demos                                      |
 
 <Note>
   GoogleChromeLabs projects are experimental and are not officially supported Google products. Use
   the Chrome developer documentation above for supported Chrome guidance.
 </Note>
 
-## Frameworks, automation, and examples
+## Frameworks, demos, and community
 
-| Resource                                                                                       | Use it for                                      |
-| ---------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| [Angular WebMCP](https://angular.dev/ai/webmcp)                                                | Angular lifecycle, forms, and testing guidance  |
-| [Puppeteer WebMCP](https://pptr.dev/guides/webmcp)                                             | Programmatic discovery and browser testing      |
-| [GoogleChromeLabs explainer](https://googlechromelabs.github.io/webmcp-tools/demos/explainer/) | Runnable comparison and WebMCP examples         |
-| [WebMCP Studio](https://github.com/GoogleChromeLabs/webmcp-tools/tree/main/webmcp-studio)      | Experimental prompt-driven site instrumentation |
-| [Awesome WebMCP](https://github.com/webmachinelearning/awesome-webmcp)                         | Community-maintained ecosystem directory        |
+| Resource                                                                                                        | Use it for                                                                           |
+| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [Angular WebMCP](https://angular.dev/ai/webmcp)                                                                 | Angular lifecycle, forms, and testing guidance                                       |
+| [Puppeteer WebMCP](https://pptr.dev/guides/webmcp)                                                              | Programmatic discovery and browser testing                                           |
+| [GoogleChromeLabs explainer](https://googlechromelabs.github.io/webmcp-tools/demos/explainer/)                  | Runnable comparison and WebMCP examples                                              |
+| [WebMCP Page Agent](https://googlechromelabs.github.io/webmcp-tools/demos/page-agent/)                          | Gemini-powered, polyfill-backed consumer demo                                        |
+| [WebMCP Studio](https://github.com/GoogleChromeLabs/webmcp-tools/tree/main/webmcp-studio)                       | Experimental Gemini CLI or Antigravity workflow for generating WebMCP code and evals |
+| [Awesome WebMCP community directory](https://github.com/webmachinelearning/awesome-webmcp)                      | Community-maintained ecosystem directory                                             |
+| [GoogleChromeLabs WebMCP catalog](https://github.com/GoogleChromeLabs/webmcp-tools/blob/main/AWESOME_WEBMCP.md) | Experimental demos, libraries, and tools                                             |
 
 Angular and Puppeteer label their WebMCP APIs experimental. Follow their own
 documentation for compatibility and release requirements.

--- a/apps/documentation-website/index.mdx
+++ b/apps/documentation-website/index.mdx
@@ -1,7 +1,15 @@
 ---
 title: 'WebMCP documentation and MCP-B packages'
-description: 'Use official WebMCP and Chrome resources for browser behavior, and use these docs for @mcp-b packages and integrations.'
-keywords: ['WebMCP documentation', 'Chrome WebMCP', 'MCP-B packages', 'polyfill', 'React']
+description: 'Use official WebMCP, Chrome, and OpenAI resources for platform behavior, and use these docs for @mcp-b packages and integrations.'
+keywords:
+  [
+    'WebMCP documentation',
+    'Chrome WebMCP',
+    'Codex site tools',
+    'MCP-B packages',
+    'polyfill',
+    'React',
+  ]
 icon: 'house'
 mode: 'custom'
 ---
@@ -15,8 +23,8 @@ import { LiveLandingTool } from '/snippets-jsx/live-landing-tool.jsx';
         <h1 className="docs-landing-title">WebMCP documentation and MCP-B packages</h1>
 
         <p className="docs-landing-lead">
-          Use the upstream WebMCP and Chrome documentation for the browser platform. Use this site
-          for <code>@mcp-b/*</code> packages, integrations, and project-specific guidance.
+          Use upstream WebMCP, Chrome, and OpenAI documentation for platform behavior. Use this
+          site for <code>@mcp-b/*</code> packages, integrations, and compatibility notes.
         </p>
 
         <div className="docs-landing-links">
@@ -44,10 +52,10 @@ import { LiveLandingTool } from '/snippets-jsx/live-landing-tool.jsx';
 
       <div className="docs-landing-two-up">
         <div className="docs-landing-list-card">
-          <p className="docs-landing-kicker">WebMCP and Chrome</p>
+          <p className="docs-landing-kicker">WebMCP platforms and agents</p>
           <p className="docs-landing-body">
-            Find the current proposal, native browser behavior, demos, security guidance, and
-            Chrome tooling upstream.
+            Find the current proposal, implementation documentation, compatibility notes, demos,
+            security guidance, and tools.
           </p>
           <ul>
             <li>
@@ -55,6 +63,9 @@ import { LiveLandingTool } from '/snippets-jsx/live-landing-tool.jsx';
             </li>
             <li>
               <a href="https://developer.chrome.com/docs/ai/webmcp">Chrome WebMCP documentation</a>
+            </li>
+            <li>
+              <a href="/reference/webmcp/codex-site-tools">Codex site tools compatibility</a>
             </li>
             <li>
               <a href="/explanation/design/spec-status-and-limitations">
@@ -101,8 +112,9 @@ import { LiveLandingTool } from '/snippets-jsx/live-landing-tool.jsx';
         <h2 className="docs-landing-heading">Try a registered WebMCP tool.</h2>
         <p className="docs-landing-section-copy">
           This page registers <code>get_docs_info</code> through{' '}
-          <code>document.modelContext</code>. Call it with a compatible browser agent, then follow
-          the <a href="/tutorials/first-tool">first tool tutorial</a> to register your own.
+          <code>document.modelContext</code>. If site tools are available in ChatGPT's built-in
+          browser, ask Codex to call it. You can also use another compatible browser agent. Then
+          follow the <a href="/tutorials/first-tool">first tool tutorial</a> to register your own.
         </p>
       </div>
 

--- a/apps/documentation-website/reference/webmcp/codex-site-tools.mdx
+++ b/apps/documentation-website/reference/webmcp/codex-site-tools.mdx
@@ -1,0 +1,132 @@
+---
+title: 'Codex site tools compatibility'
+description: "Dated comparison of Codex site tools in ChatGPT's built-in browser with the WebMCP Community Group draft."
+keywords: ['Codex WebMCP', 'site tools', 'ChatGPT browser', 'document.modelContext']
+sidebarTitle: 'Codex site tools'
+icon: 'robot'
+---
+
+OpenAI calls its WebMCP implementation **site tools**. The [official site tools
+documentation](https://learn.chatgpt.com/docs/webmcp) owns availability, setup,
+security, and supported features. This page records an independent compatibility
+snapshot from August 27, 2026. It is not an OpenAI release document or a formal
+conformance claim.
+
+## Authoritative sources
+
+| Source                                                                                                            | Owns                                                       |
+| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| [OpenAI site tools documentation](https://learn.chatgpt.com/docs/webmcp)                                          | Product availability, setup, security, API example, limits |
+| [OpenAI Help Center](https://help.openai.com/en/articles/20001423-using-site-tools-in-the-chatgpt-desktop-app)    | User-facing availability, scope, and controls              |
+| [ChatGPT built-in browser](https://learn.chatgpt.com/docs/browser)                                                | Browser profiles and supported Codex surfaces              |
+| [WebMCP Community Group draft](https://webmachinelearning.github.io/webmcp/)                                      | Proposed WebMCP interfaces, algorithms, and security model |
+| [Runme and WebMCP with Codex](https://developers.openai.com/blog/automating-repetitive-work-at-openai-with-codex) | First-party example of a WebMCP workflow                   |
+
+OpenAI documents site tools for ChatGPT Work and Codex in the ChatGPT desktop
+app's built-in browser. This snapshot does not cover Chrome, Codex CLI, or the
+Codex IDE extension. Check OpenAI's documentation for current model, account,
+workspace, and rollout requirements.
+
+## Test scope
+
+| Field          | Value                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------- |
+| Date           | August 27, 2026                                                                             |
+| Agent          | Codex with GPT-5.6 Sol                                                                      |
+| Browser        | ChatGPT desktop app's built-in browser; build identifier unavailable                        |
+| Host           | macOS                                                                                       |
+| Test page      | `http://127.0.0.1:41739` top-level page with `window.isSecureContext === true`              |
+| Runtime        | `document.modelContext` provided by ChatGPT's built-in browser, without MCP-B or a polyfill |
+| Draft baseline | WebMCP Draft Community Group Report dated August 26, 2026                                   |
+
+One manual probe produced the observations below. Its [fixtures and captured
+results](https://github.com/WebMCP-org/npm-packages/tree/main/docs/research/codex-site-tools-2026-08-27)
+are preserved in this repository. The test covered imperative registration,
+discovery, execution, results, registration lifecycle, declarative markup, a
+same-origin iframe, invalid registrations, origin options, and the `tools`
+Permissions Policy. It did not run the Web Platform Tests or test every app build,
+account configuration, origin, or active-call cancellation path.
+
+Agent integration results came from Codex's agent-facing tool bridge. Page API
+results came from JavaScript calls inside the test page. The probe inspected but
+did not call the undocumented `codexGetTools` or `codexExecuteTool` properties.
+
+## Agent integration
+
+| Capability                 | Observed on August 27, 2026                                                                                                        | Source                  |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| Top-level imperative tools | Discovered and invoked tools registered with `document.modelContext.registerTool()`                                                | OpenAI and manual probe |
+| Tool listing               | Included name, title, description, input schema, `readOnlyHint`, `untrustedContentHint`, origin, and page URL                      | Manual probe            |
+| Dynamic registration       | Refreshed the agent's tool list after registration and abort-based removal                                                         | Manual probe            |
+| Page lifecycle             | Removed tools after navigation                                                                                                     | OpenAI and manual probe |
+| Inputs                     | Passed a JavaScript object to the tool callback                                                                                    | Manual probe            |
+| Results                    | Preserved JSON-compatible objects, arrays, primitives, and `null`; converted `undefined` to `null`                                 | Manual probe            |
+| Non-JSON results           | Rejected `BigInt` and circular values                                                                                              | Manual probe            |
+| Declarative tools          | Did not discover tools declared through form attributes                                                                            | OpenAI and manual probe |
+| Iframe tools               | OpenAI documents them as unsupported; the tested same-origin child had no `document.modelContext`, so it could not register a tool | OpenAI and manual probe |
+| Disabled `tools` policy    | Discovered a registration from a response with `Permissions-Policy: tools=()`                                                      | Manual probe            |
+
+The draft's execution algorithm does not validate calls against `inputSchema`. In
+Codex agent-bridge probes, missing required values, wrong types, extra properties,
+and out-of-range values reached the handler. Validate and authorize every call in
+application code.
+
+On the agent path, `undefined` became `null`. The draft's public execution path
+treats `undefined`, `BigInt`, and circular results as serialization failures. It
+does not specify the browser agent's result transport.
+
+## Page API comparison
+
+The draft defines `getTools()` and `executeTool()` for in-page JavaScript agents. A
+browser agent receives an implementation-defined observation instead, and the
+draft does not prescribe the format used to expose tools to it. This table compares
+direct page calls only.
+
+| Surface                          | August 26 draft                                                                                                                       | Observed in Codex                                                                                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `document.modelContext`          | Same-object `ModelContext` in secure contexts                                                                                         | Repeated reads returned the same object                                                                                                           |
+| `navigator.modelContext`         | Not defined                                                                                                                           | `undefined`                                                                                                                                       |
+| Event interface                  | `ModelContext` extends `EventTarget` and exposes `ontoolchange`                                                                       | `addEventListener()` and `ontoolchange` were absent                                                                                               |
+| `registerTool()`                 | Resolves with `undefined` after registration; supports registration `signal`                                                          | Resolved with `undefined`; abort-based removal worked                                                                                             |
+| `getTools()`                     | Returns entries with a deep-copied object `inputSchema`, owning `window`, and origin                                                  | Returned a serialized JSON schema and origin, without `window`                                                                                    |
+| `executeTool()` input and result | Accepts an optional object input, defaults to `{}`, and resolves to a JSON string                                                     | Accepted an object, rejected a JSON string, and resolved to a JSON string; omitted input was untested                                             |
+| Tool callback                    | Receives `(input, { signal })`                                                                                                        | Received the input, but callback options did not contain an `AbortSignal`                                                                         |
+| `tools` Permissions Policy       | Keeps the interface exposed, but methods reject `NotAllowedError` when denied; default allowlist is `'self'`                          | The interface remained present and `registerTool()` resolved under `Permissions-Policy: tools=()`                                                 |
+| `exposedTo`                      | Lists cross-origin callers that may discover and execute a registration; rejects invalid or non-trustworthy URLs with `SecurityError` | Accepted `http://insecure.example`; cross-document behavior was untested because the child lacked `modelContext`                                  |
+| `fromOrigins`                    | Requests tools from matching cross-origin descendant documents; rejects invalid or non-trustworthy URLs with `SecurityError`          | Accepted `http://insecure.example`; cross-document behavior was untested                                                                          |
+| Registration errors              | Duplicate, empty, or invalid names and empty descriptions reject with `InvalidStateError`; schema serialization errors propagate      | Named cases rejected with a plain `Object` whose `name` and `message` were `null` and JSON form was `{}`; a circular schema rejected with `Error` |
+
+The object also exposed `codexGetTools` and `codexExecuteTool` during the test.
+They are undocumented product internals, not WebMCP APIs. Do not call them or use
+their presence for feature detection.
+
+## Compatibility notes
+
+| Constraint                 | Compatibility requirement                                                                                                                      |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Feature detection          | Check that `document.modelContext?.registerTool` is a function.                                                                                |
+| Registration location      | Register site tools in the top-level page.                                                                                                     |
+| Callback options           | Treat callback options as optional and use `options?.signal` when present. The draft requires it.                                              |
+| Input enforcement          | Validate and authorize inputs in application code.                                                                                             |
+| Results                    | Return JSON-compatible values.                                                                                                                 |
+| Cleanup                    | Use the registration `AbortSignal` to remove tools when their application scope ends.                                                          |
+| Origin and policy controls | The tested build accepted non-trustworthy origin options and allowed registration under `tools=()`. Cross-document enforcement was not tested. |
+| Product internals          | Use only documented WebMCP properties, not `codexGetTools` or `codexExecuteTool`.                                                              |
+
+These observations describe the tested build. Recheck the [official site tools
+documentation](https://learn.chatgpt.com/docs/webmcp) and this page's date before
+depending on them.
+
+## Codex with Chrome DevTools MCP
+
+[Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) is a
+separate integration that lets Codex inspect a Chrome instance through MCP. Its
+experimental WebMCP category exposes tool discovery and execution; see the
+[WebMCP tool
+reference](https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/docs/tool-reference.md#webmcp).
+This integration is separate from site tools in ChatGPT's built-in browser.
+
+Codex site tools use the current page directly and do not require the MCP-B local
+relay. For other implementations, see [WebMCP resources and
+status](/explanation/design/spec-status-and-limitations) and the [package
+index](/packages/index).

--- a/apps/documentation-website/reference/webmcp/standard-api.mdx
+++ b/apps/documentation-website/reference/webmcp/standard-api.mdx
@@ -8,12 +8,14 @@ icon: 'brackets-curly'
 `document.modelContext` belongs to the evolving WebMCP Community Group
 proposal. Use the source that owns the behavior you need.
 
-## Upstream sources
+## Platform and implementation sources
 
 | Need                                             | Source                                                                                                          |
 | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
 | Proposed interface, dictionaries, and algorithms | [WebMCP Community Group draft](https://webmachinelearning.github.io/webmcp/)                                    |
 | Chrome's implemented imperative behavior         | [Chrome imperative API](https://developer.chrome.com/docs/ai/webmcp/imperative-api)                             |
+| Codex site tools behavior                        | [OpenAI site tools documentation](https://learn.chatgpt.com/docs/webmcp)                                        |
+| Independent Codex compatibility snapshot         | [Codex site tools compatibility](/reference/webmcp/codex-site-tools)                                            |
 | Browser and agent availability                   | [WebMCP implementation status](https://github.com/webmachinelearning/webmcp/blob/main/implementation-status.md) |
 | Executable browser conformance                   | [Web Platform Tests](https://wpt.fyi/results/webmcp)                                                            |
 | Ambient TypeScript declarations                  | [Upstream `webmcp-types`](https://github.com/webmachinelearning/webmcp-types)                                   |

--- a/apps/documentation-website/start-here/choose-your-path.mdx
+++ b/apps/documentation-website/start-here/choose-your-path.mdx
@@ -1,7 +1,8 @@
 ---
 title: 'Choose your path'
-description: 'Choose between upstream WebMCP and Chrome resources or MCP-B package documentation.'
-keywords: ['WebMCP', 'Chrome WebMCP', 'MCP-B packages', 'getting started', 'runtime']
+description: 'Choose between upstream WebMCP platform and agent resources or MCP-B package documentation.'
+keywords:
+  ['WebMCP', 'Chrome WebMCP', 'Codex site tools', 'MCP-B packages', 'getting started', 'runtime']
 icon: 'signs-post'
 mode: 'wide'
 ---
@@ -9,10 +10,10 @@ mode: 'wide'
 WebMCP platform behavior and MCP-B package behavior have different sources of truth. Start with the
 lane that matches your question.
 
-## WebMCP and Chrome
+## WebMCP platforms and agents
 
-Use upstream documentation for the proposal, native browser support, security guidance, demos, and
-Chrome tooling.
+Use upstream documentation for the proposal, implementations, security guidance, demos, and
+agent tooling.
 
 <CardGroup cols={2}>
   <Card
@@ -28,6 +29,10 @@ Chrome tooling.
     href="https://webmachinelearning.github.io/webmcp/"
   >
     Read the authoritative proposal and follow its issue tracker and test suite.
+  </Card>
+  <Card title="Codex compatibility snapshot" icon="robot" href="/reference/webmcp/codex-site-tools">
+    Compare OpenAI's official support with dated observations from Codex in ChatGPT's built-in
+    browser.
   </Card>
   <Card
     title="Resources and implementation status"

--- a/docs/research/codex-site-tools-2026-08-27/README.md
+++ b/docs/research/codex-site-tools-2026-08-27/README.md
@@ -1,0 +1,61 @@
+# Codex site tools compatibility probe
+
+This directory preserves the fixtures and results behind the August 27, 2026
+[Codex site tools compatibility snapshot](../../../apps/documentation-website/reference/webmcp/codex-site-tools.mdx).
+
+## Environment
+
+- macOS
+- ChatGPT desktop app's built-in browser; build identifier unavailable
+- Codex with GPT-5.6 Sol
+- `http://127.0.0.1:41739`, where `window.isSecureContext === true`
+- `document.modelContext` supplied by the built-in browser
+- no MCP-B package or WebMCP polyfill
+- WebMCP Community Group draft dated August 26, 2026, reviewed at
+  [webmachinelearning/webmcp@41d12f0](https://github.com/webmachinelearning/webmcp/tree/41d12f057167ccf5954dbcf49d99502cb6c84491)
+
+## Run the fixtures
+
+```bash
+node docs/research/codex-site-tools-2026-08-27/server.mjs
+```
+
+Open `http://127.0.0.1:41739` in ChatGPT's built-in browser. The server maps
+each HTML filename to a page at the same origin. It adds
+`Permissions-Policy: tools=()` only for `policy-disabled.html`.
+
+| Fixture                | Probe                                                      |
+| ---------------------- | ---------------------------------------------------------- |
+| `imperative.html`      | Page API, registration errors, origin options, and cleanup |
+| `lifecycle.html`       | Dynamic registration, invocation, and abort-based removal  |
+| `results.html`         | Agent-bridge result values and errors                      |
+| `declarative.html`     | Declarative form discovery                                 |
+| `iframe-parent.html`   | Same-origin iframe discovery and child-frame page API      |
+| `policy-disabled.html` | Registration and discovery with the tools policy disabled  |
+
+The captured page output is in [imperative-results.json](./imperative-results.json).
+Manually recorded agent-bridge calls are in [agent-results.json](./agent-results.json).
+
+## Manual agent procedure
+
+1. Open the root page and refresh the agent's site-tool list. Record the
+   `codex_probe_echo` listing, then call it with each
+   `toolInputCalls.*.value.input` object.
+2. Open `results.html`, refresh the list, and call
+   `codex_probe_result_shape` once for each `mode` under `toolResultCalls`.
+3. Open `lifecycle.html`, select **Register dynamic tool**, refresh the list,
+   call `codex_probe_dynamic` with `{}`, select **Abort registration**, and
+   refresh again. Register it once more, navigate away, and confirm the previous
+   page's tools disappear.
+4. Open `declarative.html` and `iframe-parent.html`, refreshing the list on
+   each page. Record whether either fixture contributes a tool and inspect the
+   child frame's displayed `document.modelContext` type.
+5. Open `policy-disabled.html`, confirm that page registration resolves,
+   refresh the list, and record whether `codex_probe_policy_disabled` appears.
+
+## Limits
+
+This is a dated manual compatibility probe, not a Web Platform Test run or an
+OpenAI conformance claim. It covers one app build and account configuration.
+It does not cover every origin, cross-document execution, or cancellation of an
+active call.

--- a/docs/research/codex-site-tools-2026-08-27/agent-results.json
+++ b/docs/research/codex-site-tools-2026-08-27/agent-results.json
@@ -1,0 +1,155 @@
+{
+  "agentToolListing": {
+    "fixtureUrl": "http://127.0.0.1:41739/",
+    "tool": {
+      "name": "codex_probe_echo",
+      "title": "Codex probe echo",
+      "description": "Returns the supplied message and records the execution callback shape.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "required": ["message"],
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "untrustedContentHint": false
+      },
+      "origin": "http://127.0.0.1:41739",
+      "pageUrl": "http://127.0.0.1:41739/"
+    }
+  },
+  "toolInputCalls": {
+    "valid": {
+      "ok": true,
+      "value": {
+        "hasSignal": false,
+        "input": {
+          "count": 2,
+          "message": "agent object"
+        },
+        "inputType": "object",
+        "signalAborted": null
+      }
+    },
+    "missingRequired": {
+      "ok": true,
+      "value": {
+        "hasSignal": false,
+        "input": {
+          "count": 2
+        },
+        "inputType": "object",
+        "signalAborted": null
+      }
+    },
+    "wrongType": {
+      "ok": true,
+      "value": {
+        "hasSignal": false,
+        "input": {
+          "count": "two",
+          "message": 7
+        },
+        "inputType": "object",
+        "signalAborted": null
+      }
+    },
+    "extraProperty": {
+      "ok": true,
+      "value": {
+        "hasSignal": false,
+        "input": {
+          "message": "extra",
+          "unexpected": true
+        },
+        "inputType": "object",
+        "signalAborted": null
+      }
+    },
+    "belowMinimum": {
+      "ok": true,
+      "value": {
+        "hasSignal": false,
+        "input": {
+          "count": 0,
+          "message": "minimum"
+        },
+        "inputType": "object",
+        "signalAborted": null
+      }
+    }
+  },
+  "toolResultCalls": {
+    "object": {
+      "ok": true,
+      "value": {
+        "nested": {
+          "count": 1
+        },
+        "ok": true
+      }
+    },
+    "array": {
+      "ok": true,
+      "value": ["alpha", 2, false]
+    },
+    "string": {
+      "ok": true,
+      "value": "plain string"
+    },
+    "number": {
+      "ok": true,
+      "value": 42
+    },
+    "boolean": {
+      "ok": true,
+      "value": true
+    },
+    "null": {
+      "ok": true,
+      "value": null
+    },
+    "undefined": {
+      "ok": true,
+      "value": null
+    },
+    "bigint": {
+      "ok": false,
+      "name": "Error",
+      "message": "Browser Use encountered an error interacting with this webpage: Error: WebMCP tool result is not JSON-serializable."
+    },
+    "circular": {
+      "ok": false,
+      "name": "Error",
+      "message": "Browser Use encountered an error interacting with this webpage: Error: WebMCP tool result is not JSON-serializable."
+    },
+    "throw": {
+      "ok": false,
+      "name": "Error",
+      "message": "Browser Use encountered an error interacting with this webpage: Error: probe throw"
+    },
+    "reject_string": {
+      "ok": false,
+      "name": "Error",
+      "message": "Browser Use encountered an error interacting with this webpage: probe rejection"
+    }
+  },
+  "manualObservations": {
+    "topLevelImperativeTool": "discovered and invoked",
+    "dynamicRegistration": "tool list refreshed after registration and abort-based removal",
+    "navigation": "tools from the previous page were removed",
+    "declarativeTool": "not discovered",
+    "sameOriginIframeTool": "not discovered; child document.modelContext was undefined",
+    "disabledToolsPolicy": "registration resolved and the agent discovered the tool",
+    "activeCallCancellation": "not tested"
+  }
+}

--- a/docs/research/codex-site-tools-2026-08-27/declarative.html
+++ b/docs/research/codex-site-tools-2026-08-27/declarative.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Codex WebMCP declarative probe</title>
+  </head>
+  <body>
+    <h1>Codex WebMCP declarative probe</h1>
+    <p>This page does not load a WebMCP polyfill.</p>
+
+    <form
+      id="product-search"
+      toolname="codex_probe_product_search"
+      tooltitle="Product search"
+      tooldescription="Searches the probe catalog by query, category, quantity, and availability."
+    >
+      <label>
+        Query
+        <input name="query" type="search" required minlength="2" maxlength="40" />
+      </label>
+      <label>
+        Category
+        <select name="category">
+          <option value="all">All</option>
+          <option value="books">Books</option>
+          <option value="hardware">Hardware</option>
+        </select>
+      </label>
+      <label>
+        Quantity
+        <input name="quantity" type="number" min="1" max="10" value="1" />
+      </label>
+      <label>
+        <input name="in_stock" type="checkbox" checked />
+        In stock only
+      </label>
+      <button type="submit">Search</button>
+    </form>
+
+    <pre id="results">Waiting for an invocation…</pre>
+
+    <script>
+      const form = document.querySelector('#product-search');
+      const results = document.querySelector('#results');
+      const events = [];
+
+      for (const eventName of ['toolactivated', 'toolcanceled', 'submit']) {
+        form.addEventListener(eventName, (event) => {
+          events.push({
+            type: event.type,
+            submitter: event.submitter?.tagName ?? null,
+            agentInvoked: event.agentInvoked ?? null,
+            toolInput: event.toolInput ?? null,
+          });
+          results.textContent = JSON.stringify(events, null, 2);
+          if (event.type === 'submit') event.preventDefault();
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/docs/research/codex-site-tools-2026-08-27/iframe-child.html
+++ b/docs/research/codex-site-tools-2026-08-27/iframe-child.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Codex WebMCP child-frame probe</title>
+  </head>
+  <body>
+    <h1>Child frame</h1>
+    <pre id="results">Starting…</pre>
+    <script>
+      const results = document.querySelector('#results');
+      const context = document.modelContext;
+      results.textContent = `document.modelContext: ${typeof context}`;
+      if (context) {
+        context
+          .registerTool({
+            name: 'codex_probe_child_frame',
+            description: 'Returns the child frame URL.',
+            inputSchema: { type: 'object', properties: {} },
+            execute: async () => ({ url: location.href }),
+          })
+          .then(() => {
+            results.textContent += '\nRegistered child-frame tool';
+          })
+          .catch((error) => {
+            results.textContent += `\n${error.name}: ${error.message}`;
+          });
+      }
+    </script>
+  </body>
+</html>

--- a/docs/research/codex-site-tools-2026-08-27/iframe-parent.html
+++ b/docs/research/codex-site-tools-2026-08-27/iframe-parent.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Codex WebMCP iframe probe</title>
+  </head>
+  <body>
+    <h1>Codex WebMCP iframe probe</h1>
+    <p>This page does not load a WebMCP polyfill.</p>
+    <iframe src="/iframe-child.html" title="Same-origin WebMCP child"></iframe>
+  </body>
+</html>

--- a/docs/research/codex-site-tools-2026-08-27/imperative-results.json
+++ b/docs/research/codex-site-tools-2026-08-27/imperative-results.json
@@ -1,0 +1,184 @@
+[
+  {
+    "name": "secureContext",
+    "value": true
+  },
+  {
+    "name": "document.modelContext",
+    "value": "object"
+  },
+  {
+    "name": "navigator.modelContext",
+    "value": "undefined"
+  },
+  {
+    "name": "sameDocumentObject",
+    "value": true
+  },
+  {
+    "name": "navigatorAlias",
+    "value": false
+  },
+  {
+    "name": "prototype",
+    "value": "Object"
+  },
+  {
+    "name": "prototypeProperties",
+    "value": [
+      "__defineGetter__",
+      "__defineSetter__",
+      "__lookupGetter__",
+      "__lookupSetter__",
+      "__proto__",
+      "constructor",
+      "hasOwnProperty",
+      "isPrototypeOf",
+      "propertyIsEnumerable",
+      "toLocaleString",
+      "toString",
+      "valueOf"
+    ]
+  },
+  {
+    "name": "ownProperties",
+    "value": ["codexExecuteTool", "codexGetTools", "executeTool", "getTools", "registerTool"]
+  },
+  {
+    "name": "methods",
+    "value": {
+      "registerTool": "function",
+      "getTools": "function",
+      "executeTool": "function",
+      "addEventListener": "undefined",
+      "ontoolchange": false
+    }
+  },
+  {
+    "name": "registerResult",
+    "value": {
+      "type": "undefined",
+      "value": null
+    }
+  },
+  {
+    "name": "getTools",
+    "value": [
+      {
+        "name": "codex_probe_echo",
+        "title": "Codex probe echo",
+        "description": "Returns the supplied message and records the execution callback shape.",
+        "inputSchema": "{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"},\"count\":{\"type\":\"integer\",\"minimum\":1}},\"required\":[\"message\"],\"additionalProperties\":false}",
+        "annotations": {
+          "readOnlyHint": true,
+          "untrustedContentHint": false
+        },
+        "origin": "http://127.0.0.1:41739",
+        "hasWindow": false
+      }
+    ]
+  },
+  {
+    "name": "executeTool.objectInput",
+    "value": {
+      "type": "string",
+      "value": "{\"input\":{\"message\":\"direct object\",\"count\":2},\"inputType\":\"object\",\"hasSignal\":false,\"signalAborted\":null}"
+    }
+  },
+  {
+    "name": "executeTool.stringInput",
+    "value": {
+      "type": "object",
+      "constructor": "Error",
+      "name": "Error",
+      "message": "WebMCP executeTool requires an object input.",
+      "string": "Error: WebMCP executeTool requires an object input.",
+      "keys": [],
+      "json": "{}"
+    }
+  },
+  {
+    "name": "duplicateRegistration",
+    "value": {
+      "type": "object",
+      "constructor": "Object",
+      "name": null,
+      "message": null,
+      "string": "[object Object]",
+      "keys": [],
+      "json": "{}"
+    }
+  },
+  {
+    "name": "emptyName",
+    "value": {
+      "type": "object",
+      "constructor": "Object",
+      "name": null,
+      "message": null,
+      "string": "[object Object]",
+      "keys": [],
+      "json": "{}"
+    }
+  },
+  {
+    "name": "invalidName",
+    "value": {
+      "type": "object",
+      "constructor": "Object",
+      "name": null,
+      "message": null,
+      "string": "[object Object]",
+      "keys": [],
+      "json": "{}"
+    }
+  },
+  {
+    "name": "emptyDescription",
+    "value": {
+      "type": "object",
+      "constructor": "Object",
+      "name": null,
+      "message": null,
+      "string": "[object Object]",
+      "keys": [],
+      "json": "{}"
+    }
+  },
+  {
+    "name": "circularSchema",
+    "value": {
+      "type": "object",
+      "constructor": "Error",
+      "name": "Error",
+      "message": "Converting circular structure to JSON\n    --> starting at object with constructor 'Object'\n    --- property 'self' closes the circle",
+      "string": "Error: Converting circular structure to JSON\n    --> starting at object with constructor 'Object'\n    --- property 'self' closes the circle",
+      "keys": [],
+      "json": "{}"
+    }
+  },
+  {
+    "name": "preAbortedRegistration",
+    "value": {
+      "type": "string",
+      "constructor": "String",
+      "name": null,
+      "message": null,
+      "string": "pre-aborted registration",
+      "keys": [],
+      "json": "\"pre-aborted registration\""
+    }
+  },
+  {
+    "name": "insecureExposedTo",
+    "value": "resolved"
+  },
+  {
+    "name": "insecureFromOrigins",
+    "value": "resolved"
+  },
+  {
+    "name": "abortUnregisters",
+    "value": true
+  }
+]

--- a/docs/research/codex-site-tools-2026-08-27/imperative.html
+++ b/docs/research/codex-site-tools-2026-08-27/imperative.html
@@ -1,0 +1,231 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Codex WebMCP imperative probe</title>
+  </head>
+  <body>
+    <h1>Codex WebMCP imperative probe</h1>
+    <p>This page does not load a WebMCP polyfill.</p>
+    <pre id="results">Running…</pre>
+
+    <script>
+      const results = [];
+      const record = (name, value) => {
+        results.push({ name, value });
+        document.querySelector('#results').textContent = JSON.stringify(results, null, 2);
+        console.log('[codex-webmcp-probe]', name, value);
+      };
+
+      const describeError = (error) => ({
+        type: typeof error,
+        constructor: error?.constructor?.name ?? null,
+        name: error?.name ?? null,
+        message: error?.message ?? null,
+        string: String(error),
+        keys: error && typeof error === 'object' ? Object.keys(error) : [],
+        json: (() => {
+          try {
+            return JSON.stringify(error);
+          } catch {
+            return null;
+          }
+        })(),
+      });
+
+      const context = document.modelContext;
+      record('secureContext', window.isSecureContext);
+      record('document.modelContext', typeof context);
+      record('navigator.modelContext', typeof navigator.modelContext);
+      record('sameDocumentObject', context === document.modelContext);
+      record('navigatorAlias', context === navigator.modelContext);
+
+      if (context) {
+        const prototype = Object.getPrototypeOf(context);
+        record('prototype', prototype?.constructor?.name ?? null);
+        record(
+          'prototypeProperties',
+          prototype ? Object.getOwnPropertyNames(prototype).sort() : []
+        );
+        record('ownProperties', Object.getOwnPropertyNames(context).sort());
+        record('methods', {
+          registerTool: typeof context.registerTool,
+          getTools: typeof context.getTools,
+          executeTool: typeof context.executeTool,
+          addEventListener: typeof context.addEventListener,
+          ontoolchange: 'ontoolchange' in context,
+        });
+
+        let toolchangeCount = 0;
+        context.addEventListener?.('toolchange', () => {
+          toolchangeCount += 1;
+          record('toolchange', toolchangeCount);
+        });
+
+        const registration = new AbortController();
+        const echoTool = {
+          name: 'codex_probe_echo',
+          title: 'Codex probe echo',
+          description: 'Returns the supplied message and records the execution callback shape.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              message: { type: 'string' },
+              count: { type: 'integer', minimum: 1 },
+            },
+            required: ['message'],
+            additionalProperties: false,
+          },
+          annotations: {
+            readOnlyHint: true,
+            untrustedContentHint: false,
+          },
+          execute: async (input, options) => ({
+            input,
+            inputType: typeof input,
+            hasSignal: options?.signal instanceof AbortSignal,
+            signalAborted: options?.signal?.aborted ?? null,
+          }),
+        };
+
+        Promise.resolve()
+          .then(async () => {
+            const registrationResult = await context.registerTool(echoTool, {
+              signal: registration.signal,
+            });
+            record('registerResult', {
+              type: typeof registrationResult,
+              value: registrationResult ?? null,
+            });
+
+            if (typeof context.getTools === 'function') {
+              const tools = await context.getTools();
+              record(
+                'getTools',
+                tools.map((tool) => ({
+                  name: tool.name,
+                  title: tool.title,
+                  description: tool.description,
+                  inputSchema: tool.inputSchema,
+                  annotations: tool.annotations,
+                  origin: tool.origin,
+                  hasWindow: 'window' in tool,
+                }))
+              );
+
+              const echo = tools.find((tool) => tool.name === echoTool.name);
+              if (echo && typeof context.executeTool === 'function') {
+                for (const candidate of [
+                  { label: 'objectInput', input: { message: 'direct object', count: 2 } },
+                  {
+                    label: 'stringInput',
+                    input: JSON.stringify({ message: 'direct string', count: 3 }),
+                  },
+                ]) {
+                  try {
+                    const value = await context.executeTool(echo, candidate.input);
+                    record(`executeTool.${candidate.label}`, {
+                      type: typeof value,
+                      value,
+                    });
+                  } catch (error) {
+                    record(`executeTool.${candidate.label}`, describeError(error));
+                  }
+                }
+              }
+            }
+
+            try {
+              await context.registerTool(echoTool);
+              record('duplicateRegistration', 'resolved');
+            } catch (error) {
+              record('duplicateRegistration', describeError(error));
+            }
+
+            for (const candidate of [
+              { label: 'emptyName', tool: { ...echoTool, name: '' } },
+              { label: 'invalidName', tool: { ...echoTool, name: 'invalid name' } },
+              {
+                label: 'emptyDescription',
+                tool: { ...echoTool, name: 'empty_description', description: '' },
+              },
+            ]) {
+              try {
+                await context.registerTool(candidate.tool);
+                record(candidate.label, 'resolved');
+              } catch (error) {
+                record(candidate.label, describeError(error));
+              }
+            }
+
+            const circularSchema = { type: 'object' };
+            circularSchema.self = circularSchema;
+            try {
+              await context.registerTool({
+                ...echoTool,
+                name: 'circular_schema',
+                inputSchema: circularSchema,
+              });
+              record('circularSchema', 'resolved');
+            } catch (error) {
+              record('circularSchema', describeError(error));
+            }
+
+            const preAborted = new AbortController();
+            preAborted.abort('pre-aborted registration');
+            try {
+              await context.registerTool(
+                { ...echoTool, name: 'pre_aborted_registration' },
+                { signal: preAborted.signal }
+              );
+              record('preAbortedRegistration', 'resolved');
+            } catch (error) {
+              record('preAbortedRegistration', describeError(error));
+            }
+
+            const insecureExposure = new AbortController();
+            try {
+              await context.registerTool(
+                { ...echoTool, name: 'insecure_exposure' },
+                {
+                  signal: insecureExposure.signal,
+                  exposedTo: ['http://insecure.example'],
+                }
+              );
+              record('insecureExposedTo', 'resolved');
+            } catch (error) {
+              record('insecureExposedTo', describeError(error));
+            } finally {
+              insecureExposure.abort('probe cleanup');
+            }
+
+            if (typeof context.getTools === 'function') {
+              try {
+                await context.getTools({ fromOrigins: ['http://insecure.example'] });
+                record('insecureFromOrigins', 'resolved');
+              } catch (error) {
+                record('insecureFromOrigins', describeError(error));
+              }
+            }
+
+            const removable = new AbortController();
+            await context.registerTool(
+              { ...echoTool, name: 'codex_probe_removable' },
+              { signal: removable.signal }
+            );
+            removable.abort('probe cleanup');
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            if (typeof context.getTools === 'function') {
+              const tools = await context.getTools();
+              record(
+                'abortUnregisters',
+                !tools.some((tool) => tool.name === 'codex_probe_removable')
+              );
+            }
+          })
+          .catch((error) => record('setupError', describeError(error)));
+      }
+    </script>
+  </body>
+</html>

--- a/docs/research/codex-site-tools-2026-08-27/lifecycle.html
+++ b/docs/research/codex-site-tools-2026-08-27/lifecycle.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Codex WebMCP lifecycle probe</title>
+  </head>
+  <body>
+    <h1>Codex WebMCP lifecycle probe</h1>
+    <p>This page does not load a WebMCP polyfill.</p>
+    <button id="register" type="button">Register dynamic tool</button>
+    <button id="unregister" type="button">Abort registration</button>
+    <pre id="results">Waiting…</pre>
+
+    <script>
+      const results = document.querySelector('#results');
+      let controller;
+      let calls = 0;
+
+      const render = (message) => {
+        results.textContent = `${message}\nCalls: ${calls}`;
+        console.log('[codex-webmcp-probe]', message);
+      };
+
+      document.querySelector('#register').addEventListener('click', async () => {
+        controller?.abort();
+        controller = new AbortController();
+        try {
+          await document.modelContext.registerTool(
+            {
+              name: 'codex_probe_dynamic',
+              description: 'Returns the current call count after incrementing it.',
+              inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+              execute: async (_input, { signal } = {}) => {
+                calls += 1;
+                render(`Executed; signal present: ${signal instanceof AbortSignal}`);
+                return { calls };
+              },
+            },
+            { signal: controller.signal }
+          );
+          render('Registered');
+        } catch (error) {
+          render(`${error?.name ?? 'Error'}: ${error?.message ?? String(error)}`);
+        }
+      });
+
+      document.querySelector('#unregister').addEventListener('click', () => {
+        controller?.abort();
+        render('Registration aborted');
+      });
+
+      render(`document.modelContext: ${typeof document.modelContext}`);
+    </script>
+  </body>
+</html>

--- a/docs/research/codex-site-tools-2026-08-27/policy-disabled.html
+++ b/docs/research/codex-site-tools-2026-08-27/policy-disabled.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Codex WebMCP Permissions Policy probe</title>
+  </head>
+  <body>
+    <h1>Codex WebMCP Permissions Policy probe</h1>
+    <p>The response sets <code>Permissions-Policy: tools=()</code>.</p>
+    <pre id="results">Starting…</pre>
+    <script>
+      const results = document.querySelector('#results');
+      const context = document.modelContext;
+      results.textContent = `document.modelContext: ${typeof context}`;
+
+      if (context) {
+        context
+          .registerTool({
+            name: 'codex_probe_policy_disabled',
+            description:
+              'Reports whether Codex discovers a tool when the tools policy is disabled.',
+            inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+            execute: async () => ({ discovered: true }),
+          })
+          .then(() => {
+            results.textContent += '\nRegistration resolved';
+          })
+          .catch((error) => {
+            results.textContent += `\n${error?.name ?? 'Error'}: ${error?.message ?? String(error)}`;
+          });
+      }
+    </script>
+  </body>
+</html>

--- a/docs/research/codex-site-tools-2026-08-27/results.html
+++ b/docs/research/codex-site-tools-2026-08-27/results.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Codex WebMCP result probe</title>
+  </head>
+  <body>
+    <h1>Codex WebMCP result probe</h1>
+    <p>This page does not load a WebMCP polyfill.</p>
+    <pre id="results">Registering…</pre>
+
+    <script>
+      const results = document.querySelector('#results');
+      const circular = { value: 'circular' };
+      circular.self = circular;
+
+      const values = {
+        object: () => ({ ok: true, nested: { count: 1 } }),
+        array: () => ['alpha', 2, false],
+        string: () => 'plain string',
+        number: () => 42,
+        boolean: () => true,
+        null: () => null,
+        undefined: () => undefined,
+        bigint: () => 1n,
+        circular: () => circular,
+        throw: () => {
+          throw new Error('probe throw');
+        },
+        reject_string: () => Promise.reject('probe rejection'),
+      };
+
+      document.modelContext
+        .registerTool({
+          name: 'codex_probe_result_shape',
+          description: 'Returns the selected JavaScript value or error for compatibility testing.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              mode: { type: 'string', enum: Object.keys(values) },
+            },
+            required: ['mode'],
+            additionalProperties: false,
+          },
+          execute: async ({ mode }) => values[mode](),
+        })
+        .then(() => {
+          results.textContent = 'Registered';
+        })
+        .catch((error) => {
+          results.textContent = `${error?.name ?? 'Error'}: ${error?.message ?? String(error)}`;
+        });
+    </script>
+  </body>
+</html>

--- a/docs/research/codex-site-tools-2026-08-27/server.mjs
+++ b/docs/research/codex-site-tools-2026-08-27/server.mjs
@@ -1,0 +1,30 @@
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(fileURLToPath(import.meta.url));
+
+createServer(async (request, response) => {
+  const pathname = new URL(request.url, 'http://127.0.0.1').pathname;
+  const filename = pathname === '/' ? 'imperative.html' : pathname.slice(1);
+
+  if (filename.includes('/') || filename.includes('..')) {
+    response.writeHead(404).end();
+    return;
+  }
+
+  try {
+    const body = await readFile(join(root, filename));
+    if (filename === 'policy-disabled.html') {
+      response.setHeader('Permissions-Policy', 'tools=()');
+    }
+    response.setHeader(
+      'Content-Type',
+      filename.endsWith('.html') ? 'text/html; charset=utf-8' : 'text/plain'
+    );
+    response.writeHead(200).end(body);
+  } catch {
+    response.writeHead(404).end();
+  }
+}).listen(41739, '127.0.0.1');


### PR DESCRIPTION
## Summary

Move fast-changing WebMCP platform guidance to its first-party owners and add a dated, evidence-backed Codex site tools compatibility reference.

## Problem

The documentation mixed MCP-B-owned guidance with browser and agent details that now change faster than this site. Chrome, the Web Machine Learning Community Group, and OpenAI all maintain current first-party material.

## Decision

- Treat the Community Group draft, Chrome documentation, and OpenAI site tools documentation as the sources of truth for their platforms.
- Keep this site focused on routing, MCP-B package boundaries, and a dated independent compatibility snapshot.
- Preserve the Codex probe fixtures and captured results so the snapshot can be audited and repeated.

## Changes

- Expand the resource directory with current Chrome guides, Lighthouse audits, DevTools tooling, GoogleChromeLabs experiments, Angular, Puppeteer, and community catalogs.
- Add a Codex site tools reference comparing the August 27, 2026 ChatGPT built-in-browser behavior with the August 26 Community Group draft.
- Record imperative, declarative, iframe, lifecycle, result-shape, origin-option, and Permissions Policy probes under `docs/research/`.
- Advertise the Codex reference from the docs home page, path chooser, standard API source map, and navigation.
- Update the documentation authoring rules so future edits preserve these source-of-truth boundaries.

## First-party sources

- [WebMCP Community Group draft](https://webmachinelearning.github.io/webmcp/)
- [Chrome WebMCP and AI agents hub](https://developer.chrome.com/docs/ai/agents)
- [Chrome WebMCP documentation](https://developer.chrome.com/docs/ai/webmcp)
- [Chrome build-tools guidance](https://developer.chrome.com/docs/ai/webmcp/build-tools)
- [Chrome DevTools MCP WebMCP reference](https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/docs/tool-reference.md#webmcp)
- [GoogleChromeLabs WebMCP tools](https://github.com/GoogleChromeLabs/webmcp-tools)
- [OpenAI site tools documentation](https://learn.chatgpt.com/docs/webmcp)
- [OpenAI built-in browser documentation](https://learn.chatgpt.com/docs/browser)
- [OpenAI WebMCP case study](https://developers.openai.com/blog/automating-repetitive-work-at-openai-with-codex)

## Related issues

None.

## Safety and scope

This changes documentation and probe artifacts only. It does not change package contracts or runtime behavior. No changeset is needed.

## Checklist

- [x] PR title follows conventional commit format
- [x] Followed the AI Contribution Manifesto and kept platform ownership explicit
- [x] Followed the MCP-B package boundaries
- [x] Selected documentation, artifact, and existing repository validation layers
- [x] Code builds without errors
- [x] Unit tests pass
- [x] Committed files pass lint and formatting
- [x] TypeScript compiles
- [x] Changeset not needed for documentation-only changes

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm test:unit`
- `vp check <all 18 committed files>`
- `pnpm build` in `apps/documentation-website`
- `pnpm exec mintlify broken-links` in `apps/documentation-website`
- `jq empty docs/research/codex-site-tools-2026-08-27/{imperative-results,agent-results}.json`
- Served every tracked probe page and verified HTTP 200; verified `Permissions-Policy: tools=()` on the policy fixture
- Checked every newly added external URL; all resolve except the OpenAI Help Center blocks command-line requests, and the evidence link will resolve after merge
- `pnpm audit:ci:critical` — passed with zero critical advisories
- `pnpm audit:ci:high` — informational failure from 19 existing high advisories in landing-page dependencies

The repository-wide `vp check` also saw an unrelated unstaged formatting issue in `apps/documentation-website/packages/webmcp-types/reference.mdx`. That file is not in this PR; the committed-file check passes.

## Screenshots

Not included. Mintlify validation, broken-link validation, and a local browser rendering check passed.