### PR TITLE
fix(transports): stop injecting Chrome globals into consumers

### DIFF
--- a/.changeset/quiet-ports-own-types.md
+++ b/.changeset/quiet-ports-own-types.md
@@ -1,0 +1,10 @@
+---
+'@mcp-b/transports': patch
+---
+
+Stop installing and forcing `@types/chrome` into every transport consumer. The
+extension server accepts an `ExtensionPort` with only the methods it uses, so
+existing Chrome ports remain compatible with either `@types/chrome` or
+Chromium's `chrome-types`. Page and iframe transport imports no longer add
+Chrome extension globals. Extension applications should declare their chosen
+Chrome types as their own development dependency.

--- a/apps/documentation-website/packages/transports/reference.mdx
+++ b/apps/documentation-website/packages/transports/reference.mdx
@@ -28,6 +28,10 @@ pnpm add @mcp-b/transports @modelcontextprotocol/server
 
 Install `@modelcontextprotocol/client` when you use a client transport.
 
+The package does not install Chrome extension globals. Extension applications
+must declare their own types with either `@types/chrome` or `chrome-types` as a
+development dependency. Page and iframe transports need neither.
+
 ## Minimal example
 
 <Snippet file="snippets/packages/transports-quickstart.ts" />
@@ -221,8 +225,13 @@ sender passes your allowlist.
 #### Constructor
 
 ```typescript title="Extension server transport constructor"
-new ExtensionServerTransport(port: chrome.runtime.Port, options?: ExtensionServerTransportOptions)
+new ExtensionServerTransport(port: ExtensionPort, options?: ExtensionServerTransportOptions)
 ```
+
+`ExtensionPort` is exported by `@mcp-b/transports`. It contains `postMessage`,
+`disconnect`, and the `addListener`/`removeListener` methods on `onMessage` and
+`onDisconnect`. Chrome `runtime.Port` objects from either declaration package
+satisfy this interface.
 
 #### ExtensionServerTransportOptions
 

