### PR TITLE
fix(ci): recover release signatures with cosign bundles

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -110,6 +110,16 @@ an already published version. If npm publishing succeeded but a later GitHub art
 failed, recover those missing artifacts explicitly: existing tags can make Changesets
 report no new publication on a rerun. A rerun of snapshot versioning creates a new timestamp.
 
+If only signing failed after stable GitHub releases were created, recover signatures with:
+
+```bash
+gh workflow run "Release" --ref main -f recover_signatures_version=5.0.3
+```
+
+Use the affected stable version. This checks out its `usewebmcp@<version>` tag, validates
+every public package's version, tag commit and existing release, then signs source archives
+with Sigstore bundles. It never publishes npm packages or replaces SBOM/MCPB/R2 artifacts.
+
 Verify exact versions (`npm view <name>@<version> version`) and dist-tags, including unscoped
 `usewebmcp` and nested `@mcp-b/smart-dom-reader-server`. Do not use the default `npm view`
 version as a prerelease check: it reads `latest`.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -15,6 +15,10 @@ on:
         required: false
         default: 'beta'
         type: string
+      recover_signatures_version:
+        description: 'Sign an existing stable version only (e.g. 5.0.3); skips all publishing'
+        required: false
+        type: string
 
 env:
   CI: true
@@ -29,7 +33,7 @@ concurrency:
 jobs:
   release:
     name: Release
-    if: github.event_name == 'push' && github.repository == 'WebMCP-org/npm-packages'
+    if: github.repository == 'WebMCP-org/npm-packages' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.recover_signatures_version != ''))
     timeout-minutes: 15
     runs-on: ubuntu-latest
     environment:
@@ -42,16 +46,49 @@ jobs:
       id-token: write # Required for npm provenance/OIDC
 
     steps:
+      - name: Validate signature recovery version
+        if: inputs.recover_signatures_version != ''
+        env:
+          RECOVER_VERSION: ${{ inputs.recover_signatures_version }}
+        run: |
+          if [[ ! "$RECOVER_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo '::error::Signature recovery requires a stable version such as 5.0.3.'
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ inputs.recover_signatures_version && format('refs/tags/usewebmcp@{0}', inputs.recover_signatures_version) || github.sha }}
           # Fetch all history for proper changelog generation
           fetch-depth: 0
 
+      - name: Validate existing releases for signature recovery
+        if: inputs.recover_signatures_version != ''
+        id: recovery
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RECOVER_VERSION: ${{ inputs.recover_signatures_version }}
+        run: |
+          # Read the fixed release train from its tag, never from newer main manifests.
+          shopt -s nullglob
+          PACKAGES=$(jq -sc '[.[] | select(.private != true) | {name, version}]' packages/*/package.json packages/*/*/package.json)
+          echo "$PACKAGES" | jq -e --arg version "$RECOVER_VERSION" 'length > 0 and all(.[]; .version == $version)'
+          RELEASE_SHA=$(git rev-parse HEAD)
+          # Validate the whole train before uploading any signatures.
+          echo "$PACKAGES" | jq -r '.[] | "\(.name)@\(.version)"' | while read -r tag; do
+            test "$(git rev-parse --verify "refs/tags/${tag}^{commit}")" = "$RELEASE_SHA"
+            gh release view "$tag" --json isDraft,isPrerelease | jq -e '.isDraft == false and .isPrerelease == false'
+          done
+          echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
+
       - name: Setup pnpm
+        if: inputs.recover_signatures_version == ''
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Vite+
+        if: inputs.recover_signatures_version == ''
         uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
         with:
           node-version: '24'
@@ -59,18 +96,23 @@ jobs:
           run-install: false
 
       - name: Use npm with trusted publishing support
+        if: inputs.recover_signatures_version == ''
         run: npm install --global npm@11.14.1
 
       - name: Install dependencies
+        if: inputs.recover_signatures_version == ''
         run: vp install --frozen-lockfile
 
       - name: Build packages
