### PR TITLE
fix(webmcp-local-relay): forward tool cancellation to the browser

### DIFF
--- a/.changeset/relay-execution-cancellation.md
+++ b/.changeset/relay-execution-cancellation.md
@@ -1,0 +1,7 @@
+---
+'@mcp-b/webmcp-local-relay': patch
+---
+
+Forward MCP request cancellation through direct and shared relay connections to the browser's `executeTool()` signal. `RelayBridgeServer.invokeTool()` also accepts an optional `signal`. Timeouts and connection teardown cancel outstanding calls and clean up their listeners; cancellations are scoped to the requesting connection.
+
+Stopping handler work requires a browser runtime that forwards execution signals and a handler that observes them.

--- a/packages/webmcp-local-relay/README.md
+++ b/packages/webmcp-local-relay/README.md
@@ -240,6 +240,28 @@ Runtime dispatch behavior in the browser embed/widget layer:
 - Refreshes the descriptor before every invocation so Chrome never receives a
   stale registration object.
 
+### Cancellation
+
+MCP request cancellation is forwarded to the browser's `executeTool()` signal in
+both server and client modes. Timeouts and connection teardown also cancel
+outstanding calls. Each relay client can cancel only its own calls.
+
+Programmatic callers can pass a signal to an existing `RelayBridgeServer`:
+
+```ts
+const result = await bridge.invokeTool(
+  'search_docs',
+  { query: 'WebMCP' },
+  {
+    signal: AbortSignal.timeout(10_000),
+  }
+);
+```
+
+Stopping handler work requires a runtime that forwards execution signals and a
+handler that observes them. Runtimes that only cancel the wait for a result may
+leave the handler running.
+
 ### WebMCP Standard Status
 
 WebMCP is an emerging web platform proposal. This relay works with the current native Chrome preview and MCP-B runtimes, but native extension details can still change as implementations mature.
@@ -299,6 +321,12 @@ pnpm install
 pnpm --filter @mcp-b/webmcp-local-relay build
 pnpm --filter @mcp-b/webmcp-local-relay test
 pnpm --filter @mcp-b/webmcp-local-relay test:e2e