--- a/packages/transports/README.md
+++ b/packages/transports/README.md
@@ -37,6 +37,10 @@
 npm install @mcp-b/transports @modelcontextprotocol/client @modelcontextprotocol/server zod
 ```
 
+The package does not install Chrome extension globals. Extension applications
+should add either `@types/chrome` or `chrome-types` as a development dependency.
+The exported `ExtensionPort` type accepts ports from either declaration package.
+
 ## Transport Types
 
 ### Tab Transports (In-Page Communication)

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -61,7 +61,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "build": "vp pack --filter main",
+    "build": "vp pack --filter main && pnpm run typecheck:consumer",
     "check": "vp check --fix",
     "clean": "rm -rf dist",
     "format": "vp fmt --write",
@@ -74,18 +74,20 @@
     "test:browser:ui": "VITEST_BROWSER=true vp test --browser",
     "test:e2e": "pnpm --filter @mcp-b/transports build && pnpm --filter @mcp-b/webmcp-polyfill build && pnpm --filter @mcp-b/webmcp-ts-sdk build && vp pack --filter e2e-extension && node e2e/build-extension.mjs && node --experimental-strip-types --test e2e/extension-runtime.e2e.test.ts",
     "test:watch": "vp test",
-    "typecheck": "tsc -p tsconfig.check.json && tsc -p e2e/tsconfig.extension.json --noEmit"
+    "typecheck": "tsc -p tsconfig.check.json && tsc -p e2e/tsconfig.extension.json --noEmit",
+    "typecheck:consumer": "tsc -p type-tests/tsconfig.json && tsc -p type-tests/tsconfig.extension.json --types node,chrome && tsc -p type-tests/tsconfig.extension.json --types node,chrome-types"
   },
   "dependencies": {
     "@modelcontextprotocol/core": "catalog:",
-    "@modelcontextprotocol/server": "catalog:",
-    "@types/chrome": "catalog:"
+    "@modelcontextprotocol/server": "catalog:"
   },
   "devDependencies": {
     "@mcp-b/webmcp-ts-sdk": "workspace:*",
     "@modelcontextprotocol/client": "catalog:",
+    "@types/chrome": "catalog:",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "chrome-types": "catalog:",
     "playwright": "catalog:",
     "typescript": "catalog:",
     "vite-plus": "catalog:",

--- a/packages/transports/src/ExtensionServerTransport.test.ts
+++ b/packages/transports/src/ExtensionServerTransport.test.ts
@@ -1,32 +1,29 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { ExtensionServerTransport } from './ExtensionServerTransport.js';
+import { type ExtensionPort, ExtensionServerTransport } from './ExtensionServerTransport.js';
 
 type Listener<T extends unknown[]> = (...args: T) => void;
 
 function createPort() {
-  const messageListeners = new Set<Listener<[unknown, chrome.runtime.Port]>>();
-  const disconnectListeners = new Set<Listener<[chrome.runtime.Port]>>();
+  const messageListeners = new Set<Listener<[unknown]>>();
+  const disconnectListeners = new Set<Listener<[]>>();
   const port = {
     disconnect: vi.fn(),
     postMessage: vi.fn(),
     onMessage: {
-      addListener: (listener: Listener<[unknown, chrome.runtime.Port]>) =>
-        messageListeners.add(listener),
-      removeListener: (listener: Listener<[unknown, chrome.runtime.Port]>) =>
-        messageListeners.delete(listener),
+      addListener: (listener: Listener<[unknown]>) => messageListeners.add(listener),
+      removeListener: (listener: Listener<[unknown]>) => messageListeners.delete(listener),
     },
     onDisconnect: {
-      addListener: (listener: Listener<[chrome.runtime.Port]>) => disconnectListeners.add(listener),
-      removeListener: (listener: Listener<[chrome.runtime.Port]>) =>
-        disconnectListeners.delete(listener),
+      addListener: (listener: Listener<[]>) => disconnectListeners.add(listener),
+      removeListener: (listener: Listener<[]>) => disconnectListeners.delete(listener),
     },
-  } as unknown as chrome.runtime.Port;
+  } satisfies ExtensionPort;
 
   return {
     port,
     remoteDisconnect() {
-      for (const listener of disconnectListeners) listener(port);
+      for (const listener of disconnectListeners) listener();
     },
   };
 }

--- a/packages/transports/src/ExtensionServerTransport.ts
+++ b/packages/transports/src/ExtensionServerTransport.ts
@@ -1,6 +1,20 @@
 import { JSONRPCMessageSchema } from '@modelcontextprotocol/core';
 import type { JSONRPCMessage, Transport, TransportSendOptions } from '@modelcontextprotocol/server';
 
+/** The runtime Port methods used by this transport, independent of Chrome ambient types. */
+export interface ExtensionPort {
+  postMessage(message: unknown): void;
+  disconnect(): void;
+  onMessage: {
+    addListener(callback: (message: unknown) => void): void;
+    removeListener(callback: (message: unknown) => void): void;
+  };
+  onDisconnect: {
+    addListener(callback: () => void): void;
+    removeListener(callback: () => void): void;
+  };
+}
+
 export interface ExtensionServerTransportOptions {
   /** Send keep-alive messages (default: true). */
   keepAlive?: boolean;
@@ -10,11 +24,11 @@ export interface ExtensionServerTransportOptions {
 
 /** Server transport for one Chrome extension Port connection. */
 export class ExtensionServerTransport implements Transport {
-  private _port: chrome.runtime.Port | undefined;
+  private _port: ExtensionPort | undefined;
   private _started = false;
   private _closed = false;
-  private _messageHandler: ((message: unknown, port: chrome.runtime.Port) => void) | undefined;
-  private _disconnectHandler: ((port: chrome.runtime.Port) => void) | undefined;
+  private _messageHandler: ((message: unknown) => void) | undefined;
+  private _disconnectHandler: (() => void) | undefined;
   private _keepAliveTimer: ReturnType<typeof setInterval> | undefined;
   private readonly _keepAliveInterval: number | undefined;
   private readonly _connectionInfo = {
@@ -27,7 +41,7 @@ export class ExtensionServerTransport implements Transport {
   onerror?: (error: Error) => void;
   onmessage?: Transport['onmessage'];
 
-  constructor(port: chrome.runtime.Port, options: ExtensionServerTransportOptions = {}) {
+  constructor(port: ExtensionPort, options: ExtensionServerTransportOptions = {}) {
     this._port = port;
     this._keepAliveInterval =
       options.keepAlive === false ? undefined : (options.keepAliveInterval ?? 25_000);

--- a/packages/transports/type-tests/browser.ts
+++ b/packages/transports/type-tests/browser.ts
@@ -1,0 +1,6 @@
+import { TabClientTransport } from '@mcp-b/transports';
+
+new TabClientTransport({ targetOrigin: location.origin });
+
+// @ts-expect-error Importing a page transport must not introduce Chrome extension globals.
+void chrome.runtime;

--- a/packages/transports/type-tests/extension.ts
+++ b/packages/transports/type-tests/extension.ts
@@ -1,0 +1,12 @@
+import { ExtensionClientTransport, ExtensionServerTransport } from '@mcp-b/transports';
+
+new ExtensionClientTransport();
+chrome.runtime.onConnect.addListener((port) => {
+  new ExtensionServerTransport(port);
+});
+
+// Importing transports must not change the consumer's Chrome event and enum types.
+chrome.tabs.onUpdated.addListener((_tabId, _changeInfo, tab) => {
+  void tab.url;
+});
+void chrome.windows.create({ type: 'popup' });

--- a/packages/transports/type-tests/tsconfig.extension.json
+++ b/packages/transports/type-tests/tsconfig.extension.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["extension.ts"]
+}

--- a/packages/transports/type-tests/tsconfig.json
+++ b/packages/transports/type-tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": false,
+    // MCP SDK v2 references Buffer, but no Chrome globals should be loaded.
+    "types": ["node"]
+  },
+  "include": ["browser.ts"]
+}

--- a/packages/transports/vite.config.ts
+++ b/packages/transports/vite.config.ts
@@ -11,7 +11,6 @@ const mainConfig: PackUserConfig = {
   entry: ['src/index.ts'],
   dts: true,
   format: ['esm'],
-  banner: { dts: '/// <reference types="chrome" />' },
   sourcemap: true,
   clean: true,
   treeshake: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ catalogs:
     '@vitest/coverage-v8':
       specifier: ^4.1.7
       version: 4.1.7
+    chrome-types:
+      specifier: 0.1.438
+      version: 0.1.438
     playwright:
       specifier: ^1.60.0
       version: 1.60.0
@@ -746,9 +749,6 @@ importers:
       '@modelcontextprotocol/server':
         specifier: 'catalog:'
         version: 2.0.0
-      '@types/chrome':
-        specifier: 'catalog:'
-        version: 0.0.326
     devDependencies:
       '@mcp-b/webmcp-ts-sdk':
         specifier: workspace:*
@@ -756,12 +756,18 @@ importers:
       '@modelcontextprotocol/client':
         specifier: 'catalog:'
         version: 2.0.0
+      '@types/chrome':
+        specifier: 'catalog:'
+        version: 0.0.326
       '@types/node':
         specifier: 'catalog:'
         version: 22.17.2
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.7(@voidzero-dev/vite-plus-test@0.1.24)
+      chrome-types:
+        specifier: 'catalog:'
+        version: 0.1.438
       playwright:
         specifier: 'catalog:'
         version: 1.60.0
@@ -7350,6 +7356,9 @@ packages:
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  chrome-types@0.1.438:
+    resolution: {integrity: sha512-eh9Zh3rg+svzT7zYzDbJ+ePITAlZvuNXrYymsYanzZCYTDvnD4GsFkFnlEYIqpa2RzC+f4w40xhBYvI1qj5mTQ==}
 
   chromium-bidi@0.6.2:
     resolution: {integrity: sha512-4WVBa6ijmUTVr9cZD4eicQD8Mdy/HCX3bzEIYYpmk0glqYLoWH+LqQEvV9RpDRzoQSbY1KJHloYXbDMXMbDPhg==}
@@ -19638,6 +19647,8 @@ snapshots:
     optional: true
 
   chownr@3.0.0: {}
+
+  chrome-types@0.1.438: {}
 
   chromium-bidi@0.6.2(devtools-protocol@0.0.1312386):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ catalog:
   '@types/react': ^19.2.9
   '@types/react-dom': ^19.1.2
   '@vitest/coverage-v8': ^4.1.7
+  chrome-types: 0.1.438
   playwright: ^1.60.0
   react: ^19.1.0
   react-dom: ^19.1.0


### PR DESCRIPTION
Importing `@mcp-b/transports@5.0.1` currently forces `@types/chrome` into the consumer's global scope, even when the consumer only uses page or iframe transports. This broke the [Rook](https://github.com/WebMCP-org/rook) upgrade because Rook already uses [Chromium's `chrome-types`](https://github.com/GoogleChrome/chrome-types): the two global namespaces conflict, and existing Chrome event and enum types stop compiling.

There are three parts to the fix:

- Move `@types/chrome` to development dependencies and remove the forced `/// <reference types="chrome" />` declaration banner.
- Accept an exported `ExtensionPort` containing only the [runtime Port methods](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-Port) the server uses. Existing ports from either declaration package remain assignable. No messaging, validation, keep-alive, or lifecycle behavior changes.
- Check the built declaration entry point during every package build with no Chrome globals, with `@types/chrome`, and with `chrome-types`. Update the reference, README, and patch changeset. Extension applications now declare their chosen Chrome types directly.