+        if: inputs.recover_signatures_version == ''
         run: pnpm build
 
       - name: Check release metadata
+        if: inputs.recover_signatures_version == ''
         run: pnpm release:check
 
       - name: Create Release PR or Publish
+        if: inputs.recover_signatures_version == ''
         id: changesets
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v1
         with:
@@ -147,56 +189,42 @@ jobs:
           done
 
       - name: Install cosign
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || steps.recovery.outputs.packages != ''
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v3.8.0
 
       - name: Sign release artifacts with sigstore
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || steps.recovery.outputs.packages != ''
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+          PACKAGES: ${{ steps.recovery.outputs.packages || steps.changesets.outputs.publishedPackages }}
         run: |
           # Process each published package
           echo "$PACKAGES" | jq -c '.[]' | while read -r pkg; do
             PKG_NAME=$(echo "$pkg" | jq -r '.name')
             PKG_VERSION=$(echo "$pkg" | jq -r '.version')
 
-            # Convert scoped package name to GitHub release tag format
-            # @mcp-b/transports@1.0.0 -> @mcp-b/transports@1.0.0
             TAG="${PKG_NAME}@${PKG_VERSION}"
 
             echo "Signing release: $TAG"
 
             # Download the source tarball from the release
-            TARBALL_URL=$(gh release view "$TAG" --json tarballUrl -q '.tarballUrl' 2>/dev/null || echo "")
+            TARBALL_URL=$(gh release view "$TAG" --json tarballUrl -q '.tarballUrl')
+            TARBALL_FILE="${PKG_NAME//\//-}-${PKG_VERSION}.tar.gz"
+            curl -sSfL "$TARBALL_URL" -o "/tmp/$TARBALL_FILE"
 
-            if [ -n "$TARBALL_URL" ]; then
-              TARBALL_FILE="${PKG_NAME//\//-}-${PKG_VERSION}.tar.gz"
-              curl -sSfL "$TARBALL_URL" -o "/tmp/$TARBALL_FILE"
+            # The bundle contains the signature, certificate and transparency proof.
+            cosign sign-blob "/tmp/$TARBALL_FILE" \
+              --yes \
+              --bundle "/tmp/${TARBALL_FILE}.sigstore"
 
-              # Sign with cosign (keyless via OIDC)
-              cosign sign-blob "/tmp/$TARBALL_FILE" \
-                --yes \
-                --output-signature "/tmp/${TARBALL_FILE}.sig" \
-                --output-certificate "/tmp/${TARBALL_FILE}.pem" \
-                --bundle "/tmp/${TARBALL_FILE}.sigstore"
-
-              # Upload signatures to the release
-              gh release upload "$TAG" \
-                "/tmp/${TARBALL_FILE}.sig" \
-                "/tmp/${TARBALL_FILE}.pem" \
-                "/tmp/${TARBALL_FILE}.sigstore" \
-                --clobber
-
-              echo "✓ Signed and uploaded signatures for $TAG"
-            else
-              echo "⚠ No release found for $TAG, skipping"
-            fi
+            gh release upload "$TAG" "/tmp/${TARBALL_FILE}.sigstore" --clobber
+            echo "✓ Signed and uploaded signature bundle for $TAG"
           done
 
   prerelease:
     name: Publish Prerelease
-    if: github.event_name == 'workflow_dispatch' && github.repository == 'WebMCP-org/npm-packages' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' && github.repository == 'WebMCP-org/npm-packages' && github.ref == 'refs/heads/main' && inputs.recover_signatures_version == ''
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:

