### PR TITLE
fix(ci): scope release workflow triggers

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    # Docs and app-only merges cannot change publishable package state.
+    paths:
+      - '.changeset/**'
+      - 'packages/**'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Why

The Release workflow ran after docs-only PR #298 and failed while retrying unrelated unpublished package versions. The same npm failure has made every `main` push red since the 5.0.1 release.

Failed run: https://github.com/WebMCP-org/npm-packages/actions/runs/33148531840

## What changed

Run the push-triggered Release workflow only when `packages/**` or `.changeset/**` changes. Those are the only pushes that can create package release state. Manual prerelease dispatch remains available.

This does not hide package-release failures: package and changeset changes still execute the existing release job. It stops docs and app merges from retrying npm publication when they cannot affect package versions.

## Remaining registry setup

`@mcp-b/smart-dom-reader-server@5.0.1` still needs the `changesets.yml` trusted publisher configured. `@mcp-b/webmcp-extension` needs an authenticated first publish before npm can attach a trusted publisher; npm requires the package to exist first.

Reference: [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/) and [`npm trust`](https://docs.npmjs.com/cli/v11/commands/npm-trust/).

## Verification

- Vite+ formatting check
- YAML parser validation
- `git diff --check`