### PR TITLE
docs(docs): make explanation paths more visual

### DIFF
--- a/apps/documentation-website/explanation/architecture/runtime-layering.mdx
+++ b/apps/documentation-website/explanation/architecture/runtime-layering.mdx
@@ -14,12 +14,18 @@ initializes those layers and connects the selected browser transport.
 
 Global initialization preserves the browser-shaped programming model:
 
-1. Install or adopt a compatible `document.modelContext` implementation.
-2. Capture that implementation as the native context.
-3. Wrap it with `BrowserMcpServer`, which mirrors core registrations down to
-   the captured context.
-4. Replace `document.modelContext` with the wrapper and connect the selected
-   transport in the background.
+<Columns cols={3}>
+  <Card title="1. Browser context" icon="browser">
+    A native implementation or `@mcp-b/webmcp-polyfill` supplies the browser surface.
+  </Card>
+  <Card title="2. MCP-B runtime" icon="layer-group">
+    `BrowserMcpServer` mirrors core tools, adds MCP-B extensions, and becomes
+    `document.modelContext`.
+  </Card>
+  <Card title="3. Selected transport" icon="plug">
+    The transport connects explicit MCP clients without changing page code.
+  </Card>
+</Columns>
 
 Initialization returns no server handle. Application and library code keeps
 using `document.modelContext` normally, whether the active implementation is

--- a/apps/documentation-website/explanation/architecture/tool-lifecycle-and-context-replacement.mdx
+++ b/apps/documentation-website/explanation/architecture/tool-lifecycle-and-context-replacement.mdx
@@ -12,6 +12,17 @@ Agents should see only actions that are currently
 meaningful and authorized, with descriptions and schemas that match the active
 application context.
 