--- a/scripts/release-safety.test.mjs
+++ b/scripts/release-safety.test.mjs
@@ -87,3 +87,133 @@ test('snapshot dispatch rejects shell input, latest, and existing pre state', ()
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+// Run the actual recovery/signing shell against local files; only remote tools are stubbed.
+test('signature recovery validates the train and uploads the bundle cosign actually creates', () => {
+  const workflow = readFileSync(new URL('../.github/workflows/changesets.yml', scripts), 'utf8');
+  const step = (name) =>
+    workflow
+      .split(`      - name: ${name}\n`)[1]
+      .split('\n      - name: ')[0]
+      .split('\n  prerelease:')[0];
+  const shell = (name) => step(name).split('        run: |\n')[1];
+  const root = mkdtempSync(join(tmpdir(), 'signature-recovery-'));
+  const name = `recovery-test-${root.split('/').at(-1)}`;
+  const archive = `/tmp/${name}-5.0.3.tar.gz`;
+  try {
+    mkdirSync(join(root, 'bin'));
+    const env = {
+      ...process.env,
+      PATH: `${join(root, 'bin')}:${process.env.PATH}`,
+      RECOVER_VERSION: '5.0.3',
+      GITHUB_OUTPUT: join(root, 'output'),
+    };
+    const run = (script, extra = {}) =>
+      spawnSync('bash', ['-e', '-o', 'pipefail', '-c', script], {
+        cwd: root,
+        env: { ...env, ...extra },
+        encoding: 'utf8',
+      });
+    const guard = shell('Validate signature recovery version');
+    assert.equal(run(guard).status, 0);
+    for (const version of [
+      '',
+      'main',
+      'v5.0.3',
+      '5.0.3-beta.0',
+      '05.0.3',
+      '5.0.3; true',
+      '$(true)',
+    ])
+      assert.notEqual(run(guard, { RECOVER_VERSION: version }).status, 0);
+    assert.match(
+      step('Create Release PR or Publish'),
+      /if: inputs\.recover_signatures_version == ''/
+    );
+    assert.match(
+      workflow.split('  prerelease:')[1].split('    runs-on:')[0],
+      /inputs\.recover_signatures_version == ''/
+    );
+
+    for (const [dir, manifest] of [
+      ['packages/root', { name, version: '5.0.3' }],
+      ['packages/root/server', { name: 'nested-server', version: '5.0.3' }],
+      ['packages/private', { name: 'private', version: '0.0.0', private: true }],
+    ]) {
+      mkdirSync(join(root, dir), { recursive: true });
+      writeFileSync(join(root, dir, 'package.json'), JSON.stringify(manifest));
+    }
+    assert.equal(
+      run(
+        'git init -q && git add packages && git -c user.name=Test -c user.email=test@example.com commit -qm initial && git tag "$TEST_TAG" && git tag nested-server@5.0.3',
+        { TEST_TAG: `${name}@5.0.3` }
+      ).status,
+      0
+    );
+    writeFileSync(
+      join(root, 'bin/gh'),
+      `#!/bin/bash
+set -e
+if [ "$2" = view ]; then
+  [ "$FAIL_RELEASE" != true ]
+  if [ "$5" = tarballUrl ]; then
+    echo https://example.invalid/source.tar.gz
+  else
+    echo '{"isDraft":false,"isPrerelease":false}'
+  fi
+else
+  [ "$2" = upload ] && [ "$#" = 5 ] && [[ "$4" = *.sigstore ]] && [ -f "$4" ]
+  echo "$4" >> uploads
+fi
+`,
+      { mode: 0o755 }
+    );
+    const recovery = shell('Validate existing releases for signature recovery');
+    const result = run(recovery);
+    assert.equal(result.status, 0, result.stderr);
+    const packages = JSON.parse(
+      readFileSync(env.GITHUB_OUTPUT, 'utf8').trim().slice('packages='.length)
+    );
+    assert.equal(packages.length, 2, 'include nested packages and exclude private packages');
+    for (const extra of [{ RECOVER_VERSION: '5.0.4' }, { FAIL_RELEASE: 'true' }]) {
+      writeFileSync(env.GITHUB_OUTPUT, '');
+      assert.notEqual(run(recovery, extra).status, 0);
+      assert.equal(
+        readFileSync(env.GITHUB_OUTPUT, 'utf8'),
+        '',
+        'fail before exposing packages to signing'
+      );
+    }
+    assert.equal(
+      run('git -c user.name=Test -c user.email=test@example.com commit --allow-empty -qm newer')
+        .status,
+      0
+    );
+    assert.notEqual(run(recovery).status, 0, 'tags must point at the checkout commit');
+
+    writeFileSync(join(root, 'bin/curl'), '#!/bin/bash\n[ "$3" = -o ] && echo source > "$4"\n', {
+      mode: 0o755,
+    });
+    writeFileSync(
+      join(root, 'bin/cosign'),
+      '#!/bin/bash\n[ "$1" = sign-blob ] && [ "$3" = --yes ] && [ "$4" = --bundle ] && echo bundle > "$5"\n',
+      { mode: 0o755 }
+    );
+    const signing = shell('Sign release artifacts with sigstore');
+    const signingEnv = { PACKAGES: JSON.stringify([{ name, version: '5.0.3' }]) };
+    const signed = run(signing, signingEnv);
+    assert.equal(signed.status, 0, signed.stderr);
+    assert.equal(readFileSync(join(root, 'uploads'), 'utf8').trim(), `${archive}.sigstore`);
+    rmSync(join(root, 'uploads'));
+    assert.notEqual(
+      run(signing, { ...signingEnv, FAIL_RELEASE: 'true' }).status,
+      0,
+      'missing release must fail, not skip'
+    );
+    assert.equal(run('test ! -f uploads').status, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(archive, { force: true });
+    rmSync(`${archive}.sigstore`, { force: true });
+  }
+});


### PR DESCRIPTION
## Why

The [5.0.3 release run](https://github.com/WebMCP-org/npm-packages/actions/runs/33346276939) published all 12 npm packages and uploaded the SBOM/MCPB, then failed signing: cosign created a `.sigstore` bundle but ignored the deprecated separate signature/certificate flags. Uploading the nonexistent `.sig` file failed.

This follows [the CI cleanup #302](https://github.com/WebMCP-org/npm-packages/pull/302) and [release #305](https://github.com/WebMCP-org/npm-packages/pull/305). Simply rerunning Changesets after its tags exist would skip signing, so the missing signatures need an explicit recovery path.

## Changes

- Upload the Sigstore bundle that cosign actually creates, matching the existing snapshot workflow and [Sigstore's recommended blob-signing format](https://docs.sigstore.dev/cosign/signing/signing_with_blobs/).
- Add `recover_signatures_version` to the existing Release dispatch. It accepts a stable version, checks out its release tag, and verifies every public package version, tag commit, and existing stable GitHub release before signing.
- Recovery runs only on canonical `main`, in the existing `npm-publish` environment/concurrency group. It skips npm publication, prereleases, dependency installation, builds, SBOM and MCPB/R2 uploads. Those successful artifacts remain untouched; [GitHub's clobber option replaces existing assets](https://cli.github.com/manual/gh_release_upload).
- Document recovery and execute the actual workflow shell in a regression test with real local Git tags and stubbed remote commands. Missing releases now fail rather than silently skipping signatures.

The checkout deliberately uses the release tag: [workflow dispatch SHA/ref identify the dispatch branch](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch), which may already contain newer package changes.

No package source, public API, dependency, version or React runtime behavior changes. After merge, dispatch `recover_signatures_version=5.0.3` to finish that release without republishing it.

## Validation

- `vp install --frozen-lockfile`
- `pnpm build && pnpm typecheck && vp check && pnpm test:unit && pnpm release:check`
- `pnpm audit:ci:critical` passed. `pnpm audit:ci:high` reports the existing `sharp` advisory through `apps/landing-page > astro > sharp`; this PR changes no dependencies.
- `node --test scripts/release-safety.test.mjs`
- `actionlint .github/workflows/changesets.yml`
- Independent agent review; verified all 12 existing 5.0.3 tags resolve to the release commit.

Browser/runtime changes: none; GitHub CI will still run the required E2E lanes before merge.