Moving the dependency alone would leave an unresolved `chrome.runtime.Port` in the public declarations. Removing only the banner would still install an ambient type package into downstream projects; TypeScript can [include visible `@types` packages automatically](https://www.typescriptlang.org/tsconfig/types.html).

The upstream audit also checked the other package findings from the Pizza-Maker incident against published 5.0.1 and current main:

| Finding | Current package behavior | Action |
| --- | --- | --- |
| Bare native tool results | [`parseNativeToolResult`](https://github.com/WebMCP-org/npm-packages/blob/dcab762768e6920ddf90f74550645c5b4390c8f5/packages/webmcp-ts-sdk/src/browser-server.ts#L97-L111) already falls back to text normalization; native null already sets `isError`. | No duplicate runtime fix. |
| Malformed native input schemas | [Native reconciliation](https://github.com/WebMCP-org/npm-packages/blob/dcab762768e6920ddf90f74550645c5b4390c8f5/packages/webmcp-ts-sdk/src/browser-server.ts#L464-L565) already skips malformed schemas and isolates schema compilation failures per tool. | No duplicate roster fix. |
| `CallToolResult.structuredContent` type drift | [`webmcp-types`](https://github.com/WebMCP-org/npm-packages/blob/dcab762768e6920ddf90f74550645c5b4390c8f5/packages/webmcp-types/src/common.ts#L1-L7) already re-exports the SDK's result type. | No new local result type. |

The declaration regressions failed before the fix: an unexpected `chrome` global in the page fixture, and conflicting namespaces/broken `addListener` types in the Chromium fixture. All three fixtures pass afterward with `skipLibCheck: false`. They explicitly include Node declarations because the SDK v2 server declaration entry point also references `Buffer`.

Validation passed:

```sh
pnpm install --frozen-lockfile --ignore-scripts --offline
pnpm build
CI=true pnpm typecheck
vp check
CI=true pnpm test:unit
pnpm --filter @mcp-b/transports test
pnpm --filter @mcp-b/transports test:e2e
pnpm --filter @mcp-b/documentation-website exec mintlify broken-links
pnpm syncpack:lint
pnpm release:check
pnpm audit:ci:critical
```

Also packed transports with `pnpm pack --pack-destination /tmp/webmcp-transport-consumer.AGxUT7`, installed that tarball alongside published `@mcp-b/global@5.0.1` in a fresh pnpm project, and ran `pnpm exec tsc -p tsconfig.json` and `pnpm exec tsc -p tsconfig.extension.json --types node,chrome-types`. Both passed. The installed dependency graph contains no `@types/chrome`, and the packed declarations contain no Chrome namespace references.

`pnpm audit:ci:high` still reports 19 existing high-severity advisories under the unchanged landing-page dependency tree. The required critical gate passes with zero critical advisories. No host code or existing working checkout is changed by this PR.