+```mermaid
+flowchart TD
+  Current["Current registration"] -->|"context changes or cleanup"| Abort["Abort the old signal"]
+  Abort --> Removed["Old tool is removed"]
+  Removed -->|"another tool is valid"| Register["Register replacement<br/>with a new signal"]
+  Removed -->|"no tool is valid"| None["No registered tool"]
+  Register --> Current
+  Removed -. "toolchange" .-> Refresh["Consumers refresh their catalog"]
+  Register -. "toolchange" .-> Refresh
+```
+
 The current registration pattern ties a tool to an `AbortSignal`:
 
 ```ts title="Registration lifetime"

--- a/apps/documentation-website/explanation/architecture/transports-and-bridges.mdx
+++ b/apps/documentation-website/explanation/architecture/transports-and-bridges.mdx
@@ -11,6 +11,22 @@ a native mechanism for document-tree discovery. MCP-B transports solve a
 different problem: carrying MCP protocol messages between an explicit client
 and server.
 
+<Columns cols={2}>
+  <Card title="Native document discovery" icon="window-restore">
+    **Child:** registers and executes the tool. **Parent:** discovers its descriptor through the
+    browser.
+
+    Execution remains in the child document.
+
+  </Card>
+  <Card title="MCP-B iframe bridge" icon="bridge">
+    **Parent:** MCP client. **Child:** MCP server and tool handler.
+
+    A transport carries MCP messages across the frame boundary; execution remains in the child.
+
+  </Card>
+</Columns>
+
 ## Native cross-document discovery
 
 Native WebMCP stays within the browser's document model:

--- a/apps/documentation-website/explanation/design/security-and-human-in-the-loop.mdx
+++ b/apps/documentation-website/explanation/design/security-and-human-in-the-loop.mdx
@@ -15,6 +15,17 @@ authorization or guarantee a confirmation prompt. Human review should follow
 consequence: financial, destructive, external-communication, and
 privacy-sensitive actions need stronger confirmation than read-only lookup.
 
+<Columns cols={2}>
+  <Card title="Context and signals" icon="circle-info">
+    Browser mediation, session identity, schemas, and annotations provide context. They do not
+    authorize a call or guarantee confirmation.
+  </Card>
+  <Card title="Enforced controls" icon="shield-halved">
+    The application validates input, authorizes the current user, and requires human review when the
+    consequence warrants it.
+  </Card>
+</Columns>
+
 The Community Group draft's [security and privacy
 considerations](https://webmachinelearning.github.io/webmcp/#security-and-privacy-considerations)
 cover the proposal's threat model. Chrome publishes separate guidance for

--- a/apps/documentation-website/explanation/design/spec-status-and-limitations.mdx
+++ b/apps/documentation-website/explanation/design/spec-status-and-limitations.mdx
@@ -9,58 +9,273 @@ WebMCP is a Draft Community Group Report. It is not a W3C Standard or a
 Standards Track document. The proposal, browser implementations, and MCP-B
 packages can change on separate schedules.
 
-Use this page as a directory. Each linked source owns the details in its row.
+Use this page as a directory. Each linked source owns the details on its card.
 
 ## Proposal and implementation status
 
-| Source                                                                                                   | Owns                                                  |
-| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| [WebMCP Community Group draft](https://webmachinelearning.github.io/webmcp/)                             | Proposed API, algorithms, and security considerations |
-| [WebMCP repository](https://github.com/webmachinelearning/webmcp)                                        | Explainers, issues, and proposal development          |
-| [Implementation status](https://github.com/webmachinelearning/webmcp/blob/main/implementation-status.md) | Browser and agent implementation links                |
-| [Web Platform Status](https://webstatus.dev/features/document-modelcontext)                              | Aggregated implementation and test status             |
-| [Chrome Status](https://chromestatus.com/feature/5117755740913664)                                       | Chrome rollout and experiment status                  |
-| [Web Platform Tests](https://wpt.fyi/results/webmcp)                                                     | Cross-browser conformance results                     |
+<CardGroup cols={2}>
+  <Card
+    title="WebMCP Community Group draft"
+    icon="users"
+    href="https://webmachinelearning.github.io/webmcp/"
+    horizontal
+  >
+    Proposed API, algorithms, and security considerations.
+  </Card>
+  <Card
+    title="WebMCP repository"
+    icon="github"
+    iconType="brands"
+    href="https://github.com/webmachinelearning/webmcp"
+    horizontal
+  >
+    Explainers, issues, and proposal development.
+  </Card>
+  <Card
+    title="Implementation status"
+    icon="github"
+    iconType="brands"
+    href="https://github.com/webmachinelearning/webmcp/blob/main/implementation-status.md"
+    horizontal
+  >
+    Browser and agent implementation links.
+  </Card>
+  <Card
+    title="Web Platform Status"
+    icon="globe"
+    href="https://webstatus.dev/features/document-modelcontext"
+    horizontal
+  >
+    Aggregated implementation and test status.
+  </Card>
+  <Card
+    title="Chrome Status"
+    icon="chrome"
+    iconType="brands"
+    href="https://chromestatus.com/feature/5117755740913664"
+    horizontal
+  >
+    Chrome rollout and experiment status.
+  </Card>
+  <Card title="Web Platform Tests" icon="flask" href="https://wpt.fyi/results/webmcp" horizontal>
+    Cross-browser conformance results.
+  </Card>
+</CardGroup>
 
 Do not infer compatibility from a cached browser version or copied API table.
 Check the implementation source when making a release decision.
 
 ## Chrome developer documentation
 
-| Resource                                                                                     | Use it for                                            |
-| -------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| [WebMCP and AI agents](https://developer.chrome.com/docs/ai/agents)                          | Chrome's WebMCP and agent resource hub                |
-| [WebMCP overview](https://developer.chrome.com/docs/ai/webmcp)                               | Chrome setup, availability, and limitations           |
-| [Imperative API](https://developer.chrome.com/docs/ai/webmcp/imperative-api)                 | JavaScript registration, discovery, and execution     |
-| [Declarative API](https://developer.chrome.com/docs/ai/webmcp/declarative-api)               | Form attributes, submission, events, and focus states |
-| [User journeys](https://developer.chrome.com/docs/ai/webmcp/use-cases)                       | Candidate tasks and tool boundaries                   |
-| [Best practices](https://developer.chrome.com/docs/ai/webmcp/best-practices)                 | Tool names, schemas, outputs, and lifecycle design    |
-| [Build tools around user workflows](https://developer.chrome.com/docs/ai/webmcp/build-tools) | User goals, initial state, recovery, and evaluation   |
-| [Tool security](https://developer.chrome.com/docs/ai/webmcp/secure-tools)                    | Guidance for sites that expose tools                  |
-| [Agent security](https://developer.chrome.com/docs/agents/security)                          | Guidance for agents that consume tools                |
-| [WebMCP and MCP](https://developer.chrome.com/docs/ai/webmcp/compare-mcp)                    | Browser API and client-server protocol differences    |
+<CardGroup cols={2}>
+  <Card
+    title="WebMCP and AI agents"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/ai/agents"
+    horizontal
+  >
+    Chrome's WebMCP and agent resource hub.
+  </Card>
+  <Card
+    title="WebMCP overview"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/ai/webmcp"
+    horizontal
+  >
+    Chrome setup, availability, and limitations.
+  </Card>
+  <Card
+    title="Imperative API"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/ai/webmcp/imperative-api"
+    horizontal
+  >
+    JavaScript registration, discovery, and execution.
+  </Card>
+  <Card
+    title="Declarative API"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/ai/webmcp/declarative-api"
+    horizontal
+  >
+    Form attributes, submission, events, and focus states.
+  </Card>
+  <Card
+    title="User journeys"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/ai/webmcp/use-cases"
+    horizontal
+  >
+    Candidate tasks and tool boundaries.
+  </Card>
+  <Card
+    title="Best practices"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/ai/webmcp/best-practices"
+    horizontal
+  >
+    Tool names, schemas, outputs, and lifecycle design.
+  </Card>
+  <Card
+    title="Build tools around user workflows"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/ai/webmcp/build-tools"
+    horizontal
+  >
+    User goals, initial state, recovery, and evaluation.
+  </Card>
+  <Card
+    title="Tool security"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/ai/webmcp/secure-tools"
+    horizontal
+  >
+    Guidance for sites that expose tools.
+  </Card>
+  <Card
+    title="Agent security"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/agents/security"
+    horizontal
+  >
+    Guidance for agents that consume tools.
+  </Card>
+  <Card
+    title="WebMCP and MCP"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/ai/webmcp/compare-mcp"
+    horizontal
+  >
+    Browser API and client-server protocol differences.
+  </Card>
+</CardGroup>
 
 ## Codex and ChatGPT
 
-| Resource                                                                                                       | Use it for                                                     |
-| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| [OpenAI site tools documentation](https://learn.chatgpt.com/docs/webmcp)                                       | Current Codex and ChatGPT Work support in the built-in browser |
-| [Codex site tools compatibility](/reference/webmcp/codex-site-tools)                                           | Dated observations compared with the Community Group draft     |
-| [OpenAI WebMCP case study](https://developers.openai.com/blog/automating-repetitive-work-at-openai-with-codex) | Runme's browser-side tools in a Codex workflow                 |
+<CardGroup cols={2}>
+  <Card
+    title="OpenAI site tools documentation"
+    icon="openai"
+    iconType="brands"
+    href="https://learn.chatgpt.com/docs/webmcp"
+    horizontal
+  >
+    Current Codex and ChatGPT Work support in the built-in browser.
+  </Card>
+  <Card
+    title="Codex site tools compatibility"
+    icon="robot"
+    href="/reference/webmcp/codex-site-tools"
+    horizontal
+  >
+    Dated observations compared with the Community Group draft.
+  </Card>
+  <Card
+    title="OpenAI WebMCP case study"
+    icon="openai"
+    iconType="brands"
+    href="https://developers.openai.com/blog/automating-repetitive-work-at-openai-with-codex"
+    horizontal
+  >
+    Runme's browser-side tools in a Codex workflow.
+  </Card>
+</CardGroup>
 
 ## Inspection and testing tools
 
-| Resource                                                                                                                            | Use it for                                                                           |
-| ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [Chrome DevTools WebMCP panel](https://developer.chrome.com/docs/devtools/application/webmcp)                                       | Manual inspection and invocation; use the MCP reference below for coding-agent setup |
-| [Model Context Tool Inspector](https://chromewebstore.google.com/detail/webmcp-model-context-tool/gbpdfapgefenggkahomfgkhfehlcenpd) | Manual and model-assisted tool inspection                                            |
-| [Chrome DevTools MCP WebMCP tools](https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/docs/tool-reference.md#webmcp)   | Letting a coding agent inspect and invoke page tools                                 |
-| [Lighthouse registered tools audit](https://developer.chrome.com/docs/lighthouse/agentic-browsing/registered-webmcp-tools)          | Listing tools discovered on a page                                                   |
-| [Lighthouse schema validity audit](https://developer.chrome.com/docs/lighthouse/agentic-browsing/webmcp-schema-validity)            | Finding declarative schema problems                                                  |
-| [Lighthouse agentic browsing requirements](https://developer.chrome.com/docs/lighthouse/agentic-browsing/scoring)                   | Category availability, prerequisites, and scoring model                              |
-| [WebMCP eval guidance](https://developer.chrome.com/docs/ai/webmcp/evals)                                                           | Designing deterministic tests and model evaluations                                  |
-| [WebMCP Evals](https://github.com/GoogleChromeLabs/webmcp-tools/blob/main/webmcp-evals/README.md)                                   | Deterministic smoke tests and experimental model evaluations                         |
-| [GoogleChromeLabs WebMCP tools](https://github.com/GoogleChromeLabs/webmcp-tools)                                                   | Experimental utilities, eval tooling, and demos                                      |
+<CardGroup cols={2}>
+  <Card
+    title="Chrome DevTools WebMCP panel"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/devtools/application/webmcp"
+    horizontal
+  >
+    Manual inspection and invocation.
+  </Card>
+  <Card
+    title="Model Context Tool Inspector"
+    icon="chrome"
+    iconType="brands"
+    href="https://chromewebstore.google.com/detail/webmcp-model-context-tool/gbpdfapgefenggkahomfgkhfehlcenpd"
+    horizontal
+  >
+    Manual and model-assisted tool inspection.
+  </Card>
+  <Card
+    title="Chrome DevTools MCP WebMCP tools"
+    icon="github"
+    iconType="brands"
+    href="https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/docs/tool-reference.md#webmcp"
+    horizontal
+  >
+    Let a coding agent inspect and invoke page tools.
+  </Card>
+  <Card
+    title="Lighthouse registered tools audit"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/lighthouse/agentic-browsing/registered-webmcp-tools"
+    horizontal
+  >
+    List tools discovered on a page.
+  </Card>
+  <Card
+    title="Lighthouse schema validity audit"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/lighthouse/agentic-browsing/webmcp-schema-validity"
+    horizontal
+  >
+    Find declarative schema problems.
+  </Card>
+  <Card
+    title="Lighthouse agentic browsing requirements"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/lighthouse/agentic-browsing/scoring"
+    horizontal
+  >
+    Category availability, prerequisites, and scoring model.
+  </Card>
+  <Card
+    title="WebMCP eval guidance"
+    icon="chrome"
+    iconType="brands"
+    href="https://developer.chrome.com/docs/ai/webmcp/evals"
+    horizontal
+  >
+    Design deterministic tests and model evaluations.
+  </Card>
+  <Card
+    title="WebMCP Evals"
+    icon="github"
+    iconType="brands"
+    href="https://github.com/GoogleChromeLabs/webmcp-tools/blob/main/webmcp-evals/README.md"
+    horizontal
+  >
+    Deterministic smoke tests and experimental model evaluations.
+  </Card>
+  <Card
+    title="GoogleChromeLabs WebMCP tools"
+    icon="github"
+    iconType="brands"
+    href="https://github.com/GoogleChromeLabs/webmcp-tools"
+    horizontal
+  >
+    Experimental utilities, eval tooling, and demos.
+  </Card>
+</CardGroup>
 
 <Note>
   GoogleChromeLabs projects are experimental and are not officially supported Google products. Use
@@ -69,15 +284,65 @@ Check the implementation source when making a release decision.
 
 ## Frameworks, demos, and community
 
-| Resource                                                                                                        | Use it for                                                                           |
-| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [Angular WebMCP](https://angular.dev/ai/webmcp)                                                                 | Angular lifecycle, forms, and testing guidance                                       |
-| [Puppeteer WebMCP](https://pptr.dev/guides/webmcp)                                                              | Programmatic discovery and browser testing                                           |
-| [GoogleChromeLabs explainer](https://googlechromelabs.github.io/webmcp-tools/demos/explainer/)                  | Runnable comparison and WebMCP examples                                              |
-| [WebMCP Page Agent](https://googlechromelabs.github.io/webmcp-tools/demos/page-agent/)                          | Gemini-powered, polyfill-backed consumer demo                                        |
-| [WebMCP Studio](https://github.com/GoogleChromeLabs/webmcp-tools/tree/main/webmcp-studio)                       | Experimental Gemini CLI or Antigravity workflow for generating WebMCP code and evals |
-| [Awesome WebMCP community directory](https://github.com/webmachinelearning/awesome-webmcp)                      | Community-maintained ecosystem directory                                             |
-| [GoogleChromeLabs WebMCP catalog](https://github.com/GoogleChromeLabs/webmcp-tools/blob/main/AWESOME_WEBMCP.md) | Experimental demos, libraries, and tools                                             |
+<CardGroup cols={2}>
+  <Card
+    title="Angular WebMCP"
+    icon="angular"
+    iconType="brands"
+    href="https://angular.dev/ai/webmcp"
+    horizontal
+  >
+    Angular lifecycle, forms, and testing guidance.
+  </Card>
+  <Card title="Puppeteer WebMCP" icon="browser" href="https://pptr.dev/guides/webmcp" horizontal>
+    Programmatic discovery and browser testing.
+  </Card>
+  <Card
+    title="GoogleChromeLabs explainer"
+    icon="google"
+    iconType="brands"
+    href="https://googlechromelabs.github.io/webmcp-tools/demos/explainer/"
+    horizontal
+  >
+    Runnable comparison and WebMCP examples.
+  </Card>
+  <Card
+    title="WebMCP Page Agent"
+    icon="google"
+    iconType="brands"
+    href="https://googlechromelabs.github.io/webmcp-tools/demos/page-agent/"
+    horizontal
+  >
+    Gemini-powered, polyfill-backed consumer demo.
+  </Card>
+  <Card
+    title="WebMCP Studio"
+    icon="github"
+    iconType="brands"
+    href="https://github.com/GoogleChromeLabs/webmcp-tools/tree/main/webmcp-studio"
+    horizontal
+  >
+    Experimental workflow for generating WebMCP code and evaluations.
+  </Card>
+  <Card
+    title="Awesome WebMCP community directory"
+    icon="github"
+    iconType="brands"
+    href="https://github.com/webmachinelearning/awesome-webmcp"
+    horizontal
+  >
+    Community-maintained ecosystem directory.
+  </Card>
+  <Card
+    title="GoogleChromeLabs WebMCP catalog"
+    icon="github"
+    iconType="brands"
+    href="https://github.com/GoogleChromeLabs/webmcp-tools/blob/main/AWESOME_WEBMCP.md"
+    horizontal
+  >
+    Experimental demos, libraries, and tools.
+  </Card>
+</CardGroup>
 
 Angular and Puppeteer label their WebMCP APIs experimental. Follow their own
 documentation for compatibility and release requirements.

--- a/apps/documentation-website/explanation/strict-core-vs-mcp-b-extensions.mdx
+++ b/apps/documentation-website/explanation/strict-core-vs-mcp-b-extensions.mdx
@@ -17,11 +17,20 @@ without depending on an MCP server or transport.
 
 ## Three related layers
 
-| Layer                 | Responsibility                                                      |
-| --------------------- | ------------------------------------------------------------------- |
-| WebMCP proposal       | Defines the evolving `document.modelContext` browser API            |
-| MCP-B portable layer  | Supplies package types, registration helpers, and polyfill behavior |
-| MCP-B extension layer | Adds MCP server features and transports around page tools           |
+```mermaid
+flowchart TB
+  subgraph Upstream["Community Group"]
+    Proposal["WebMCP proposal<br/>evolving document.modelContext API"]
+  end
+
+  subgraph Project["MCP-B packages"]
+    Portable["Portable layer<br/>types, helpers, polyfill"]
+    Extensions["Extension layer<br/>BrowserMcpServer, MCP features, transports"]
+    Portable -->|"extended by"| Extensions
+  end
+
+  Proposal -->|"target browser contract"| Portable
+```
 
 The live draft owns the exact `ModelContext` members and signatures. MCP-B may
 retain compatibility types or adapters while browser implementations converge.

--- a/apps/documentation-website/explanation/what-is-webmcp.mdx
+++ b/apps/documentation-website/explanation/what-is-webmcp.mdx
@@ -17,6 +17,18 @@ reuse that context without moving browser-only logic into a separate service.
 The application still validates inputs, enforces permissions, and asks for
 confirmation when the consequence warrants it.
 
+```mermaid
+sequenceDiagram
+  participant Site as Web application
+  participant Context as Browser WebMCP context
+  participant Agent as AI agent
+  Site->>Context: Register structured tools
+  Agent->>Context: Discover and invoke a tool
+  Context->>Site: Run the registered handler
+  Site-->>Context: Return a structured result
+  Context-->>Agent: Return the result
+```
+
 ## Learn about the proposal
 
 The [Community Group draft](https://webmachinelearning.github.io/webmcp/) owns

--- a/apps/documentation-website/index.mdx
+++ b/apps/documentation-website/index.mdx
@@ -19,24 +19,52 @@ import { LiveLandingTool } from '/snippets-jsx/live-landing-tool.jsx';
 <div className="docs-landing">
   <section className="docs-landing-hero">
     <div className="docs-landing-inner">
-      <div className="docs-landing-copy">
-        <h1 className="docs-landing-title">WebMCP documentation and MCP-B packages</h1>
+      <div className="docs-landing-hero-grid">
+        <div className="docs-landing-copy">
+          <h1 className="docs-landing-title">WebMCP documentation and MCP-B packages</h1>
 
-        <p className="docs-landing-lead">
-          Use upstream WebMCP, Chrome, and OpenAI documentation for platform behavior. Use this
-          site for <code>@mcp-b/*</code> packages, integrations, and compatibility notes.
-        </p>
+          <p className="docs-landing-lead">
+            Use upstream WebMCP and browser documentation for platform behavior. Use this site for{' '}
+            <code>@mcp-b/*</code> packages, integrations, and project-specific compatibility notes.
+          </p>
 
-        <div className="docs-landing-links">
-          <a
-            className="docs-landing-link docs-landing-link-primary"
-            href="https://developer.chrome.com/docs/ai/webmcp"
-          >
-            Read Chrome's WebMCP docs
-          </a>
-          <a className="docs-landing-link" href="/packages/index">
-            Browse MCP-B packages
-          </a>
+          <div className="docs-landing-links">
+            <a
+              className="docs-landing-link docs-landing-link-primary"
+              href="/start-here/choose-your-path"
+            >
+              Get started
+            </a>
+            <a className="docs-landing-link" href="/tutorials/first-tool">
+              Build your first tool
+            </a>
+            <a className="docs-landing-link" href="/packages/index">
+              Browse the packages
+            </a>
+          </div>
+        </div>
+
+        <div
+          className="docs-landing-hero-diagram"
+          role="img"
+          aria-label="WebMCP exposes website tools through the browser, MCP is a separate protocol, and MCP-B connects the two with runtime and transport packages."
+        >
+          <img
+            className="docs-landing-hero-diagram-svg docs-landing-hero-diagram-light"
+            src="/logo/mcp-b-architecture-light.svg"
+            alt=""
+            width="800"
+            height="420"
+            noZoom
+          />
+          <img
+            className="docs-landing-hero-diagram-svg docs-landing-hero-diagram-dark"
+            src="/logo/mcp-b-architecture-dark.svg"
+            alt=""
+            width="800"
+            height="420"
+            noZoom
+          />
         </div>
       </div>
     </div>
@@ -46,16 +74,33 @@ import { LiveLandingTool } from '/snippets-jsx/live-landing-tool.jsx';
   <section className="docs-landing-section">
     <div className="docs-landing-inner">
       <div className="docs-landing-section-head">
+        <p className="docs-landing-kicker">Live on this page</p>
+        <h2 className="docs-landing-heading">Try a registered WebMCP tool.</h2>
+        <p className="docs-landing-section-copy">
+          This page registers <code>get_docs_info</code> through{' '}
+          <code>document.modelContext</code>. Ask a compatible browser agent to call it, including
+          Codex when site tools are available. Then follow the{' '}
+          <a href="/tutorials/first-tool">first tool tutorial</a> to register your own.
+        </p>
+      </div>
+
+      <LiveLandingTool />
+    </div>
+
+  </section>
+
+  <section className="docs-landing-section docs-landing-section-end">
+    <div className="docs-landing-inner">
+      <div className="docs-landing-section-head">
         <p className="docs-landing-kicker">Choose a path</p>
         <h2 className="docs-landing-heading">Start with the source that owns your question.</h2>
       </div>
 
       <div className="docs-landing-two-up">
         <div className="docs-landing-list-card">
-          <p className="docs-landing-kicker">WebMCP platforms and agents</p>
+          <p className="docs-landing-kicker">WebMCP and browser agents</p>
           <p className="docs-landing-body">
-            Find the current proposal, implementation documentation, compatibility notes, demos,
-            security guidance, and tools.
+            Find the proposal, implementation documentation, compatibility notes, and tools.
           </p>
           <ul>
             <li>
@@ -65,16 +110,14 @@ import { LiveLandingTool } from '/snippets-jsx/live-landing-tool.jsx';
               <a href="https://developer.chrome.com/docs/ai/webmcp">Chrome WebMCP documentation</a>
             </li>
             <li>
+              <a href="https://learn.chatgpt.com/docs/webmcp">OpenAI site tools documentation</a>
+            </li>
+            <li>
               <a href="/reference/webmcp/codex-site-tools">Codex site tools compatibility</a>
             </li>
             <li>
               <a href="/explanation/design/spec-status-and-limitations">
                 Resources and implementation status
-              </a>
-            </li>
-            <li>
-              <a href="https://developer.chrome.com/docs/devtools/application/webmcp">
-                Chrome DevTools WebMCP panel
               </a>
             </li>
           </ul>
@@ -101,24 +144,6 @@ import { LiveLandingTool } from '/snippets-jsx/live-landing-tool.jsx';
           </ul>
         </div>
       </div>
-    </div>
-
-  </section>
-
-  <section className="docs-landing-section docs-landing-section-end">
-    <div className="docs-landing-inner">
-      <div className="docs-landing-section-head">
-        <p className="docs-landing-kicker">Live on this page</p>
-        <h2 className="docs-landing-heading">Try a registered WebMCP tool.</h2>
-        <p className="docs-landing-section-copy">
-          This page registers <code>get_docs_info</code> through{' '}
-          <code>document.modelContext</code>. If site tools are available in ChatGPT's built-in
-          browser, ask Codex to call it. You can also use another compatible browser agent. Then
-          follow the <a href="/tutorials/first-tool">first tool tutorial</a> to register your own.
-        </p>
-      </div>
-
-      <LiveLandingTool />
     </div>
 
   </section>


### PR DESCRIPTION
## Why

The documentation refresh deliberately sends browser-platform questions to their current owners, but the resulting pages became too text-heavy and the landing page lost its strongest visual anchor. This follow-up keeps the source-of-truth boundary while making architecture, lifecycle, trust, and resource relationships easier to scan.

## What changed

- Restores the existing responsive MCP-B architecture artwork and three internal task CTAs on the landing page.
- Moves the live WebMCP example ahead of the source directory so the page shows a working tool before routing readers onward.
- Adds focused Mermaid diagrams or responsive comparison cards to the Explanation pages for the WebMCP interaction model, package layers, runtime layers, transport boundaries, tool lifecycle, and security controls.
- Replaces the dense WebMCP resource tables with compact link cards carrying Chrome, GitHub, OpenAI, Angular, Google, and other recognizable destination icons.
- Keeps the Codex compatibility snapshot and OpenAI site-tools documentation visible from both the landing page and resource directory.

No new CSS, custom components, dependencies, or image assets were added. The landing page reuses its existing light/dark SVG pair, and the documentation pages use Mintlify-native components.

## Sources and component contracts

- [Mintlify Cards](https://www.mintlify.com/docs/components/cards)
- [Mintlify Icons](https://www.mintlify.com/docs/components/icons)
- [Mintlify Mermaid diagrams](https://www.mintlify.com/docs/components/mermaid-diagrams)
- [WebMCP Community Group draft](https://webmachinelearning.github.io/webmcp/)
- [Chrome WebMCP documentation](https://developer.chrome.com/docs/ai/webmcp)
- [OpenAI site tools documentation](https://learn.chatgpt.com/docs/webmcp)

## Validation

- `vp fmt --check` on all eight changed MDX files
- `pnpm --filter @mcp-b/documentation-website build`
- `git diff --check`
- Browser assertions across eight pages at desktop and mobile widths: one H1, no horizontal overflow, expected Mermaid/card content present
- Landing-page light/dark image switching verified
- Resource directory verified with 35 rendered cards, correct external/internal link targets, and no raw-URL image alt text
- Three independent final reviews for Diataxis/content accuracy, landing responsiveness, and Mintlify/accessibility usage