+```
+
+To include native browser cancellation tests, use Chrome Canary with WebMCP:
+
+```bash
+WEBMCP_NATIVE=1 CHROME_BIN=/path/to/chrome-canary pnpm --filter @mcp-b/webmcp-local-relay test:e2e
 ```
 
 ### Build MCPB Bundle

--- a/packages/webmcp-local-relay/src/bridgeServer.test.ts
+++ b/packages/webmcp-local-relay/src/bridgeServer.test.ts
@@ -110,6 +110,78 @@ async function getOpenPort(): Promise<number> {
 }
 
 describe('RelayBridgeServer', () => {
+  it.each(['server', 'client'] as const)(
+    'cancels only the pending invocation in %s mode',
+    async (mode) => {
+      const server = new RelayBridgeServer({ host: '127.0.0.1', port: 0, allowedOrigins: ['*'] });
+      let client: RelayBridgeServer | undefined;
+      try {
+        await server.start();
+        const ws = await connectAndRegister(server, {
+          tabId: 'tab-cancel',
+          url: 'https://example.com',
+          tools: [{ name: 'echo' }],
+        });
+        const messages: Array<{ type: string; callId: string }> = [];
+        ws.on('message', (raw) => messages.push(JSON.parse(String(raw))));
+        const toolName = await waitFor(() => server.registry.listTools()[0]?.name);
+        if (mode === 'client') {
+          client = new RelayBridgeServer({
+            host: '127.0.0.1',
+            port: server.port,
+            allowedOrigins: ['*'],
+            persistPath,
+          });
+          await client.start();
+        }
+        const bridge = client ?? server;
+        const reason = { code: 'caller-stopped' };
+        await expect(
+          bridge.invokeTool(toolName, {}, { signal: AbortSignal.abort(reason) })
+        ).rejects.toBe(reason);
+
+        const controller = new AbortController();
+        const cancelled = bridge.invokeTool(toolName, {}, { signal: controller.signal });
+        const rejected = expect(cancelled).rejects.toBe(reason);
+        const first = await waitFor(() => messages.find((message) => message.type === 'invoke'));
+        expect(messages.filter((message) => message.type === 'invoke')).toHaveLength(1);
+        controller.abort(reason);
+        await rejected;
+        await waitFor(() => messages.find((message) => message.type === 'cancel'));
+        expect(messages.filter((message) => message.type === 'cancel')).toEqual([
+          { type: 'cancel', callId: first.callId },
+        ]);
+
+        const completedController = new AbortController();
+        const removeListener = vi.spyOn(completedController.signal, 'removeEventListener');
+        const completed = bridge.invokeTool(toolName, {}, { signal: completedController.signal });
+        const second = await waitFor(() =>
+          messages.find((message) => message.type === 'invoke' && message.callId !== first.callId)
+        );
+        for (const [callId, text] of [
+          [first.callId, 'late'],
+          [second.callId, 'fresh'],
+        ]) {
+          ws.send(
+            JSON.stringify({
+              type: 'result',
+              callId,
+              result: { content: [{ type: 'text', text }] },
+            })
+          );
+        }
+        await expect(completed).resolves.toMatchObject({
+          content: [{ type: 'text', text: 'fresh' }],
+        });
+        expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function));
+        ws.close();
+      } finally {
+        await client?.stop();
+        await server.stop();
+      }
+    }
+  );
+
   it('rejects invokeTool when no provider exists for the tool name', async () => {
     const bridge = new RelayBridgeServer({
       host: '127.0.0.1',
@@ -172,32 +244,51 @@ describe('RelayBridgeServer', () => {
     }
   });
 
-  it('times out when the tab does not return a result', async () => {
-    const bridge = new RelayBridgeServer({
-      host: '127.0.0.1',
-      port: 0,
-      allowedOrigins: ['*'],
-      invokeTimeoutMs: 50,
-    });
-
-    try {
-      await bridge.start();
-
-      const ws = await connectAndRegister(bridge, {
-        tabId: 'tab-1',
-        url: 'https://example.com',
-        tools: [{ name: 'slow_tool' }],
+  it.each(['server', 'client'] as const)(
+    'cancels browser execution after a %s timeout',
+    async (mode) => {
+      const bridge = new RelayBridgeServer({
+        host: '127.0.0.1',
+        port: 0,
+        allowedOrigins: ['*'],
+        invokeTimeoutMs: mode === 'server' ? 50 : 2000,
       });
+      let client: RelayBridgeServer | undefined;
 
-      const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
+      try {
+        await bridge.start();
 
-      await expect(bridge.invokeTool(toolName, {})).rejects.toThrow(/timed out/i);
+        const ws = await connectAndRegister(bridge, {
+          tabId: 'tab-1',
+          url: 'https://example.com',
+          tools: [{ name: 'slow_tool' }],
+        });
 
-      ws.close();
-    } finally {
-      await bridge.stop();
+        const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
+        const messages: Array<{ type: string; callId: string }> = [];
+        ws.on('message', (raw) => messages.push(JSON.parse(String(raw))));
+        if (mode === 'client') {
+          client = new RelayBridgeServer({
+            host: '127.0.0.1',
+            port: bridge.port,
+            allowedOrigins: ['*'],
+            persistPath,
+            invokeTimeoutMs: 50,
+          });
+          await client.start();
+        }
+
+        await expect((client ?? bridge).invokeTool(toolName, {})).rejects.toThrow(/timed out/i);
+        const cancel = await waitFor(() => messages.find((message) => message.type === 'cancel'));
+        expect(cancel.callId).toBe(messages.find((message) => message.type === 'invoke')?.callId);
+
+        ws.close();
+      } finally {
+        await client?.stop();
+        await bridge.stop();
+      }
     }
-  });
+  );
 
   it('rejects hello with disallowed host page origin', async () => {
     const bridge = new RelayBridgeServer({
@@ -1225,6 +1316,79 @@ describe('RelayBridgeServer', () => {
 // ---------------------------------------------------------------------------
 
 describe('RelayBridgeServer client mode', () => {
+  it('ignores cancellation from another relay connection', async () => {
+    const server = new RelayBridgeServer({ host: '127.0.0.1', port: 0, allowedOrigins: ['*'] });
+    const sockets: WebSocket[] = [];
+    try {
+      await server.start();
+      const browser = await connectAndRegister(server, {
+        tabId: 'tab-owned',
+        url: 'https://example.com',
+        tools: [{ name: 'echo' }],
+      });
+      sockets.push(browser);
+      const browserMessages: Array<{ type: string; callId: string }> = [];
+      browser.on('message', (raw) => browserMessages.push(JSON.parse(String(raw))));
+      const toolName = await waitFor(() => server.registry.listTools()[0]?.name);
+      const clients = await Promise.all(
+        [0, 1].map(async () => {
+          const ws = new WebSocket(`ws://127.0.0.1:${server.port}`, 'webmcp-relay.v1');
+          sockets.push(ws);
+          const messages: Array<{ type: string; callId: string; result?: unknown }> = [];
+          ws.on('message', (raw) => messages.push(JSON.parse(String(raw))));
+          await new Promise<void>((resolve, reject) => {
+            ws.once('open', resolve);
+            ws.once('error', reject);
+          });
+          ws.send(JSON.stringify({ type: 'relay/hello' }));
+          return { ws, messages };
+        })
+      );
+      const owner = clients[0]!;
+      const other = clients[1]!;
+      owner.ws.send(
+        JSON.stringify({ type: 'relay/invoke', callId: 'owned-call', toolName, args: {} })
+      );
+      const invocation = await waitFor(() =>
+        browserMessages.find((message) => message.type === 'invoke')
+      );
+
+      other.ws.send(JSON.stringify({ type: 'relay/cancel', callId: 'owned-call' }));
+      other.ws.send(JSON.stringify({ type: 'relay/list-tools' }));
+      // The reply confirms the server processed the preceding unauthorized cancel.
+      await waitFor(() => other.messages.find((message) => message.type === 'relay/tools'));
+      browser.send(
+        JSON.stringify({
+          type: 'result',
+          callId: invocation.callId,
+          result: { content: [{ type: 'text', text: 'still-running' }] },
+        })
+      );
+      const response = await waitFor(() =>
+        owner.messages.find((message) => message.type === 'relay/result')
+      );
+      expect(response.result).toMatchObject({ content: [{ type: 'text', text: 'still-running' }] });
+      expect(browserMessages.filter((message) => message.type === 'cancel')).toEqual([]);
+
+      owner.ws.send(
+        JSON.stringify({ type: 'relay/invoke', callId: 'owned-call', toolName, args: {} })
+      );
+      const next = await waitFor(() =>
+        browserMessages.find(
+          (message) => message.type === 'invoke' && message.callId !== invocation.callId
+        )
+      );
+      owner.ws.send(JSON.stringify({ type: 'relay/cancel', callId: 'owned-call' }));
+      const cancel = await waitFor(() =>
+        browserMessages.find((message) => message.type === 'cancel')
+      );
+      expect(cancel.callId).toBe(next.callId);
+    } finally {
+      for (const socket of sockets) socket.close();
+      await server.stop();
+    }
+  });
+
   it('receives tools from the server relay via relay/tools', async () => {
     const server = new RelayBridgeServer({
       host: '127.0.0.1',

--- a/packages/webmcp-local-relay/src/bridgeServer.ts
+++ b/packages/webmcp-local-relay/src/bridgeServer.ts
@@ -47,9 +47,9 @@ const SUPPORTED_SUBPROTOCOLS = new Set([
  */
 interface PendingInvocation {
   connectionId: string;
-  timeoutId: ReturnType<typeof setTimeout>;
   resolve: (result: RelayCallToolResult) => void;
-  reject: (error: Error) => void;
+  reject: (reason: unknown) => void;
+  cancel: (reason: unknown) => void;
 }
 
 function formatPayloadLimit(bytes: number): string {
@@ -161,6 +161,7 @@ export class RelayBridgeServer extends EventEmitter {
   private readonly pendingInvocations = new Map<string, PendingInvocation>();
   private readonly browserClientConnectionIds = new Set<string>();
   private readonly relayClientConnectionIds = new Set<string>();
+  private readonly relayClientInvocations = new Map<string, Map<string, AbortController>>();
   private readonly heartbeatIntervalByConnectionId = new Map<
     string,
     ReturnType<typeof setInterval>
@@ -390,10 +391,8 @@ export class RelayBridgeServer extends EventEmitter {
 
     if (this._mode === 'client') {
       for (const pending of this.clientPendingInvocations.values()) {
-        clearTimeout(pending.timeoutId);
-        pending.reject(new Error('Relay client stopped'));
+        pending.cancel(new Error('Relay client stopped'));
       }
-      this.clientPendingInvocations.clear();
       this.clientTools = [];
       this.clientSources = [];
       this.clientToolSourceMap = {};
@@ -412,6 +411,14 @@ export class RelayBridgeServer extends EventEmitter {
     }
 
     this.off('stateChanged', this.onStateChangedPushRelay);
+
+    for (const pending of this.pendingInvocations.values()) {
+      pending.cancel(new Error('Relay server stopped before tool invocation completed'));
+    }
+    for (const invocations of this.relayClientInvocations.values()) {
+      for (const controller of invocations.values()) controller.abort();
+    }
+    this.relayClientInvocations.clear();
 
     for (const [connectionId, socket] of this.socketByConnectionId) {
       this.registry.removeConnection(connectionId);
@@ -434,12 +441,6 @@ export class RelayBridgeServer extends EventEmitter {
     this.requestOriginByConnectionId.clear();
     this.browserClientConnectionIds.clear();
     this.relayClientConnectionIds.clear();
-
-    for (const pending of this.pendingInvocations.values()) {
-      clearTimeout(pending.timeoutId);
-      pending.reject(new Error('Relay server stopped before tool invocation completed'));
-    }
-    this.pendingInvocations.clear();
 
     const wss = this.wss;
     this.wss = null;
@@ -490,10 +491,13 @@ export class RelayBridgeServer extends EventEmitter {
     options: {
       sourceId?: string;
       requestTabId?: string;
+      /** Cancels the invocation and forwards cancellation to the browser runtime. */
+      signal?: AbortSignal;
     } = {}
   ): Promise<RelayCallToolResult> {
+    options.signal?.throwIfAborted();
     if (this._mode === 'client') {
-      return this.invokeToolViaRelay(toolName, args);
+      return this.invokeToolViaRelay(toolName, args, options.signal);
     }
 
     return this.invokeToolLocally(toolName, args, options);
@@ -611,7 +615,7 @@ export class RelayBridgeServer extends EventEmitter {
   private async invokeToolLocally(
     toolName: string,
     args: RelayInvokeArgs,
-    options: { sourceId?: string; requestTabId?: string }
+    options: { sourceId?: string; requestTabId?: string; signal?: AbortSignal }
   ): Promise<RelayCallToolResult> {
     const resolved = this.registry.resolveInvocation({
       toolName,
@@ -630,42 +634,19 @@ export class RelayBridgeServer extends EventEmitter {
       );
     }
 
-    const callId = randomUUID();
-
-    return new Promise<RelayCallToolResult>((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        this.pendingInvocations.delete(callId);
-        reject(
-          new Error(`Invocation for tool "${toolName}" timed out after ${this.invokeTimeoutMs}ms`)
-        );
-      }, this.invokeTimeoutMs);
-
-      this.pendingInvocations.set(callId, {
-        connectionId: resolved.connectionId,
-        timeoutId,
-        resolve,
-        reject,
-      });
-
-      const message: RelayToBrowserMessage = {
+    return this.requestTool(
+      socket,
+      this.pendingInvocations,
+      resolved.connectionId,
+      {
         type: 'invoke',
-        callId,
+        callId: randomUUID(),
         toolName: resolved.tool.name,
         args,
-      };
-
-      try {
-        socket.send(JSON.stringify(message));
-      } catch (err) {
-        clearTimeout(timeoutId);
-        this.pendingInvocations.delete(callId);
-        reject(
-          new Error(
-            `Failed to send invocation for tool "${toolName}": ${err instanceof Error ? err.message : err}`
-          )
-        );
-      }
-    });
+      },
+      `Invocation for tool "${toolName}" timed out after ${this.invokeTimeoutMs}ms`,
+      options.signal
+    );
   }
 
   /** Handles a raw message according to the negotiated WebSocket protocol. */
@@ -796,8 +777,6 @@ export class RelayBridgeServer extends EventEmitter {
           break;
         }
 
-        clearTimeout(pending.timeoutId);
-        this.pendingInvocations.delete(message.callId);
         pending.resolve(this.normalizeCallToolResult(message.result));
         break;
       }
@@ -841,21 +820,43 @@ export class RelayBridgeServer extends EventEmitter {
 
       case 'relay/invoke': {
         const { callId, toolName, args } = message;
-        void this.invokeToolLocally(toolName, args ?? {}, {}).then(
-          (result) => this.sendRelayResult(connectionId, callId, result),
-          (error: unknown) =>
-            this.sendRelayResult(connectionId, callId, {
-              content: [
-                {
-                  type: 'text',
-                  text: `Relay invocation failed: ${error instanceof Error ? error.message : String(error)}`,
-                },
-              ],
-              isError: true,
-            })
-        );
+        let invocations = this.relayClientInvocations.get(connectionId);
+        if (!invocations) {
+          invocations = new Map();
+          this.relayClientInvocations.set(connectionId, invocations);
+        }
+        if (invocations.has(callId)) break;
+        const controller = new AbortController();
+        invocations.set(callId, controller);
+        void this.invokeToolLocally(toolName, args ?? {}, { signal: controller.signal })
+          .then(
+            (result) => {
+              if (!controller.signal.aborted) this.sendRelayResult(connectionId, callId, result);
+            },
+            (error: unknown) => {
+              if (!controller.signal.aborted) {
+                this.sendRelayResult(connectionId, callId, {
+                  content: [
+                    {
+                      type: 'text',
+                      text: `Relay invocation failed: ${error instanceof Error ? error.message : String(error)}`,
+                    },
+                  ],
+                  isError: true,
+                });
+              }
+            }
+          )
+          .finally(() => {
+            invocations.delete(callId);
+            if (invocations.size === 0) this.relayClientInvocations.delete(connectionId);
+          });
         break;
       }
+
+      case 'relay/cancel':
+        this.relayClientInvocations.get(connectionId)?.get(message.callId)?.abort();
+        break;
     }
   }
 
@@ -917,6 +918,10 @@ export class RelayBridgeServer extends EventEmitter {
     this.requestOriginByConnectionId.delete(connectionId);
     this.browserClientConnectionIds.delete(connectionId);
     this.relayClientConnectionIds.delete(connectionId);
+    for (const controller of this.relayClientInvocations.get(connectionId)?.values() ?? []) {
+      controller.abort();
+    }
+    this.relayClientInvocations.delete(connectionId);
     this.registry.removeConnection(connectionId);
     this.socketByConnectionId.delete(connectionId);
     this.emit('stateChanged');
@@ -926,13 +931,10 @@ export class RelayBridgeServer extends EventEmitter {
     // the invocation time out silently after invokeTimeoutMs.
     const isPayloadExceeded = code === 1009;
 
-    for (const [callId, pending] of this.pendingInvocations.entries()) {
+    for (const pending of this.pendingInvocations.values()) {
       if (pending.connectionId !== connectionId) {
         continue;
       }
-
-      clearTimeout(pending.timeoutId);
-      this.pendingInvocations.delete(callId);
 
       if (isPayloadExceeded) {
         pending.reject(
@@ -1116,9 +1118,7 @@ export class RelayBridgeServer extends EventEmitter {
 
     ws.on('close', () => {
       this.clientSocket = null;
-      for (const [callId, pending] of this.clientPendingInvocations) {
-        clearTimeout(pending.timeoutId);
-        this.clientPendingInvocations.delete(callId);
+      for (const pending of this.clientPendingInvocations.values()) {
         pending.reject(new Error('Relay server connection lost during invocation'));
       }
 
@@ -1191,8 +1191,6 @@ export class RelayBridgeServer extends EventEmitter {
           );
           break;
         }
-        clearTimeout(pending.timeoutId);
-        this.clientPendingInvocations.delete(message.callId);
         pending.resolve(message.result);
         break;
       }
@@ -1253,46 +1251,82 @@ export class RelayBridgeServer extends EventEmitter {
 
   private async invokeToolViaRelay(
     toolName: string,
-    args: RelayInvokeArgs
+    args: RelayInvokeArgs,
+    signal?: AbortSignal
   ): Promise<RelayCallToolResult> {
     if (!this.clientSocket || this.clientSocket.readyState !== WebSocket.OPEN) {
       throw new Error('Not connected to relay server');
     }
 
-    const callId = randomUUID();
-    const socket = this.clientSocket;
+    return this.requestTool(
+      this.clientSocket,
+      this.clientPendingInvocations,
+      'relay-server',
+      { type: 'relay/invoke', callId: randomUUID(), toolName, args },
+      `Proxied invocation for tool "${toolName}" timed out after ${this.invokeTimeoutMs}ms`,
+      signal
+    );
+  }
 
+  private requestTool(
+    socket: WebSocket,
+    invocations: Map<string, PendingInvocation>,
+    connectionId: string,
+    message:
+      | Extract<RelayToBrowserMessage, { type: 'invoke' }>
+      | Extract<RelayClientToServerMessage, { type: 'relay/invoke' }>,
+    timeoutMessage: string,
+    signal?: AbortSignal
+  ): Promise<RelayCallToolResult> {
+    signal?.throwIfAborted();
+    const { callId } = message;
     return new Promise<RelayCallToolResult>((resolve, reject) => {
       const timeoutId = setTimeout(() => {
-        this.clientPendingInvocations.delete(callId);
-        reject(
-          new Error(
-            `Proxied invocation for tool "${toolName}" timed out after ${this.invokeTimeoutMs}ms`
-          )
-        );
+        pending.cancel(new Error(timeoutMessage));
       }, this.invokeTimeoutMs);
-
-      this.clientPendingInvocations.set(callId, {
-        connectionId: 'relay-server',
-        timeoutId,
-        resolve,
-        reject,
-      });
-
-      const message: RelayClientToServerMessage = {
-        type: 'relay/invoke',
-        callId,
-        toolName,
-        args,
+      const onAbort = () => pending.cancel(signal?.reason);
+      const cleanup = () => {
+        if (!invocations.delete(callId)) return false;
+        clearTimeout(timeoutId);
+        signal?.removeEventListener('abort', onAbort);
+        return true;
       };
+      const pending: PendingInvocation = {
+        connectionId,
+        resolve: (result) => {
+          if (cleanup()) resolve(result);
+        },
+        reject: (reason) => {
+          if (cleanup()) reject(reason);
+        },
+        cancel: (reason) => {
+          if (!cleanup()) return;
+          try {
+            if (socket.readyState === WebSocket.OPEN) {
+              const cancellation: RelayToBrowserMessage | RelayClientToServerMessage = {
+                type: message.type === 'invoke' ? 'cancel' : 'relay/cancel',
+                callId,
+              };
+              socket.send(JSON.stringify(cancellation));
+            }
+          } catch (error) {
+            process.stderr.write(
+              `[webmcp-local-relay] warn: failed to cancel call ${callId}: ${error instanceof Error ? error.message : String(error)}\n`
+            );
+          }
+          reject(reason);
+        },
+      };
+      invocations.set(callId, pending);
+      signal?.addEventListener('abort', onAbort, { once: true });
 
       try {
         socket.send(JSON.stringify(message));
       } catch (err) {
-        clearTimeout(timeoutId);
-        this.clientPendingInvocations.delete(callId);
-        reject(
-          new Error(`Failed to send relay invocation: ${err instanceof Error ? err.message : err}`)
+        pending.reject(
+          new Error(
+            `Failed to send invocation: ${err instanceof Error ? err.message : String(err)}`
+          )
         );
       }
     });

--- a/packages/webmcp-local-relay/src/browser/embed.test.ts
+++ b/packages/webmcp-local-relay/src/browser/embed.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+const HOST_ORIGIN = 'https://app.example.com';
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it('cancels only authenticated matching invocations, including pending discovery and page teardown', async () => {
+  class ScriptElement {
+    src = 'https://relay.example.com/embed.js';
+    getAttribute() {
+      return null;
+    }
+    hasAttribute() {
+      return false;
+    }
+  }
+  const listeners = new Map<string, (event: MessageEvent) => void>();
+  const widget = { postMessage: vi.fn() };
+  const tool = { name: 'slow', description: 'Waits for completion' };
+  const discovery = Promise.withResolvers<(typeof tool)[]>();
+  const getTools = vi.fn().mockReturnValue(discovery.promise);
+  const executions: Array<{ signal: AbortSignal; resolve: (value: string) => void }> = [];
+  const executeTool = vi.fn(
+    (_tool: unknown, _args: string, { signal }: { signal: AbortSignal }) =>
+      new Promise<string>((resolve) => executions.push({ signal, resolve }))
+  );
+  const appendChild = vi.fn();
+  vi.stubGlobal('HTMLScriptElement', ScriptElement);
+  vi.stubGlobal('sessionStorage', { getItem: () => null, setItem: vi.fn() });
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({ ok: true, text: async () => '<head></head>' })
+  );
+  vi.stubGlobal('window', {
+    location: { origin: HOST_ORIGIN, href: `${HOST_ORIGIN}/page` },
+    addEventListener: (type: string, listener: (event: MessageEvent) => void) => {
+      listeners.set(type, listener);
+    },
+  });
+  vi.stubGlobal('document', {
+    currentScript: new ScriptElement(),
+    title: 'Host',
+    querySelector: () => null,
+    body: { appendChild },
+    createElement: () => ({
+      contentWindow: widget,
+      style: {},
+      setAttribute: vi.fn(),
+      addEventListener: vi.fn(),
+    }),
+    addEventListener: vi.fn(),
+    modelContext: { getTools, executeTool, addEventListener: vi.fn() },
+  });
+  vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:relay-widget');
+  await import('./embed.js');
+  await vi.waitFor(() => expect(appendChild).toHaveBeenCalled());
+
+  const send = (type: string, requestId: string, origin = HOST_ORIGIN, source = widget) => {
+    listeners.get('message')?.({
+      data: { type, requestId, toolName: 'slow', args: { value: 1 } },
+      origin,
+      source,
+    } as unknown as MessageEvent);
+  };
+  send('webmcp.tools.invoke.request', 'discovering');
+  send('webmcp.tools.cancel.request', 'discovering');
+  discovery.resolve([tool]);
+  await Promise.resolve();
+  expect(executeTool).not.toHaveBeenCalled();
+
+  getTools.mockResolvedValue([tool]);
+  send('webmcp.tools.invoke.request', 'first');
+  send('webmcp.tools.invoke.request', 'second');
+  await Promise.resolve();
+  expect(executeTool).toHaveBeenCalledWith(tool, '{"value":1}', {
+    signal: expect.any(AbortSignal),
+  });
+  expect(executions).toHaveLength(2);
+  send('webmcp.tools.cancel.request', 'first', 'https://evil.example.com');
+  send('webmcp.tools.cancel.request', 'first', HOST_ORIGIN, { postMessage: vi.fn() });
+  send('webmcp.tools.cancel.request', 'unknown');
+  expect(executions[0]?.signal.aborted).toBe(false);
+  send('webmcp.tools.cancel.request', 'first');
+  expect(executions[0]?.signal.aborted).toBe(true);
+  expect(executions[1]?.signal.aborted).toBe(false);
+
+  executions[0]?.resolve('late cancelled result');
+  executions[1]?.resolve('completed');
+  await vi.waitFor(() =>
+    expect(widget.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'webmcp.tools.invoke.response', requestId: 'second' }),
+      HOST_ORIGIN
+    )
+  );
+  expect(widget.postMessage.mock.calls.some(([message]) => message.requestId === 'first')).toBe(
+    false
+  );
+  send('webmcp.tools.cancel.request', 'second');
+  expect(executions[1]?.signal.aborted).toBe(false);
+
+  send('webmcp.tools.invoke.request', 'teardown');
+  await Promise.resolve();
+  listeners.get('pagehide')?.(new Event('pagehide') as MessageEvent);
+  expect(executions[2]?.signal.aborted).toBe(true);
+  executions[2]?.resolve('late teardown result');
+});

--- a/packages/webmcp-local-relay/src/browser/embed.ts
+++ b/packages/webmcp-local-relay/src/browser/embed.ts
@@ -62,6 +62,7 @@ const INPUT_REQUIRED_UNSUPPORTED_MESSAGE =
 
 let widgetWindow: Window | null = null;
 let config: RelayConfig;
+const activeInvocations = new Map<string, AbortController>();
 
 function getCurrentScriptElement(): HTMLScriptElement | null {
   return document.currentScript instanceof HTMLScriptElement ? document.currentScript : null;
@@ -206,7 +207,12 @@ async function listRelayTools(): Promise<RelayToolDescriptor[]> {
     .filter((tool): tool is RelayToolDescriptor => tool !== null);
 }
 
-async function invokeRelayTool(name: string, args: JsonObject): Promise<CallToolResult> {
+async function invokeRelayTool(
+  name: string,
+  args: JsonObject,
+  signal: AbortSignal
+): Promise<CallToolResult> {
+  signal.throwIfAborted();
   const descriptorContext = getDocumentDescriptorContext();
   if (!descriptorContext) {
     throw new Error('No executable WebMCP runtime found on this page');
@@ -215,11 +221,13 @@ async function invokeRelayTool(name: string, args: JsonObject): Promise<CallTool
   // Current Chrome requires a RegisteredTool returned by getTools(), not a
   // name or a stale copy.
   const tool = (await descriptorContext.getTools()).find((candidate) => candidate.name === name);
+  signal.throwIfAborted();
   if (!tool) {
     throw new Error(`Tool not found: ${name}`);
   }
 
-  const serialized = await descriptorContext.executeTool(tool, JSON.stringify(args));
+  const serialized = await descriptorContext.executeTool(tool, JSON.stringify(args), { signal });
+  signal.throwIfAborted();
   return normalizeSerializedToolResult(serialized);
 }
 
@@ -380,8 +388,12 @@ function handleListRequest(request: WidgetRequestMessage, event: MessageEvent): 
 }
 
 function handleInvokeRequest(request: WidgetRequestMessage, event: MessageEvent): void {
-  invokeRelayTool(String(request.toolName ?? ''), toInvokeArgs(request.args))
+  if (activeInvocations.has(request.requestId)) return;
+  const controller = new AbortController();
+  activeInvocations.set(request.requestId, controller);
+  invokeRelayTool(String(request.toolName ?? ''), toInvokeArgs(request.args), controller.signal)
     .then((result) => {
+      if (controller.signal.aborted) return;
       respondToSource(event.source, event.origin, {
         type: 'webmcp.tools.invoke.response',
         requestId: request.requestId,
@@ -389,11 +401,17 @@ function handleInvokeRequest(request: WidgetRequestMessage, event: MessageEvent)
       });
     })
     .catch((error: unknown) => {
+      if (controller.signal.aborted) return;
       respondToSource(event.source, event.origin, {
         type: 'webmcp.tools.invoke.error',
         requestId: request.requestId,
         error: String(error instanceof Error ? error.message : error),
       });
+    })
+    .finally(() => {
+      if (activeInvocations.get(request.requestId) === controller) {
+        activeInvocations.delete(request.requestId);
+      }
     });
 }
 
@@ -492,7 +510,19 @@ if (!document.querySelector(RELAY_IFRAME_SELECTOR)) {
 
     if (request.type === 'webmcp.tools.invoke.request') {
       handleInvokeRequest(request, event);
+      return;
     }
+
+    if (request.type === 'webmcp.tools.cancel.request') {
+      const controller = activeInvocations.get(request.requestId);
+      activeInvocations.delete(request.requestId);
+      controller?.abort();
+    }
+  });
+
+  window.addEventListener('pagehide', () => {
+    for (const controller of activeInvocations.values()) controller.abort();
+    activeInvocations.clear();
   });
 
   const launchWidget = (): void => {

--- a/packages/webmcp-local-relay/src/browser/widget.test.ts
+++ b/packages/webmcp-local-relay/src/browser/widget.test.ts
@@ -808,6 +808,85 @@ describe('widget runtime', () => {
     });
   });
 
+  it('cancels only the matching host request and ignores late responses and cancellations', async () => {
+    const env = startRuntime();
+    const connection = await completeHandshake(env);
+    for (const callId of ['cancelled', 'survivor']) {
+      connection.client.send(JSON.stringify({ type: 'invoke', callId, toolName: 'slow' }));
+    }
+    const first = await waitForPostedMessage(env, 'webmcp.tools.invoke.request');
+    const second = await waitForPostedMessage(env, 'webmcp.tools.invoke.request', 1);
+    connection.client.send(JSON.stringify({ type: 'cancel', callId: 'unknown' }));
+    connection.client.send(JSON.stringify({ type: 'cancel', callId: 'cancelled' }));
+    connection.client.send(JSON.stringify({ type: 'cancel', callId: 'cancelled' }));
+    expect(getPostedMessages(env, 'webmcp.tools.cancel.request')).toEqual([
+      {
+        payload: { type: 'webmcp.tools.cancel.request', requestId: first.payload.requestId },
+        targetOrigin: APP_ORIGIN,
+      },
+    ]);
+
+    env.hostWindow.dispatchMessage(APP_ORIGIN, {
+      type: 'webmcp.tools.invoke.response',
+      requestId: first.payload.requestId,
+      result: { content: [{ type: 'text', text: 'late success' }] },
+    });
+    env.hostWindow.dispatchMessage(APP_ORIGIN, {
+      type: 'webmcp.tools.invoke.response',
+      requestId: second.payload.requestId,
+      result: { content: [{ type: 'text', text: 'survivor' }] },
+    });
+    await vi.waitFor(() => expect(connection.messages).toHaveLength(4));
+    expect(connection.messages.slice(2)).toEqual([
+      {
+        type: 'result',
+        callId: 'survivor',
+        result: { content: [{ type: 'text', text: 'survivor' }] },
+      },
+      {
+        type: 'result',
+        callId: 'cancelled',
+        result: {
+          isError: true,
+          content: [{ type: 'text', text: 'Tool execution cancelled' }],
+        },
+      },
+    ]);
+    connection.client.send(JSON.stringify({ type: 'cancel', callId: 'survivor' }));
+    expect(getPostedMessages(env, 'webmcp.tools.cancel.request')).toHaveLength(1);
+  });
+
+  it('cancels host execution when its response times out', async () => {
+    const env = startRuntime({
+      search: buildSearch({ hostOrigin: APP_ORIGIN, requestTimeout: '1000' }),
+    });
+    const connection = await completeHandshake(env);
+    vi.useFakeTimers();
+    try {
+      connection.client.send(
+        JSON.stringify({ type: 'invoke', callId: 'timeout', toolName: 'slow' })
+      );
+      const request = getPostedMessages(env, 'webmcp.tools.invoke.request')[0];
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(getPostedMessages(env, 'webmcp.tools.cancel.request')).toEqual([
+        {
+          payload: { type: 'webmcp.tools.cancel.request', requestId: request?.payload.requestId },
+          targetOrigin: APP_ORIGIN,
+        },
+      ]);
+      expect(connection.messages).toContainEqual({
+        type: 'result',
+        callId: 'timeout',
+        result: {
+          isError: true,
+          content: [{ type: 'text', text: 'Host response timeout: webmcp.tools.invoke' }],
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('reconnects after handshake failures and closed pending invocations', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const env = startRuntime();
@@ -851,8 +930,17 @@ describe('widget runtime', () => {
       })
     );
 
-    await waitForPostedMessage(env, 'webmcp.tools.invoke.request');
+    const pendingInvoke = await waitForPostedMessage(env, 'webmcp.tools.invoke.request');
     secondConnection.client.close();
+    expect(getPostedMessages(env, 'webmcp.tools.cancel.request')).toEqual([
+      {
+        payload: {
+          type: 'webmcp.tools.cancel.request',
+          requestId: pendingInvoke.payload.requestId,
+        },
+        targetOrigin: APP_ORIGIN,
+      },
+    ]);
 
     await waitForConnection(env, 2);
     await waitForPostedMessage(env, 'webmcp.tools.list.request', 2);

--- a/packages/webmcp-local-relay/src/browser/widgetRuntime.ts
+++ b/packages/webmcp-local-relay/src/browser/widgetRuntime.ts
@@ -45,6 +45,7 @@ interface PendingRequest {
   timeoutId: ReturnType<typeof setTimeout>;
   responseType: string;
   errorType: string;
+  callId?: string;
 }
 
 interface RelayHelloMessage {
@@ -417,6 +418,7 @@ async function probeRelayEndpoint(candidate: {
 
 function runWidget(cfg: WidgetConfig): void {
   const pendingRequests = new Map<string, PendingRequest>();
+  const invocationRequests = new Map<string, string>();
   let activeEndpoint: RelayEndpoint | null = null;
   let activeSocket: WebSocket | null = null;
   let helloAccepted = false;
@@ -426,21 +428,39 @@ function runWidget(cfg: WidgetConfig): void {
   let discoveryCycleCount = 0;
   let dormantHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
-  const rejectPendingRequests = (reason: string): void => {
-    for (const [requestId, pending] of pendingRequests) {
+  const takePendingRequest = (requestId: string): PendingRequest | undefined => {
+    const pending = pendingRequests.get(requestId);
+    if (pending) {
       clearTimeout(pending.timeoutId);
       pendingRequests.delete(requestId);
-      pending.reject(new Error(reason));
+      if (pending.callId !== undefined) invocationRequests.delete(pending.callId);
     }
+    return pending;
   };
 
-  function requestHost(baseType: string, payload: Record<string, unknown>): Promise<HostMessage> {
+  const cancelHostRequest = (requestId: string, reason: string): void => {
+    const pending = takePendingRequest(requestId);
+    if (!pending) return;
+    if (pending.callId !== undefined) {
+      window.parent.postMessage({ type: 'webmcp.tools.cancel.request', requestId }, cfg.hostOrigin);
+    }
+    pending.reject(new Error(reason));
+  };
+
+  const rejectPendingRequests = (reason: string): void => {
+    for (const requestId of pendingRequests.keys()) cancelHostRequest(requestId, reason);
+  };
+
+  function requestHost(
+    baseType: string,
+    payload: Record<string, unknown>,
+    callId?: string
+  ): Promise<HostMessage> {
     const requestId = createRequestId();
 
     return new Promise((resolve, reject) => {
       const timeoutId = setTimeout(() => {
-        pendingRequests.delete(requestId);
-        reject(new Error(`Host response timeout: ${baseType}`));
+        cancelHostRequest(requestId, `Host response timeout: ${baseType}`);
       }, cfg.requestTimeoutMs);
 
       pendingRequests.set(requestId, {
@@ -449,7 +469,9 @@ function runWidget(cfg: WidgetConfig): void {
         timeoutId,
         responseType: `${baseType}.response`,
         errorType: `${baseType}.error`,
+        ...(callId === undefined ? {} : { callId }),
       });
+      if (callId !== undefined) invocationRequests.set(callId, requestId);
 
       window.parent.postMessage(
         { type: `${baseType}.request`, requestId, ...payload },
@@ -485,6 +507,7 @@ function runWidget(cfg: WidgetConfig): void {
     phase = 'idle';
 
     socket.addEventListener('message', (event) => {
+      if (activeSocket !== socket) return;
       let parsed: unknown;
       try {
         parsed = JSON.parse(String(event.data));
@@ -554,6 +577,13 @@ function runWidget(cfg: WidgetConfig): void {
         return;
       }
 
+      if (relayMessage.type === 'cancel') {
+        if (typeof relayMessage.callId !== 'string') return;
+        const requestId = invocationRequests.get(relayMessage.callId);
+        if (requestId !== undefined) cancelHostRequest(requestId, 'Tool execution cancelled');
+        return;
+      }
+
       if (relayMessage.type !== 'invoke') {
         console.debug(
           '[webmcp-relay-widget] Ignoring unrecognized message type:',
@@ -562,10 +592,18 @@ function runWidget(cfg: WidgetConfig): void {
         return;
       }
 
-      requestHost('webmcp.tools.invoke', {
-        toolName: relayMessage.toolName,
-        args: isJsonObject(relayMessage.args) ? relayMessage.args : {},
-      })
+      if (typeof relayMessage.callId !== 'string' || invocationRequests.has(relayMessage.callId)) {
+        return;
+      }
+
+      requestHost(
+        'webmcp.tools.invoke',
+        {
+          toolName: relayMessage.toolName,
+          args: isJsonObject(relayMessage.args) ? relayMessage.args : {},
+        },
+        relayMessage.callId
+      )
         .then((hostResponse) => {
           safeSend(
             socket,
@@ -886,15 +924,13 @@ function runWidget(cfg: WidgetConfig): void {
     }
 
     if (message.type === pending.responseType) {
-      clearTimeout(pending.timeoutId);
-      pendingRequests.delete(message.requestId);
+      takePendingRequest(message.requestId);
       pending.resolve(message);
       return;
     }
 
     if (message.type === pending.errorType) {
-      clearTimeout(pending.timeoutId);
-      pendingRequests.delete(message.requestId);
+      takePendingRequest(message.requestId);
       pending.reject(new Error(String(message.error || 'Unknown host error')));
     }
   });

--- a/packages/webmcp-local-relay/src/mcpRelayServer.test.ts
+++ b/packages/webmcp-local-relay/src/mcpRelayServer.test.ts
@@ -699,6 +699,37 @@ describe('LocalRelayMcpServer', () => {
     await cleanup();
   });
 
+  it('forwards MCP caller cancellation to the browser execution', async () => {
+    const { bridge, client, cleanup } = await createConnectedRelay({ invokeTimeoutMs: 2000 });
+    let ws: WebSocket | undefined;
+    try {
+      ws = await connectBrowser(bridge, {
+        tabId: 'tab-cancel',
+        url: 'https://example.com',
+        tools: [{ name: 'slow_tool', description: 'Waits for cancellation' }],
+      });
+      const messages: Array<{ type: string; callId: string }> = [];
+      ws.on('message', (raw) => messages.push(JSON.parse(String(raw))));
+      const toolName = await waitFor(() => bridge.registry.listTools()[0]?.name);
+      await waitForClientTool(client, toolName);
+
+      const controller = new AbortController();
+      const pending = client.callTool(
+        { name: toolName, arguments: {} },
+        { signal: controller.signal }
+      );
+      const rejected = expect(pending).rejects.toThrow('caller cancelled');
+      const invocation = await waitFor(() => messages.find((message) => message.type === 'invoke'));
+      controller.abort(new Error('caller cancelled'));
+      await rejected;
+      const cancel = await waitFor(() => messages.find((message) => message.type === 'cancel'));
+      expect(cancel.callId).toBe(invocation.callId);
+    } finally {
+      ws?.close();
+      await cleanup();
+    }
+  });
+
   it('drops invalid annotations with a warning', async () => {
     const { bridge, relay, cleanup } = await createConnectedRelay();
 

--- a/packages/webmcp-local-relay/src/mcpRelayServer.ts
+++ b/packages/webmcp-local-relay/src/mcpRelayServer.ts
@@ -475,10 +475,11 @@ export class LocalRelayMcpServer {
         ...(tool.icons ? { icons: tool.icons } : {}),
         ...(tool._meta ? { _meta: tool._meta } : {}),
       },
-      async (args: Record<string, unknown>) => {
+      async (args: Record<string, unknown>, context) => {
         try {
-          return await this.bridge.invokeTool(tool.name, args);
+          return await this.bridge.invokeTool(tool.name, args, { signal: context.mcpReq.signal });
         } catch (err) {
+          if (context.mcpReq.signal.aborted) throw err;
           const message = err instanceof Error ? err.message : String(err);
           const details = err instanceof Error ? (err.stack ?? err.message) : String(err);
           process.stderr.write(

--- a/packages/webmcp-local-relay/src/relay.e2e.test.ts
+++ b/packages/webmcp-local-relay/src/relay.e2e.test.ts
@@ -28,7 +28,7 @@ const RUNTIME_CONTRACT_MODULE_PATH = resolve(
 const REAL_EMBED_PATH = resolve(PACKAGE_DIR, 'dist/browser/embed.js');
 const REAL_WIDGET_PATH = resolve(PACKAGE_DIR, 'dist/browser/widget.html');
 
-type RuntimeMode = 'fixture-native' | 'global' | 'polyfill-testing';
+type RuntimeMode = 'native' | 'fixture-native' | 'global' | 'polyfill-testing';
 
 interface RuntimeCase {
   mode: RuntimeMode;
@@ -604,6 +604,12 @@ async function setupE2EHarness(options: {
     browser = await chromium.launch({
       headless: true,
       channel: process.env.PLAYWRIGHT_CHROMIUM_CHANNEL,
+      ...(runtimeCase.mode === 'native'
+        ? {
+            executablePath: process.env.CHROME_BIN,
+            args: ['--enable-features=WebMCP'],
+          }
+        : {}),
     });
     page = await browser.newPage();
     page.on('pageerror', (runtimeError) => {
@@ -893,6 +899,85 @@ describe('relay e2e (real browser assets)', () => {
       }
     });
   }
+
+  it.runIf(process.env.WEBMCP_NATIVE === '1').each(['server', 'client'] as const)(
+    'forwards MCP cancellation to a native browser handler in %s mode',
+    async (mode) => {
+      let widgetServer: StartedHttpServer | null = null;
+      let ownerRelay: SpawnedRelay | null = null;
+      let harness: E2EHarness | null = null;
+
+      try {
+        const relayPort = await getOpenPort();
+        widgetServer = await startWidgetAssetServer();
+        if (mode === 'client') ownerRelay = await startRelayProcess(relayPort);
+        harness = await setupE2EHarness({
+          runtimeCase: { mode: 'native', scriptRoute: '/runtime/native.js', scriptSource: '' },
+          relayPort,
+          widgetOrigin: widgetServer.origin,
+          clientName: `webmcp-local-relay-e2e-cancellation-${mode}`,
+        });
+
+        await harness.page.evaluate(async () => {
+          if (!document.modelContext || Reflect.get(document.modelContext, '__isWebMCPPolyfill')) {
+            throw new Error('This test requires native Chrome WebMCP');
+          }
+          await document.modelContext.registerTool({
+            name: 'cancel_cooperative',
+            description: 'Waits until the MCP caller cancels',
+            inputSchema: { type: 'object', properties: {} },
+            execute: (_input, options?: { signal: AbortSignal }) => {
+              if (!options?.signal) throw new Error('Native execution signal is unavailable');
+              const { signal } = options;
+              document.documentElement.dataset.relayExecution = 'started';
+              return new Promise<never>((_resolve, reject) => {
+                signal.addEventListener(
+                  'abort',
+                  () => {
+                    document.documentElement.dataset.relayExecution = 'aborted';
+                    reject(signal.reason);
+                  },
+                  { once: true }
+                );
+              });
+            },
+          });
+        });
+        await waitForValue(async () => {
+          const tools = await harness?.client.listTools();
+          return tools?.tools.some((tool) => tool.name === 'cancel_cooperative') ? true : undefined;
+        });
+
+        const controller = new AbortController();
+        const call = harness.client
+          .callTool({ name: 'cancel_cooperative', arguments: {} }, { signal: controller.signal })
+          .then(
+            () => 'resolved',
+            () => 'rejected'
+          );
+        await harness.page.waitForFunction(
+          () => document.documentElement.dataset.relayExecution === 'started'
+        );
+        controller.abort(new Error('Cancelled by the MCP caller'));
+        expect(await call).toBe('rejected');
+        await harness.page.waitForFunction(
+          () => document.documentElement.dataset.relayExecution === 'aborted'
+        );
+
+        const next = await harness.client.callTool({
+          name: harness.expectedToolName,
+          arguments: { a: 2, b: 5 },
+        });
+        expect(firstContentText(next)).toBe('sum:7');
+      } catch (error) {
+        throw formatE2EError(`native cancellation ${mode}`, error, harness, ownerRelay?.logs);
+      } finally {
+        await harness?.cleanup();
+        await ownerRelay?.stop();
+        await stopHttpServer(widgetServer?.server ?? null);
+      }
+    }
+  );
 
   it('works through a second relay in client mode when port owner already exists', async () => {
     let widgetServer: StartedHttpServer | null = null;

--- a/packages/webmcp-local-relay/src/schemas.ts
+++ b/packages/webmcp-local-relay/src/schemas.ts
@@ -129,6 +129,11 @@ const RelayInvokeMessageSchema = z.object({
   args: RelayInvokeArgsSchema,
 });
 
+const RelayCancelMessageSchema = z.object({
+  type: z.literal('cancel'),
+  callId: z.string().min(1),
+});
+
 const RelayPingMessageSchema = z.object({
   type: z.literal('ping'),
 });
@@ -145,6 +150,7 @@ export const RelayToBrowserMessageSchema = z.discriminatedUnion('type', [
   RelayHelloAcceptedMessageSchema,
   RelayHelloRejectedMessageSchema,
   RelayInvokeMessageSchema,
+  RelayCancelMessageSchema,
   RelayPingMessageSchema,
   RelayReloadMessageSchema,
 ]);
@@ -189,6 +195,11 @@ const RelayClientInvokeSchema = z.object({
   args: RelayInvokeArgsSchema,
 });
 
+const RelayClientCancelSchema = z.object({
+  type: z.literal('relay/cancel'),
+  callId: z.string().min(1),
+});
+
 /**
  * Union schema for all relay-client-to-server messages.
  */
@@ -196,6 +207,7 @@ export const RelayClientToServerMessageSchema = z.discriminatedUnion('type', [
   RelayClientHelloSchema,
   RelayClientListToolsSchema,
   RelayClientInvokeSchema,
+  RelayClientCancelSchema,
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Cancelling an MCP tool call previously left its browser invocation running. This forwards cancellation through both local relay modes, the widget iframe, and the browser's `executeTool()` signal so cooperative handlers can stop.

## Changes

- Forward the MCP SDK request signal and support `RelayBridgeServer.invokeTool(..., { signal })`.
- Reuse existing call IDs for cancellation, scope requests to their owning relay connection, and clean up timers and listeners on completion, cancellation, timeout, and disconnect.
- Add transport and browser regressions, document cancellation and runtime limits, and include a patch changeset for `@mcp-b/webmcp-local-relay`.

Actual handler cancellation requires a runtime that forwards execution signals and a handler that observes them. This PR does not change polyfill execution behavior.

## References

- [MCP cancellation specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation): request-scoped cancellation, cleanup, and late-response handling.
- [WebMCP Community Group draft](https://webmachinelearning.github.io/webmcp/): execution signals and cancellation of pending tool executions.
- [Upstream execution-abort tests](https://github.com/web-platform-tests/wpt/blob/9ef2de86389e3f388578fe5fc599c979078c6667/webmcp/imperative/executeTool-abort.https.html): pre-aborted calls, independent execution signals, and late completion.

## Checklist

- [x] PR title follows conventional commit format
- [x] Followed the AI Contribution Manifesto, package ownership, and testing philosophy
- [x] Build, unit tests, lint/format, and TypeScript checks pass
- [x] Changeset and public API documentation added

## Testing

Validated in an isolated worktree based on `main` at `1c7a398a`, with only this PR's changes:

```bash
pnpm install --frozen-lockfile
pnpm build
pnpm typecheck
pnpm exec vp check
CHROME_BIN='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' pnpm test:unit
WEBMCP_NATIVE=1 CHROME_BIN='/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary' PLAYWRIGHT_CHROMIUM_CHANNEL=chrome pnpm --filter @mcp-b/webmcp-local-relay exec vp test run --config vitest.e2e.config.ts
pnpm audit:ci:high
pnpm audit:ci:critical
```

- **Unit/transport:** full workspace unit suite passes, including 275 relay tests covering cancellation, pre-aborted signals, timeouts, late responses, and connection ownership.
- **Browser E2E:** all 12 tests pass. Native tests exercise actual MCP stdio → relay → widget → native Chrome handler in server and client modes, then verify a subsequent call succeeds. Native cases require `WEBMCP_NATIVE=1`; they are opt-in.
- **Audits:** the required critical gate passes. The informational high audit reports three existing landing-page dependency advisories: one for `sharp`, two for `browserslist`. This PR changes no dependencies.

The first unit run lacked Playwright's downloaded Chromium; rerunning with the repository's supported `CHROME_BIN` override passed.
